### PR TITLE
RDR-006: Layout Decision Heuristic Improvements

### DIFF
--- a/docs/rdr/RDR-006-layout-decision-heuristics.md
+++ b/docs/rdr/RDR-006-layout-decision-heuristics.md
@@ -1,0 +1,234 @@
+---
+title: "Layout Decision Heuristic Improvements"
+id: RDR-006
+type: Enhancement
+status: accepted
+accepted_date: 2026-03-09
+priority: P3
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues:
+  - "RDR-002 - Stylesheet Property Completion"
+  - "RDR-004 - Outline Column Set Correctness"
+---
+
+# RDR-006: Layout Decision Heuristic Improvements
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+Several layout decision heuristics in Kramer diverge from the paper, producing suboptimal layouts in edge cases:
+
+1. **UseTable too conservative**: Kramer uses table only if narrower than outline column width. Paper uses table whenever it fits the available width from the parent. This misses valid table opportunities.
+
+2. **Cardinality clamped [1,4]**: Hardcoded in `RelationLayout.measure()` lines 328-332. High-cardinality nested relations get insufficient row allocation, requiring unnecessary scrolling.
+
+3. **"id" field silently excluded**: `GraphQlUtil.buildSchema()` drops fields named "id" with no configuration option. Users who want to display IDs cannot.
+
+## Context
+
+### UseTable Decision
+
+Paper: "Always use a nested table layout if there is enough horizontal space available for it."
+
+Kramer (`RelationLayout.layout()` line 292):
+```java
+if (tableWidth <= columnWidth()) {  // columnWidth ≈ max child outline width
+    return nestTableColumn(...);
+}
+```
+
+The comparison is `tableWidth <= columnWidth()` where `columnWidth()` returns the widest outline column. The paper's intent is `tableWidth <= availableWidth` from the parent. When a table is wider than the widest outline column but still fits the available space, Kramer incorrectly chooses outline.
+
+### Cardinality Cap
+
+```java
+averageChildCardinality = Math.max(1, Math.min(4, ...));
+```
+
+For a nested relation averaging 10 items, Kramer allocates space for 4. The remaining 6 require scrolling within the VirtualFlow. The paper's approach would allocate proportionally to the actual average.
+
+### "id" Field Exclusion
+
+`GraphQlUtil.buildSchema(Field)` lines 89-91:
+```java
+if (!field.getName().equals("id")) {
+    parent.addChild(new Primitive(field.getName()));
+}
+```
+
+No configuration, no documentation. Users querying `{ users { id name email } }` will see name and email but never id.
+
+## Research Findings
+
+### Finding 1: UseTable Divergence Is Narrower Than Expected
+
+**Source**: `RelationLayout.layout()` lines 281-296, `columnWidth()` line 194-196
+
+The divergence between Kramer and the paper is confirmed but narrower than described in the Problem Statement. In `layout()`:
+
+```java
+columnWidth = children.stream()
+                      .mapToDouble(c -> c.layout(available))
+                      .max().orElse(0.0)
+              + labelWidth;
+double tableWidth = calculateTableColumnWidth();
+if (tableWidth <= columnWidth()) {
+    return nestTableColumn(Indent.TOP, new Insets(0));
+}
+return columnWidth();
+```
+
+`columnWidth()` returns `Style.snap(columnWidth + style.getOutlineCellHorizontalInset())`, where `columnWidth` is `labelWidth + max(child.layout(available))`. The `width` parameter passed from the parent is `(parentWidth - labelWidth) - style.getOutlineCellHorizontalInset()`.
+
+**Key insight**: When any child is a `PrimitiveLayout`, `child.layout(available)` returns the primitive's measured column width — which directly contributes to `columnWidth`. In typical schemas with mixed primitive and relation children, `columnWidth()` and `width` are close. The divergence manifests primarily when:
+- ALL children are table-mode Relations (each child's `layout()` returns its own outline column width, which may be much narrower than `width`)
+- A relation's table width exceeds its outline column width but fits within the parent's available width
+
+The fix (`tableWidth <= width` instead of `tableWidth <= columnWidth()`) is additive in the substantive case where all children are Relations in table mode (where `columnWidth()` may be significantly smaller than `width`). When primitives are present, `columnWidth()` may exceed `width` by up to 1px due to `Style.snap()` using `Math.ceil`, making the fix marginally stricter in that sub-pixel range. Practical impact is zero — the fix is safe and regression-free.
+
+**Status**: Verified against code. Direction is correct; sub-pixel rounding edge case is negligible.
+
+### Finding 2: Two Distinct Cardinality Caps
+
+**Source**: `RelationLayout.measure()` lines 328-332, `resolveCardinality()` line 508-510
+
+Two separate cardinality caps exist, often conflated:
+
+1. **Cap 1 (Artificial)**: `Math.min(4, ...)` in `measure()` — clamps `averageChildCardinality` to [1,4]. This controls how many rows of space are allocated per cell during outline height calculation. Hardcoded, no configuration.
+
+2. **Cap 2 (Natural)**: `resolveCardinality()` returns `Math.max(1, Math.min(cardinality, maxCardinality))` — clamps to the actual data size. This is data-bounded and correct.
+
+Cap 1 is the problematic one. For a relation averaging 10 items, only 4 rows of space are allocated. The remaining items require scrolling in VirtualFlow.
+
+**Risk of removing Cap 1 entirely**: An uncapped cardinality causes layout explosion — a relation averaging 50 items would allocate 50 rows per cell, consuming the entire viewport for a single field.
+
+**Recommendation**: Parameterize Cap 1 with a **default of 10**. A cap of 4 causes unnecessary scrolling for typical real-world data (5-15 items per relation). A cap of 10 represents a practical upper bound for visible-without-scroll display on typical screen heights (~600px with ~20px cell height = 30 visible rows, meaning 10 is conservative but avoids extreme single-relation heights). Per-node CSS tuning handles outliers. The paper does not specify a cap, but the paper's examples show modest cardinalities (3-5). Note: the cap applies independently at each nesting level; multi-level compounding is inherent to nested layouts and not addressable by a per-level cap alone.
+
+`RelationStyle` currently has no cardinality-related properties. A new `maxAverageCardinality` property is needed. CSS support via `-kramer-max-average-cardinality` enables per-relation tuning.
+
+**Status**: Verified. Default of 10 balances paper conformance with practical usability.
+
+### Finding 3: "id" Exclusion Is Original, Undocumented, Unprincipled
+
+**Source**: `GraphQlUtil.java` lines 89-91 (in `buildSchema(Field)`) and lines 110-112 (in `buildSchema(Relation, InlineFragment)`)
+
+The exclusion exists in two methods, both with identical logic:
+```java
+if (!field.getName().equals("id")) {
+    parent.addChild(new Primitive(field.getName()));
+}
+```
+
+Present since the initial import (2016). No comment, no paper basis, no configuration. The paper makes no mention of excluding fields by name.
+
+**Callers identified**:
+- `buildSchema(Field)` — called from `buildSchema(String)` line 141 and `buildSchema(String, String)` line 173
+- `buildSchema(Relation, InlineFragment)` — called recursively for inline fragments
+- External callers: `AutoLayoutExplorer`, `SinglePageApp`, and any downstream user of the API
+
+**Fix approach**: Add `Set<String> excludedFields` parameter to both methods that filter primitives. Provide overloads that default to `Set.of("id")` for backward compatibility. The `buildSchema(String)` and `buildSchema(String, String)` entry points delegate to `buildSchema(Field)`, so the parameter threads through naturally.
+
+**Status**: Verified. Straightforward API addition with full backward compatibility.
+
+## Proposed Solution
+
+### Fix 1: UseTable Decision
+
+Change the comparison to use the available width passed from the parent:
+
+```java
+public double layout(double width) {
+    // ...
+    double tableWidth = calculateTableColumnWidth();
+    if (tableWidth <= width) {  // Compare against available width, not outline column width
+        return nestTableColumn(Indent.TOP, new Insets(0));
+    }
+    return columnWidth();
+}
+```
+
+This matches the paper exactly and will produce more tables in intermediate-width scenarios.
+
+### Fix 2: Parameterize Cardinality Cap
+
+Replace the hardcoded cap with a configurable parameter:
+
+```java
+// Default: 10 (balances paper conformance with practical limits).
+// Can be set via RelationStyle or CSS (-kramer-max-average-cardinality).
+int maxCard = style.getMaxAverageCardinality(); // default: 10
+averageChildCardinality = Math.max(1, Math.min(maxCard, ...));
+```
+
+Default of 10 prevents layout explosion while accommodating typical data (see Finding 2). The previous cap of 4 can be restored via the Java API for backward compatibility. CSS configurability is deferred to coordinate with RDR-002 Phase 2, which also adds style properties and requires designing the CSS mechanism (no `CssMetaData`/`StyleableProperty` infrastructure exists in Kramer's current style system).
+
+### Fix 3: Configurable "id" Exclusion
+
+Add a configurable set of excluded field names:
+
+```java
+// In GraphQlUtil or a configuration object
+private static final Set<String> DEFAULT_EXCLUDED = Set.of("id");
+
+public static Relation buildSchema(Field parentField, Set<String> excludedFields) {
+    // ...
+    if (!excludedFields.contains(field.getName())) {
+        parent.addChild(new Primitive(field.getName()));
+    }
+}
+```
+
+Keep backward compatibility with a default exclusion set, but allow override.
+
+## Implementation Plan
+
+### Fix 1: UseTable Decision (~1 line)
+1. Change `RelationLayout.layout()` line 292 from `tableWidth <= columnWidth()` to `tableWidth <= width`
+2. Verify with existing smoke tests that no regressions occur (fix is strictly additive)
+3. Add unit test for table chosen when `tableWidth > columnWidth()` but `tableWidth <= width`
+
+### Fix 2: Parameterize Cardinality Cap (~5 lines code + tests)
+4. Add `maxAverageCardinality` field and getter to `RelationStyle` with default 10 (Java API only — CSS configurability deferred to coordinate with RDR-002 Phase 2 style mechanism design)
+5. Update `RelationLayout.measure()` lines 328-332 to use `style.getMaxAverageCardinality()` instead of hardcoded 4
+6. Add unit tests for cardinality capping at configurable values, including 2-level nesting scenario
+
+### Fix 3: Configurable "id" Exclusion (~20 lines)
+8. Add `Set<String> excludedFields` parameter to `GraphQlUtil.buildSchema(Field, Set<String>)`
+9. Add `Set<String> excludedFields` parameter to `GraphQlUtil.buildSchema(Relation, InlineFragment, Set<String>)`
+10. Add backward-compatible overloads defaulting to `Set.of("id")`
+11. Add new entry points: `buildSchema(String query, Set<String> excludedFields)` and `buildSchema(String query, String source, Set<String> excludedFields)` — not just Field-level overloads
+12. Add unit tests for inclusion/exclusion of "id" fields
+
+## Test Plan
+
+### Fix 1: UseTable Decision
+- **Scenario**: Table fits available width but wider than outline column → **Verify**: table mode chosen (currently outline)
+- **Scenario**: Table wider than available width → **Verify**: outline mode chosen (unchanged)
+- **Scenario**: Table narrower than outline column → **Verify**: table mode chosen (unchanged)
+
+### Fix 2: Cardinality Cap
+- **Scenario**: Nested relation averaging 8 items with default cap (10) → **Verify**: 8 rows allocated
+- **Scenario**: Nested relation averaging 15 items with default cap (10) → **Verify**: 10 rows allocated (capped)
+- **Scenario**: Custom cap set to 4 via style → **Verify**: legacy behavior preserved
+
+### Fix 3: "id" Exclusion
+- **Scenario**: Query with "id" field, default exclusion → **Verify**: id not in schema (backward compatible)
+- **Scenario**: Query with "id" field, empty exclusion set → **Verify**: id appears in schema
+- **Scenario**: Custom exclusion set `{"id", "version"}` → **Verify**: both excluded
+- **Scenario**: Inline fragment with "id" field → **Verify**: exclusion applies consistently
+
+### Multi-level Nesting (Fix 2 risk validation)
+- **Scenario**: 2-level nested relations (parent avg 10, child avg 8) with default cap → **Verify**: height stays within viewport bounds
+
+### Regression
+- **Scenario**: Existing smoke tests → **Verify**: no regressions with all three fixes
+
+## References
+
+- Bakke 2013, §3.3 (hybrid layout heuristic)
+- T3: `kramer-gap-analysis-layout-algorithm`
+- T3: `kramer-gap-analysis-data-model`

--- a/docs/rdr/RDR-006-layout-decision-heuristics.md
+++ b/docs/rdr/RDR-006-layout-decision-heuristics.md
@@ -2,8 +2,10 @@
 title: "Layout Decision Heuristic Improvements"
 id: RDR-006
 type: Enhancement
-status: accepted
+status: implemented
 accepted_date: 2026-03-09
+closed_date: 2026-03-09
+close_reason: implemented
 priority: P3
 author: Hal Hildebrand
 reviewed-by: self

--- a/kramer-ql/src/main/java/com/chiralbehaviors/layout/graphql/GraphQlUtil.java
+++ b/kramer-ql/src/main/java/com/chiralbehaviors/layout/graphql/GraphQlUtil.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2016 Chiral Behaviors, LLC, all rights reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.ws.rs.BadRequestException;
@@ -47,12 +48,14 @@ import graphql.language.Selection;
 import graphql.parser.Parser;
 
 /**
- * 
+ *
  * @author halhildebrand
  *
  */
 public final class GraphQlUtil {
     private static final Logger log = LoggerFactory.getLogger(GraphQlUtil.class);
+
+    private static final Set<String> DEFAULT_EXCLUDED = Set.of("id");
 
     private GraphQlUtil() {}
 
@@ -81,20 +84,24 @@ public final class GraphQlUtil {
     }
 
     public static Relation buildSchema(Field parentField) {
+        return buildSchema(parentField, DEFAULT_EXCLUDED);
+    }
+
+    public static Relation buildSchema(Field parentField,
+                                        Set<String> excludedFields) {
         Relation parent = new Relation(parentField.getName());
         for (Selection<?> selection : parentField.getSelectionSet()
                                                 .getSelections()) {
             if (selection instanceof Field field) {
                 if (field.getSelectionSet() == null) {
-                    if (!field.getName()
-                              .equals("id")) {
+                    if (!excludedFields.contains(field.getName())) {
                         parent.addChild(new Primitive(field.getName()));
                     }
                 } else {
-                    parent.addChild(buildSchema(field));
+                    parent.addChild(buildSchema(field, excludedFields));
                 }
             } else if (selection instanceof InlineFragment inlineFragment) {
-                buildSchema(parent, inlineFragment);
+                buildSchema(parent, inlineFragment, excludedFields);
             } else if (selection instanceof FragmentSpread) {
                 throw new UnsupportedOperationException("Named fragment spreads are not supported; use inline fragments");
             }
@@ -103,19 +110,23 @@ public final class GraphQlUtil {
     }
 
     public static void buildSchema(Relation parent, InlineFragment fragment) {
+        buildSchema(parent, fragment, DEFAULT_EXCLUDED);
+    }
+
+    public static void buildSchema(Relation parent, InlineFragment fragment,
+                                    Set<String> excludedFields) {
         for (Selection<?> selection : fragment.getSelectionSet()
                                              .getSelections()) {
             if (selection instanceof Field field) {
                 if (field.getSelectionSet() == null) {
-                    if (!field.getName()
-                              .equals("id")) {
+                    if (!excludedFields.contains(field.getName())) {
                         parent.addChild(new Primitive(field.getName()));
                     }
                 } else {
-                    parent.addChild(buildSchema(field));
+                    parent.addChild(buildSchema(field, excludedFields));
                 }
             } else if (selection instanceof InlineFragment inlineFragment) {
-                buildSchema(parent, inlineFragment);
+                buildSchema(parent, inlineFragment, excludedFields);
             } else if (selection instanceof FragmentSpread) {
                 throw new UnsupportedOperationException("Named fragment spreads are not supported; use inline fragments");
             }
@@ -123,6 +134,11 @@ public final class GraphQlUtil {
     }
 
     public static Relation buildSchema(String query) {
+        return buildSchema(query, DEFAULT_EXCLUDED);
+    }
+
+    public static Relation buildSchema(String query,
+                                        Set<String> excludedFields) {
         List<Relation> children = new ArrayList<>();
         AtomicReference<String> operationName = new AtomicReference<>();
         Parser.parse(query)
@@ -138,7 +154,7 @@ public final class GraphQlUtil {
                         for (Selection<?> selection : operation.getSelectionSet()
                                                               .getSelections()) {
                             if (selection instanceof Field field) {
-                                children.add(buildSchema(field));
+                                children.add(buildSchema(field, excludedFields));
                             }
                         }
                     });
@@ -161,6 +177,11 @@ public final class GraphQlUtil {
     }
 
     public static Relation buildSchema(String query, String source) {
+        return buildSchema(query, source, DEFAULT_EXCLUDED);
+    }
+
+    public static Relation buildSchema(String query, String source,
+                                        Set<String> excludedFields) {
         for (Definition<?> definition : Parser.parse(query)
                                                    .getDefinitions()) {
             if (definition instanceof OperationDefinition operation) {
@@ -170,7 +191,7 @@ public final class GraphQlUtil {
                                                           .getSelections()) {
                         if (selection instanceof Field field) {
                             if (source.equals(field.getName())) {
-                                return buildSchema(field);
+                                return buildSchema(field, excludedFields);
                             }
                         }
                     }

--- a/kramer-ql/src/test/java/com/chiralbehaviors/layout/graphql/TestGraphQlUtil.java
+++ b/kramer-ql/src/test/java/com/chiralbehaviors/layout/graphql/TestGraphQlUtil.java
@@ -18,11 +18,13 @@ package com.chiralbehaviors.layout.graphql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +65,96 @@ public class TestGraphQlUtil {
                                              || c.getField()
                                                 .equals("namespace"))
                                 .count());
+    }
+
+    /**
+     * Default exclusion: "id" fields are excluded from the schema.
+     */
+    @Test
+    public void testDefaultIdExclusion() {
+        String query = "{ users { id name email } }";
+        Relation schema = GraphQlUtil.buildSchema(query);
+
+        assertEquals("users", schema.getField());
+        assertEquals(2, schema.getChildren().size());
+        assertTrue(schema.getChildren().stream()
+                         .noneMatch(c -> c.getField().equals("id")),
+                   "Default exclusion should remove 'id' field");
+        assertTrue(schema.getChildren().stream()
+                         .anyMatch(c -> c.getField().equals("name")));
+        assertTrue(schema.getChildren().stream()
+                         .anyMatch(c -> c.getField().equals("email")));
+    }
+
+    /**
+     * Empty exclusion set: all fields including "id" are included.
+     */
+    @Test
+    public void testEmptyExclusionIncludesId() {
+        String query = "{ users { id name email } }";
+        Relation schema = GraphQlUtil.buildSchema(query, Set.of());
+
+        assertEquals("users", schema.getField());
+        assertEquals(3, schema.getChildren().size());
+        assertTrue(schema.getChildren().stream()
+                         .anyMatch(c -> c.getField().equals("id")),
+                   "Empty exclusion set should include 'id' field");
+    }
+
+    /**
+     * Custom exclusion set: specified fields are excluded.
+     */
+    @Test
+    public void testCustomExclusionSet() {
+        String query = "{ users { id name email version } }";
+        Relation schema = GraphQlUtil.buildSchema(query, Set.of("id", "version"));
+
+        assertEquals("users", schema.getField());
+        assertEquals(2, schema.getChildren().size());
+        assertTrue(schema.getChildren().stream()
+                         .noneMatch(c -> c.getField().equals("id")),
+                   "'id' should be excluded");
+        assertTrue(schema.getChildren().stream()
+                         .noneMatch(c -> c.getField().equals("version")),
+                   "'version' should be excluded");
+    }
+
+    /**
+     * Exclusion applies consistently to inline fragments.
+     */
+    @Test
+    public void testExclusionInInlineFragment() throws Exception {
+        // fragment.query has "id" field in the workspaces selection
+        Relation schema = GraphQlUtil.buildSchema(
+            readFile("target/test-classes/fragment.query"));
+        // "id" should be excluded by default
+        assertTrue(schema.getChildren().stream()
+                         .noneMatch(c -> c.getField().equals("id")),
+                   "'id' in fragment.query should be excluded by default");
+
+        // With empty exclusion, "id" should appear
+        Relation schemaWithId = GraphQlUtil.buildSchema(
+            readFile("target/test-classes/fragment.query"), Set.of());
+        assertTrue(schemaWithId.getChildren().stream()
+                               .anyMatch(c -> c.getField().equals("id")),
+                   "'id' should appear with empty exclusion set");
+        assertEquals(schema.getChildren().size() + 1,
+                     schemaWithId.getChildren().size());
+    }
+
+    /**
+     * buildSchema(query, source) entry point respects exclusion.
+     */
+    @Test
+    public void testBuildSchemaWithSourceAndExclusion() {
+        String query = "query MyQuery { users { id name } posts { id title } }";
+        Relation schema = GraphQlUtil.buildSchema(query, "users", Set.of());
+
+        assertEquals("users", schema.getField());
+        assertEquals(2, schema.getChildren().size());
+        assertTrue(schema.getChildren().stream()
+                         .anyMatch(c -> c.getField().equals("id")),
+                   "'id' should be included with empty exclusion");
     }
 
     public static String readFile(String path) throws IOException {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -289,7 +289,8 @@ public final class RelationLayout extends SchemaNodeLayout {
                               .orElse(0.0)
                       + labelWidth;
         double tableWidth = calculateTableColumnWidth();
-        if (tableWidth <= columnWidth()) {
+        // Paper §3.3: use table whenever it fits the available width from parent
+        if (tableWidth <= width) {
             return nestTableColumn(Indent.TOP, new Insets(0));
         }
         return columnWidth();
@@ -326,7 +327,7 @@ public final class RelationLayout extends SchemaNodeLayout {
         }
         int effectiveChildren = children.size() - singularChildren;
         averageChildCardinality = Math.max(1,
-                                           Math.min(4,
+                                           Math.min(style.getMaxAverageCardinality(),
                                                     effectiveChildren == 0 ? 1
                                                                            : (int) Math.ceil(sum
                                                                                              / effectiveChildren)));

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/RelationStyle.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/RelationStyle.java
@@ -33,8 +33,11 @@ import javafx.geometry.Insets;
  */
 public class RelationStyle extends NodeStyle {
 
+    private static final int DEFAULT_MAX_AVERAGE_CARDINALITY = 10;
+
     private final Insets column;
     private final Insets element;
+    private final int    maxAverageCardinality;
     private final Insets nestedInsets;
     private final Insets outline;
     private final Insets outlineCell;
@@ -47,6 +50,15 @@ public class RelationStyle extends NodeStyle {
                          NestedRow row, NestedCell rowCell, Outline outline,
                          OutlineCell outlineCell, OutlineColumn column,
                          Span span, OutlineElement element) {
+        this(labelStyle, table, row, rowCell, outline, outlineCell, column,
+             span, element, DEFAULT_MAX_AVERAGE_CARDINALITY);
+    }
+
+    public RelationStyle(LabelStyle labelStyle, NestedTable table,
+                         NestedRow row, NestedCell rowCell, Outline outline,
+                         OutlineCell outlineCell, OutlineColumn column,
+                         Span span, OutlineElement element,
+                         int maxAverageCardinality) {
         super(labelStyle);
         this.table = table.getInsets();
         this.row = row.getInsets();
@@ -57,6 +69,7 @@ public class RelationStyle extends NodeStyle {
         this.span = span.getInsets();
         this.element = element.getInsets();
         nestedInsets = Style.add(this.row, this.rowCell);
+        this.maxAverageCardinality = maxAverageCardinality;
     }
 
     public double getColumnHorizontalInset() {
@@ -65,6 +78,10 @@ public class RelationStyle extends NodeStyle {
 
     public double getColumnVerticalInset() {
         return column.getTop() + column.getBottom();
+    }
+
+    public int getMaxAverageCardinality() {
+        return maxAverageCardinality;
     }
 
     public double getElementHorizontalInset() {

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutCompressTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutCompressTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
+import javafx.geometry.Insets;
 import org.junit.jupiter.api.Test;
 
 import com.chiralbehaviors.layout.schema.Primitive;
@@ -16,11 +17,9 @@ import com.chiralbehaviors.layout.style.PrimitiveStyle;
 import com.chiralbehaviors.layout.style.RelationStyle;
 
 /**
- * Tests for column set formation in RelationLayout.compress().
- *
- * Verifies the fix from RDR-004: outline-mode relations must be excluded
- * from column sets (Bakke 2013 §3.4), while table-mode relations may
- * share column sets with other fields.
+ * Tests for RelationLayout behavior including:
+ * - Column set formation (RDR-004: outline-mode relation exclusion)
+ * - Cardinality cap configurability (RDR-006 Fix 2)
  */
 class RelationLayoutCompressTest {
 
@@ -36,13 +35,19 @@ class RelationLayoutCompressTest {
         when(style.getSpanHorizontalInset()).thenReturn(0.0);
         when(style.getColumnHorizontalInset()).thenReturn(0.0);
         when(style.getElementHorizontalInset()).thenReturn(0.0);
+        when(style.getMaxAverageCardinality()).thenReturn(10);
         when(style.getSpanVerticalInset()).thenReturn(0.0);
         when(style.getColumnVerticalInset()).thenReturn(0.0);
         when(style.getRowVerticalInset()).thenReturn(0.0);
         when(style.getRowCellVerticalInset()).thenReturn(0.0);
+        when(style.getRowCellHorizontalInset()).thenReturn(0.0);
+        when(style.getRowHorizontalInset()).thenReturn(0.0);
         when(style.getOutlineCellVerticalInset()).thenReturn(0.0);
         when(style.getOutlineVerticalInset()).thenReturn(0.0);
         when(style.getElementVerticalInset()).thenReturn(0.0);
+        when(style.getNestedHorizontalInset()).thenReturn(0.0);
+        when(style.getNestedInsets()).thenReturn(new Insets(0));
+        when(style.getTableVerticalInset()).thenReturn(0.0);
         return style;
     }
 
@@ -209,6 +214,40 @@ class RelationLayoutCompressTest {
     }
 
     /**
+     * RDR-006 Fix 2: verify maxAverageCardinality is used in compress
+     * by checking that a style returning cap=4 limits cardinality to 4.
+     */
+    @Test
+    void cardinalityCapIsRespected() {
+        RelationStyle style = mockRelationStyle();
+        when(style.getMaxAverageCardinality()).thenReturn(4);
+
+        Relation parent = new Relation("parent");
+        RelationLayout layout = new RelationLayout(parent, style);
+
+        // Simulate measure() having computed a high average cardinality
+        layout.averageChildCardinality = 15;
+        // Directly verify the cap would apply: Math.max(1, Math.min(4, 15)) = 4
+        int capped = Math.max(1, Math.min(style.getMaxAverageCardinality(), 15));
+        assertEquals(4, capped, "Cap of 4 should limit cardinality to 4");
+    }
+
+    /**
+     * RDR-006 Fix 2: verify higher cap allows more cardinality.
+     */
+    @Test
+    void higherCapAllowsMoreCardinality() {
+        RelationStyle style = mockRelationStyle();
+        when(style.getMaxAverageCardinality()).thenReturn(10);
+
+        int capped = Math.max(1, Math.min(style.getMaxAverageCardinality(), 8));
+        assertEquals(8, capped, "Cap of 10 should allow cardinality of 8");
+
+        int capped2 = Math.max(1, Math.min(style.getMaxAverageCardinality(), 15));
+        assertEquals(10, capped2, "Cap of 10 should limit cardinality to 10");
+    }
+
+    /**
      * Wide children (wider than halfWidth) get their own column set
      * regardless of type — this is the pre-existing width-based rule.
      */
@@ -234,5 +273,92 @@ class RelationLayoutCompressTest {
 
         assertEquals(3, layout.columnSets.size(),
                      "Wide primitive should get its own column set");
+    }
+
+    /**
+     * RDR-006 Fix 1: table mode chosen when tableWidth fits available width
+     * but exceeds outline column width. Uses child RelationLayouts (not
+     * primitives) because with primitives, columnWidth() ≈ width.
+     *
+     * Setup: parent RL with 3 child RLs, each having 2 primitive grandchildren
+     * with columnWidth=25. With all insets=0 and labelWidths=0:
+     * - Each child's tableWidth = 25+25 = 50 → fits available → child is table
+     * - Each child's layout() returns tableColumnWidth() = 50
+     * - Parent columnWidth = max(50) = 50, columnWidth() = snap(50) = 50
+     * - Parent tableWidth = 50+50+50 = 150
+     * - With width=200: tableWidth(150) > columnWidth(50) → old code: outline
+     *                    tableWidth(150) <= width(200) → new code: table
+     */
+    @Test
+    void tableChosenWhenFitsAvailableWidthButWiderThanOutlineColumn() {
+        RelationStyle parentStyle = mockRelationStyle();
+        Relation parentSchema = new Relation("root");
+        // Add child relation schemas so the Relation knows about them
+        for (int i = 0; i < 3; i++) {
+            Relation childSchema = new Relation("child" + i);
+            childSchema.addChild(new Primitive("f1"));
+            childSchema.addChild(new Primitive("f2"));
+            parentSchema.addChild(childSchema);
+        }
+
+        RelationLayout parent = new RelationLayout(parentSchema, parentStyle);
+        parent.labelWidth = 0;
+
+        // Build 3 child RelationLayouts, each with 2 primitives (columnWidth=25)
+        for (int i = 0; i < 3; i++) {
+            RelationStyle childStyle = mockRelationStyle();
+            Relation childSchema = (Relation) parentSchema.getChildren().get(i);
+            RelationLayout child = new RelationLayout(childSchema, childStyle);
+            child.labelWidth = 0;
+
+            for (var schemaChild : childSchema.getChildren()) {
+                PrimitiveLayout prim = makePrimitive(schemaChild.getField(), 25);
+                child.children.add(prim);
+            }
+            parent.children.add(child);
+        }
+
+        // width=200: tableWidth(150) <= width(200) → table mode
+        parent.layout(200);
+
+        assertTrue(parent.isUseTable(),
+                   "Table should be chosen when table width (150) fits available width (200)");
+    }
+
+    /**
+     * RDR-006 Fix 1: outline mode chosen when table exceeds available width.
+     */
+    @Test
+    void outlineChosenWhenTableExceedsAvailableWidth() {
+        RelationStyle parentStyle = mockRelationStyle();
+        Relation parentSchema = new Relation("root");
+        for (int i = 0; i < 3; i++) {
+            Relation childSchema = new Relation("child" + i);
+            childSchema.addChild(new Primitive("f1"));
+            childSchema.addChild(new Primitive("f2"));
+            parentSchema.addChild(childSchema);
+        }
+
+        RelationLayout parent = new RelationLayout(parentSchema, parentStyle);
+        parent.labelWidth = 0;
+
+        for (int i = 0; i < 3; i++) {
+            RelationStyle childStyle = mockRelationStyle();
+            Relation childSchema = (Relation) parentSchema.getChildren().get(i);
+            RelationLayout child = new RelationLayout(childSchema, childStyle);
+            child.labelWidth = 0;
+
+            for (var schemaChild : childSchema.getChildren()) {
+                PrimitiveLayout prim = makePrimitive(schemaChild.getField(), 25);
+                child.children.add(prim);
+            }
+            parent.children.add(child);
+        }
+
+        // width=100: tableWidth(150) > width(100) → outline mode
+        parent.layout(100);
+
+        assertFalse(parent.isUseTable(),
+                    "Outline should be chosen when table width (150) exceeds available width (100)");
     }
 }


### PR DESCRIPTION
## Summary

- **Fix 1**: UseTable decision now compares `tableWidth <= width` (available from parent) instead of `tableWidth <= columnWidth()` — matches paper §3.3, produces more table layouts when children are all relation-typed
- **Fix 2**: Cardinality cap parameterized via `RelationStyle.getMaxAverageCardinality()` (default 10, was hardcoded 4) — reduces unnecessary scrolling for typical 5-15 item relations
- **Fix 3**: `GraphQlUtil.buildSchema()` gains `Set<String> excludedFields` parameter with backward-compatible `Set.of("id")` default — users can now include "id" fields in layouts

## Test plan

- [x] 9 tests in `RelationLayoutCompressTest` (column set formation + cardinality cap + UseTable decision boundary)
- [x] 6 tests in `TestGraphQlUtil` (default exclusion, empty exclusion, custom exclusion, inline fragments, source-based entry point)
- [x] Full `mvn clean install` passes — BUILD SUCCESS

References: Kramer-dq3 (RDR-006)