### PR TITLE
Fix outline column set correctness (RDR-004)

### DIFF
--- a/docs/rdr/RDR-004-outline-column-correctness.md
+++ b/docs/rdr/RDR-004-outline-column-correctness.md
@@ -2,11 +2,12 @@
 title: "Outline Column Set Correctness"
 id: RDR-004
 type: Bug
-status: draft
+status: accepted
 priority: P1
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-03-08
+accepted_date: 2026-03-08
 related_issues: []
 ---
 

--- a/docs/rdr/RDR-004-outline-column-correctness.md
+++ b/docs/rdr/RDR-004-outline-column-correctness.md
@@ -2,7 +2,7 @@
 title: "Outline Column Set Correctness"
 id: RDR-004
 type: Bug
-status: draft
+status: implemented
 priority: P1
 author: Hal Hildebrand
 reviewed-by: self

--- a/docs/rdr/RDR-004-outline-column-correctness.md
+++ b/docs/rdr/RDR-004-outline-column-correctness.md
@@ -2,7 +2,7 @@
 title: "Outline Column Set Correctness"
 id: RDR-004
 type: Bug
-status: implemented
+status: draft
 priority: P1
 author: Hal Hildebrand
 reviewed-by: self
@@ -17,9 +17,9 @@ related_issues: []
 
 ## Problem Statement
 
-The paper (§3.4) mandates that relation fields are excluded from column sets — each relation gets its own single-column column set. Kramer's `RelationLayout.compress()` uses a purely width-based threshold (`childWidth > halfWidth`) with no type check. A narrow relation field could be incorrectly grouped into a column set alongside primitive fields.
+When a child `RelationLayout` is in outline mode and its width is less than `halfWidth`, Kramer's `RelationLayout.compress()` incorrectly groups it with adjacent primitive children in the same column set. The existing width-based check (`childWidth > halfWidth`) correctly handles wide children of any type, but does not handle narrow outline-mode relation children. Per Bakke 2013 §3.4, outline-mode relations must be excluded from multi-field column sets and placed in their own single-column column set.
 
-Additionally, the paper describes dynamic programming for optimal column partitioning to minimize vertical space. Kramer uses a greedy slide-right heuristic that can produce suboptimal results.
+**Note**: The paper also recommends dynamic programming for optimal column partitioning (vs. Kramer's greedy slide-right heuristic). This is a known quality limitation but not a correctness defect — the greedy approach produces acceptable results for typical field counts (3-8 fields, 2-3 columns). DP optimization is out of scope for this RDR.
 
 ## Context
 
@@ -70,7 +70,7 @@ The code uses `childWidth > halfWidth` as the sole criterion for starting a new 
 
 Key observation: `child.layoutWidth()` returns the outline column width for RelationLayout children (computed by `RelationLayout.layout()` which recurses). For a relation child that chose table mode (`useTable == true`), `layoutWidth()` returns `tableColumnWidth()` — which can be quite narrow. Such a narrow table-mode relation COULD fall below `halfWidth` and be grouped into a column set with primitives.
 
-**Impact**: A relation with `useTable=true` and narrow table width gets grouped with primitives. This violates the paper's visual semantics — even a compact table should span the full column set width, not share space with adjacent primitives.
+**Impact**: A narrow outline-mode relation (`useTable == false`) gets grouped with primitives in the same column set instead of being isolated. **Correction (see Finding 5)**: the initial assessment that table-mode relations should also be isolated was incorrect — the paper's exclusion rule applies only to outline-mode relations. Table-mode relations may correctly share column sets.
 
 **Status**: Confirmed via code read. No test coverage exists for `compress()`, `ColumnSet`, or `Column` classes.
 
@@ -108,19 +108,25 @@ The smoke tests (`Smoke`, `PrimArraySmoke`, `SmokeTable`) exercise layout but do
 
 ### Finding 5: Paper's Nuanced Exclusion Rule
 
-Re-reading the paper more carefully: the exclusion is conditional on whether the relation "would be rendered as an outline." This means:
+**Source**: Bakke 2013, §3.4 "Columns in Outline Layouts"
+
+> "any relation field in an outline is excluded from participating in a set of multiple columns **if that would cause it to be rendered as an outline**."
+
+The key phrase is "if that would cause it to be rendered as an outline." The exclusion is conditional on rendering mode, not type:
 - If a relation child has `useTable == true` (fits as table), it is NOT excluded — it can participate in a column set
 - If a relation child has `useTable == false` (rendered as outline), it IS excluded — gets its own column set
 
-This is MORE nuanced than the simple "all relations get own column set" fix proposed in the RDR. The correct fix should check `!child.useTable` rather than `child instanceof RelationLayout`.
+**Retraction of Finding 2 impact statement**: Finding 2 incorrectly stated that "even a compact table should span the full column set width, not share space with adjacent primitives." This was based on an initial reading before the conditional nature of the exclusion rule was understood. The paper explicitly permits table-mode relations to share column sets. Only outline-mode relations are excluded.
 
-However, at the time `compress()` runs, `useTable` has already been set by the prior `layout()` call. So the check is feasible:
+This is MORE nuanced than a simple "all relations get own column set" fix. The correct fix must check `!child.useTable` rather than unconditionally checking `child instanceof RelationLayout`.
+
+The `useTable` flag is reliably set before `compress()` reads it. This ordering is guaranteed by `SchemaNodeLayout.autoLayout()` (lines 155-157), which calls `layout()` — setting `useTable` on all children via recursive `nestTableColumn()` calls — before calling `compress()`.
 
 ```java
 boolean excluded = (child instanceof RelationLayout rl) && !rl.isUseTable();
 ```
 
-**Status**: Verified. This changes the proposed fix — it should be conditional on useTable, not unconditional on type.
+**Status**: Verified against paper text and code ordering.
 
 ## Proposed Solution
 
@@ -148,30 +154,25 @@ for (SchemaNodeLayout child : children) {
 
 Note: Relations with `useTable == true` (compact tables) can still share column sets with primitives. Only outline-mode relations are excluded. This matches the paper's nuanced rule.
 
-### Fix 2: Dynamic Programming Partitioning (Optional)
-
-Replace the slide-right heuristic in `ColumnSet.compress()` with DP:
-
-```java
-// DP over field assignments to columns to minimize max column height
-// State: dp[i][j] = min max-height using fields 0..i-1 across j columns
-// Transition: try all possible split points for the last column
-```
-
-Field counts per column set are typically small (single digits), so DP is fast. However, the greedy approach works well in practice — this is a quality improvement, not a correctness fix.
-
 ## Implementation Plan
 
-1. Add `instanceof RelationLayout` check in `RelationLayout.compress()` — force relation children into their own column sets
-2. Add test: schema with a narrow relation child verifies it gets isolated column set
-3. (Optional) Replace slide-right with DP in `ColumnSet.compress()`
-4. Add test: verify column partitioning optimality for known field height distributions
+1. Add `public boolean isUseTable()` accessor to `RelationLayout` (exposes `useTable` for the conditional check)
+2. Add conditional exclusion in `RelationLayout.compress()`: `(child instanceof RelationLayout rl) && !rl.isUseTable()`
+3. Add unit tests for column set formation covering:
+   - Outline-mode relation gets its own column set
+   - Table-mode relation can share column sets with primitives
+   - Outline relation breaks column set for subsequent children
+   - All-primitives grouping (regression guard)
+   - Wide primitive gets own column set (pre-existing rule)
 
 ## Test Plan
 
-- **Scenario**: Schema with narrow relation + wide primitives → **Verify**: relation gets own column set (not grouped)
-- **Scenario**: Schema with multiple primitives of varying heights → **Verify**: column partitioning minimizes max height
-- **Scenario**: Existing layouts → **Verify**: no regressions (wide relations already get own column sets via width threshold)
+- **Scenario**: Narrow outline-mode relation between primitives → **Verify**: relation gets own column set (not grouped)
+- **Scenario**: Narrow table-mode relation with primitives → **Verify**: table-mode relation shares column set (positive case for Finding 5)
+- **Scenario**: Outline relation between primitives → **Verify**: subsequent children start a new column set
+- **Scenario**: All narrow primitives → **Verify**: all grouped in one column set (regression guard)
+- **Scenario**: Wide primitive between narrow ones → **Verify**: wide gets own column set (pre-existing width rule)
+- **Scenario**: Existing layouts → **Verify**: no regressions
 
 ## References
 

--- a/docs/rdr/RDR-004-outline-column-correctness.md
+++ b/docs/rdr/RDR-004-outline-column-correctness.md
@@ -2,12 +2,14 @@
 title: "Outline Column Set Correctness"
 id: RDR-004
 type: Bug
-status: accepted
+status: implemented
 priority: P1
 author: Hal Hildebrand
 reviewed-by: self
 created: 2026-03-08
 accepted_date: 2026-03-08
+closed_date: 2026-03-08
+close_reason: implemented
 related_issues: []
 ---
 

--- a/docs/rdr/RDR-004-outline-column-correctness.md
+++ b/docs/rdr/RDR-004-outline-column-correctness.md
@@ -1,0 +1,179 @@
+---
+title: "Outline Column Set Correctness"
+id: RDR-004
+type: Bug
+status: draft
+priority: P1
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues: []
+---
+
+# RDR-004: Outline Column Set Correctness
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+The paper (§3.4) mandates that relation fields are excluded from column sets — each relation gets its own single-column column set. Kramer's `RelationLayout.compress()` uses a purely width-based threshold (`childWidth > halfWidth`) with no type check. A narrow relation field could be incorrectly grouped into a column set alongside primitive fields.
+
+Additionally, the paper describes dynamic programming for optimal column partitioning to minimize vertical space. Kramer uses a greedy slide-right heuristic that can produce suboptimal results.
+
+## Context
+
+### Current Code
+
+`RelationLayout.compress()` lines 204-226:
+```java
+for (SchemaNodeLayout child : children) {
+    double childWidth = labelWidth + child.layoutWidth();
+    if (childWidth > halfWidth || current == null) {
+        current = new ColumnSet();
+        columnSets.add(current);
+        current.add(child);
+        if (childWidth > halfWidth) {
+            current = null;
+        }
+    } else {
+        current.add(child);
+    }
+}
+```
+
+No `instanceof` check, no `child.getNode().isRelation()` test. The infrastructure exists (`SchemaNode.isRelation()`) but is not used.
+
+### Column Partitioning
+
+`ColumnSet.compress()` + `Column.slideRight()` use iterative greedy balancing. Fields start in column 0, then slide right one-by-one if it reduces max height. This is a local optimum, not guaranteed global.
+
+## Research Findings
+
+### Finding 1: Paper's Exact Column Set Rule (§3.4)
+
+**Source**: Bakke 2013, §3.4 "Columns in Outline Layouts" (indexed in T3 docs__kramer-research)
+
+> "any relation field in an outline is excluded from participating in a set of multiple columns if that would cause it to be rendered as an outline. There is no requirement that the field would actually have to be rendered as a nested table if excluded, but if the excluded field is still rendered as an outline, that outline layout is still subject to the usual heuristics about whether to use columns or not at that next level."
+
+> "To populate column sets, the algorithm iterates over outline fields in the order they appear in the schema, assigning each to the current column set. If an excluded field is encountered, it is assigned to a new column set of its own, and a new current column set started."
+
+**Key nuance**: The exclusion rule is NOT "all relations get their own column set." It's "relations that would be rendered as outline (not table) get their own column set." A relation that fits as a table could potentially share a column set. However, in practice, the paper's Figure 3(e) shows Sample Reading List and Sections (both relations) each in their own single-column column sets.
+
+**Status**: Verified against paper text.
+
+### Finding 2: Current Kramer Implementation
+
+**Source**: `RelationLayout.compress()` lines 204-226
+
+The code uses `childWidth > halfWidth` as the sole criterion for starting a new ColumnSet. The `halfWidth` is computed as `(available / 2.0) - columnHorizontalInset - elementHorizontalInset`.
+
+Key observation: `child.layoutWidth()` returns the outline column width for RelationLayout children (computed by `RelationLayout.layout()` which recurses). For a relation child that chose table mode (`useTable == true`), `layoutWidth()` returns `tableColumnWidth()` — which can be quite narrow. Such a narrow table-mode relation COULD fall below `halfWidth` and be grouped into a column set with primitives.
+
+**Impact**: A relation with `useTable=true` and narrow table width gets grouped with primitives. This violates the paper's visual semantics — even a compact table should span the full column set width, not share space with adjacent primitives.
+
+**Status**: Confirmed via code read. No test coverage exists for `compress()`, `ColumnSet`, or `Column` classes.
+
+### Finding 3: Column Partitioning Algorithm
+
+**Source**: Bakke 2013, §3.4
+
+> "A better approach is to split the columns in such a way as to minimize the total vertical space consumed; this can be done easily with a dynamic programming routine."
+
+> "Instead, as before, we make the decision of where to begin new columns only once for the entire layout."
+
+Kramer's `ColumnSet.compress()` uses iterative greedy slide-right:
+1. All fields start in column 0
+2. Empty columns created: `IntStream.range(1, count).forEach(i -> columns.add(new Column(columnWidth)))`
+3. Outer `do...while` loop repeats until no height reduction
+4. Inner loop calls `Column.slideRight()` for each adjacent pair
+5. `slideRight()` moves rightmost field from left column to right column if `left.without() >= right.with()`
+
+The greedy property: fields only move right, never left. A field that was "slid right" past its optimal position cannot be recovered. For N fields across K columns, the greedy approach is O(N*K) per pass, with multiple passes until convergence.
+
+DP alternative: O(N^2 * K) with guaranteed global optimum. For typical field counts (3-8 fields, 2-3 columns), this is negligible.
+
+**Status**: Verified. Greedy is correct for monotonically-ordered field heights. Can be suboptimal when a tall field is sandwiched between short fields.
+
+### Finding 4: Zero Test Coverage
+
+No tests exist for:
+- `ColumnSet.compress()` or `Column.slideRight()`
+- `RelationLayout.compress()` column set formation
+- Any scenario with outline columns
+
+The smoke tests (`Smoke`, `PrimArraySmoke`, `SmokeTable`) exercise layout but don't assert column set structure or count.
+
+**Status**: Confirmed via grep of test directory. Critical gap for a correctness fix.
+
+### Finding 5: Paper's Nuanced Exclusion Rule
+
+Re-reading the paper more carefully: the exclusion is conditional on whether the relation "would be rendered as an outline." This means:
+- If a relation child has `useTable == true` (fits as table), it is NOT excluded — it can participate in a column set
+- If a relation child has `useTable == false` (rendered as outline), it IS excluded — gets its own column set
+
+This is MORE nuanced than the simple "all relations get own column set" fix proposed in the RDR. The correct fix should check `!child.useTable` rather than `child instanceof RelationLayout`.
+
+However, at the time `compress()` runs, `useTable` has already been set by the prior `layout()` call. So the check is feasible:
+
+```java
+boolean excluded = (child instanceof RelationLayout rl) && !rl.isUseTable();
+```
+
+**Status**: Verified. This changes the proposed fix — it should be conditional on useTable, not unconditional on type.
+
+## Proposed Solution
+
+### Fix 1: Conditional Column Set Exclusion (~5 lines)
+
+In `RelationLayout.compress()`, exclude outline-mode relations from column sets (per paper §3.4, Finding 5):
+
+```java
+for (SchemaNodeLayout child : children) {
+    double childWidth = labelWidth + child.layoutWidth();
+    // Paper §3.4: relations rendered as outline are excluded from column sets
+    boolean excluded = (child instanceof RelationLayout rl) && !rl.isUseTable();
+    if (excluded || childWidth > halfWidth || current == null) {
+        current = new ColumnSet();
+        columnSets.add(current);
+        current.add(child);
+        if (excluded || childWidth > halfWidth) {
+            current = null; // force next child to start new set
+        }
+    } else {
+        current.add(child);
+    }
+}
+```
+
+Note: Relations with `useTable == true` (compact tables) can still share column sets with primitives. Only outline-mode relations are excluded. This matches the paper's nuanced rule.
+
+### Fix 2: Dynamic Programming Partitioning (Optional)
+
+Replace the slide-right heuristic in `ColumnSet.compress()` with DP:
+
+```java
+// DP over field assignments to columns to minimize max column height
+// State: dp[i][j] = min max-height using fields 0..i-1 across j columns
+// Transition: try all possible split points for the last column
+```
+
+Field counts per column set are typically small (single digits), so DP is fast. However, the greedy approach works well in practice — this is a quality improvement, not a correctness fix.
+
+## Implementation Plan
+
+1. Add `instanceof RelationLayout` check in `RelationLayout.compress()` — force relation children into their own column sets
+2. Add test: schema with a narrow relation child verifies it gets isolated column set
+3. (Optional) Replace slide-right with DP in `ColumnSet.compress()`
+4. Add test: verify column partitioning optimality for known field height distributions
+
+## Test Plan
+
+- **Scenario**: Schema with narrow relation + wide primitives → **Verify**: relation gets own column set (not grouped)
+- **Scenario**: Schema with multiple primitives of varying heights → **Verify**: column partitioning minimizes max height
+- **Scenario**: Existing layouts → **Verify**: no regressions (wide relations already get own column sets via width threshold)
+
+## References
+
+- Bakke 2013, §3.4 (Columns in Outline Layouts)
+- T3: `kramer-gap-analysis-outline-columns`

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -74,6 +74,10 @@ public final class RelationLayout extends SchemaNodeLayout {
     protected double                       tableColumnWidth = 0;
     protected boolean                      useTable         = false;
 
+    public boolean isUseTable() {
+        return useTable;
+    }
+
     public RelationLayout(Relation r, RelationStyle style) {
         super(r, style.getLabelStyle());
         assert r != null && style != null;
@@ -213,11 +217,13 @@ public final class RelationLayout extends SchemaNodeLayout {
                                       - style.getElementHorizontalInset());
         for (SchemaNodeLayout child : children) {
             double childWidth = labelWidth + child.layoutWidth();
-            if (childWidth > halfWidth || current == null) {
+            // Paper §3.4: outline-mode relations are excluded from column sets
+            boolean excluded = (child instanceof RelationLayout rl) && !rl.isUseTable();
+            if (excluded || childWidth > halfWidth || current == null) {
                 current = new ColumnSet();
                 columnSets.add(current);
                 current.add(child);
-                if (childWidth > halfWidth) {
+                if (excluded || childWidth > halfWidth) {
                     current = null;
                 }
             } else {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -74,10 +74,6 @@ public final class RelationLayout extends SchemaNodeLayout {
     protected double                       tableColumnWidth = 0;
     protected boolean                      useTable         = false;
 
-    public boolean isUseTable() {
-        return useTable;
-    }
-
     public RelationLayout(Relation r, RelationStyle style) {
         super(r, style.getLabelStyle());
         assert r != null && style != null;
@@ -264,6 +260,10 @@ public final class RelationLayout extends SchemaNodeLayout {
 
     public String getStyleClass() {
         return node.getField();
+    }
+
+    public boolean isUseTable() {
+        return useTable;
     }
 
     @Override

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutCompressTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutCompressTest.java
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.LabelStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+
+/**
+ * Tests for column set formation in RelationLayout.compress().
+ *
+ * Verifies the fix from RDR-004: outline-mode relations must be excluded
+ * from column sets (Bakke 2013 §3.4), while table-mode relations may
+ * share column sets with other fields.
+ */
+class RelationLayoutCompressTest {
+
+    private static RelationStyle mockRelationStyle() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        RelationStyle style = mock(RelationStyle.class);
+        when(style.getLabelStyle()).thenReturn(labelStyle);
+        when(style.getOutlineHorizontalInset()).thenReturn(0.0);
+        when(style.getOutlineCellHorizontalInset()).thenReturn(0.0);
+        when(style.getSpanHorizontalInset()).thenReturn(0.0);
+        when(style.getColumnHorizontalInset()).thenReturn(0.0);
+        when(style.getElementHorizontalInset()).thenReturn(0.0);
+        when(style.getSpanVerticalInset()).thenReturn(0.0);
+        when(style.getColumnVerticalInset()).thenReturn(0.0);
+        when(style.getRowVerticalInset()).thenReturn(0.0);
+        when(style.getRowCellVerticalInset()).thenReturn(0.0);
+        when(style.getOutlineCellVerticalInset()).thenReturn(0.0);
+        when(style.getOutlineVerticalInset()).thenReturn(0.0);
+        when(style.getElementVerticalInset()).thenReturn(0.0);
+        return style;
+    }
+
+    private static PrimitiveLayout makePrimitive(String name, double width) {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        PrimitiveStyle primStyle = mock(PrimitiveStyle.class);
+        when(primStyle.getLabelStyle()).thenReturn(labelStyle);
+        when(primStyle.getHeight(anyDouble(), anyDouble())).thenReturn(20.0);
+        when(primStyle.getListVerticalInset()).thenReturn(0.0);
+
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive(name), primStyle);
+        layout.columnWidth = width;
+        layout.labelWidth = 0;
+        return layout;
+    }
+
+    private static RelationLayout makeChildRelation(String name, double width,
+                                                     boolean useTable) {
+        RelationStyle childStyle = mockRelationStyle();
+        RelationLayout layout = new RelationLayout(new Relation(name), childStyle);
+        layout.columnWidth = width;
+        layout.useTable = useTable;
+        layout.tableColumnWidth = width;
+        layout.labelWidth = 0;
+        layout.maxCardinality = 3;
+        layout.averageChildCardinality = 2;
+        return layout;
+    }
+
+    /**
+     * Paper §3.4: outline-mode relations are excluded from column sets.
+     * Each gets its own single-column column set.
+     */
+    @Test
+    void outlineRelationGetsOwnColumnSet() {
+        RelationStyle style = mockRelationStyle();
+        Relation parent = new Relation("parent");
+        RelationLayout layout = new RelationLayout(parent, style);
+
+        PrimitiveLayout prim1 = makePrimitive("name", 30);
+        RelationLayout outlineChild = makeChildRelation("items", 20, false);
+        PrimitiveLayout prim2 = makePrimitive("email", 30);
+
+        layout.children.clear();
+        layout.children.add(prim1);
+        layout.children.add(outlineChild);
+        layout.children.add(prim2);
+        layout.labelWidth = 10;
+        layout.averageChildCardinality = 2;
+
+        // Width large enough that all children would fit in a shared column set
+        // without the exclusion rule (halfWidth ≈ 250 >> any child width)
+        layout.compress(500);
+
+        // Verify: outline relation is alone in its column set
+        boolean relationAlone = false;
+        for (ColumnSet cs : layout.columnSets) {
+            List<SchemaNodeLayout> allFields = cs.getColumns()
+                                                  .stream()
+                                                  .flatMap(col -> col.getFields().stream())
+                                                  .toList();
+            if (allFields.contains(outlineChild)) {
+                relationAlone = (allFields.size() == 1);
+            }
+        }
+        assertTrue(relationAlone,
+                   "Outline-mode relation must be in its own column set (§3.4)");
+    }
+
+    /**
+     * Paper §3.4: table-mode relations are NOT excluded — they can share
+     * column sets with other fields.
+     */
+    @Test
+    void tableModeRelationCanShareColumnSet() {
+        RelationStyle style = mockRelationStyle();
+        Relation parent = new Relation("parent");
+        RelationLayout layout = new RelationLayout(parent, style);
+
+        PrimitiveLayout prim1 = makePrimitive("name", 30);
+        RelationLayout tableChild = makeChildRelation("items", 20, true);
+
+        layout.children.clear();
+        layout.children.add(prim1);
+        layout.children.add(tableChild);
+        layout.labelWidth = 10;
+        layout.averageChildCardinality = 2;
+
+        layout.compress(500);
+
+        // Both should end up in the same column set since the relation
+        // is in table mode and narrow enough
+        assertEquals(1, layout.columnSets.size(),
+                     "Table-mode relation should share column set with primitive");
+    }
+
+    /**
+     * Verify that the outline relation exclusion also starts a new column set
+     * for subsequent children.
+     */
+    @Test
+    void outlineRelationBreaksColumnSetForSubsequentChildren() {
+        RelationStyle style = mockRelationStyle();
+        Relation parent = new Relation("parent");
+        RelationLayout layout = new RelationLayout(parent, style);
+
+        PrimitiveLayout prim1 = makePrimitive("name", 30);
+        RelationLayout outlineChild = makeChildRelation("items", 20, false);
+        PrimitiveLayout prim2 = makePrimitive("email", 30);
+        PrimitiveLayout prim3 = makePrimitive("phone", 30);
+
+        layout.children.clear();
+        layout.children.add(prim1);
+        layout.children.add(outlineChild);
+        layout.children.add(prim2);
+        layout.children.add(prim3);
+        layout.labelWidth = 10;
+        layout.averageChildCardinality = 2;
+
+        layout.compress(500);
+
+        // Expected column sets: [prim1], [outlineChild], [prim2, prim3]
+        assertEquals(3, layout.columnSets.size(),
+                     "Should have 3 column sets: before relation, relation itself, after relation");
+
+        // Verify the outline relation is the sole occupant of the middle set
+        List<SchemaNodeLayout> middleFields = layout.columnSets.get(1)
+                                                                .getColumns()
+                                                                .stream()
+                                                                .flatMap(col -> col.getFields().stream())
+                                                                .toList();
+        assertEquals(1, middleFields.size());
+        assertSame(outlineChild, middleFields.get(0));
+    }
+
+    /**
+     * All-primitive children with no relations should behave as before the fix.
+     */
+    @Test
+    void allPrimitivesGroupedNormally() {
+        RelationStyle style = mockRelationStyle();
+        Relation parent = new Relation("parent");
+        RelationLayout layout = new RelationLayout(parent, style);
+
+        PrimitiveLayout prim1 = makePrimitive("name", 30);
+        PrimitiveLayout prim2 = makePrimitive("email", 30);
+        PrimitiveLayout prim3 = makePrimitive("phone", 30);
+
+        layout.children.clear();
+        layout.children.add(prim1);
+        layout.children.add(prim2);
+        layout.children.add(prim3);
+        layout.labelWidth = 10;
+        layout.averageChildCardinality = 2;
+
+        layout.compress(500);
+
+        // All narrow primitives should share a single column set
+        assertEquals(1, layout.columnSets.size(),
+                     "All narrow primitives should share one column set");
+    }
+
+    /**
+     * Wide children (wider than halfWidth) get their own column set
+     * regardless of type — this is the pre-existing width-based rule.
+     */
+    @Test
+    void widePrimitiveGetsOwnColumnSet() {
+        RelationStyle style = mockRelationStyle();
+        Relation parent = new Relation("parent");
+        RelationLayout layout = new RelationLayout(parent, style);
+
+        PrimitiveLayout narrow = makePrimitive("name", 30);
+        PrimitiveLayout wide = makePrimitive("description", 300);
+        PrimitiveLayout narrow2 = makePrimitive("email", 30);
+
+        layout.children.clear();
+        layout.children.add(narrow);
+        layout.children.add(wide);
+        layout.children.add(narrow2);
+        layout.labelWidth = 10;
+        layout.averageChildCardinality = 2;
+
+        // halfWidth ≈ 250, so 'wide' (310 with labelWidth) exceeds it
+        layout.compress(500);
+
+        assertEquals(3, layout.columnSets.size(),
+                     "Wide primitive should get its own column set");
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug**: `RelationLayout.compress()` used only a width threshold to partition children into column sets. A narrow relation rendered as an outline could be incorrectly grouped with primitives, violating Bakke 2013 §3.4.
- **Fix**: Add conditional exclusion — outline-mode relations (`!useTable`) get their own column set. Table-mode relations may still share column sets with primitives, matching the paper's nuanced rule.
- **RDR**: Creates RDR-004 documenting the bug, 5 research findings, and the fix.

## Changes

- `RelationLayout.java`: Added `isUseTable()` accessor; updated `compress()` with `(child instanceof RelationLayout rl) && !rl.isUseTable()` check
- `RDR-004-outline-column-correctness.md`: New RDR with research findings and implementation plan

## Test plan

- [ ] `mvn clean install` passes (verified locally)
- [ ] Existing smoke tests pass without regression
- [ ] Future: add test for narrow relation + wide primitives scenario (no test coverage exists for compress/ColumnSet/Column yet)

References: Kramer-oo0