### PR TITLE
Implement RDR-002: Stylesheet Property System Completion

### DIFF
--- a/docs/rdr/RDR-002-stylesheet-property-completion.md
+++ b/docs/rdr/RDR-002-stylesheet-property-completion.md
@@ -2,8 +2,10 @@
 title: "Stylesheet Property System Completion"
 id: RDR-002
 type: Feature
-status: accepted
+status: closed
 accepted_date: 2026-03-09
+closed_date: 2026-03-09
+close_reason: implemented
 priority: P2
 author: Hal Hildebrand
 reviewed-by: self

--- a/docs/rdr/RDR-002-stylesheet-property-completion.md
+++ b/docs/rdr/RDR-002-stylesheet-property-completion.md
@@ -1,0 +1,225 @@
+---
+title: "Stylesheet Property System Completion"
+id: RDR-002
+type: Feature
+status: accepted
+accepted_date: 2026-03-09
+priority: P2
+author: Hal Hildebrand
+reviewed-by: self
+created: 2026-03-08
+related_issues:
+  - "RDR-001 - Java 25 Modernization (closed)"
+---
+
+# RDR-002: Stylesheet Property System Completion
+
+> Revise during planning; lock at implementation.
+> If wrong, abandon code and iterate RDR.
+
+## Problem Statement
+
+The Bakke 2013 paper defines 20 stylesheet properties (Table 1) that drive layout decisions. Kramer implements only 7 fully, 4 partially, and is missing 9 entirely. The most impactful missing property is `IsVariableLength`, which drives a chain of dependent behaviors: `ValueDefaultWidth` computation (average vs max width), `OutlineSnapValueWidth` rounding for fixed-width data, and `TableMaxPrimitiveWidth` capping.
+
+Without these properties, all primitives are treated identically — fixed-width data (dates, IDs, enums) can't get clean uniform column widths, and variable-length data (descriptions, names) lacks proper width management.
+
+## Context
+
+### Gap Analysis Source
+
+6-agent parallel deep analysis comparing Bakke 2013 paper against Kramer implementation (2026-03-08). Full findings in T3: `kramer-gap-analysis-stylesheet-properties`.
+
+### Current State
+
+| Property | Status | Location |
+|----------|--------|----------|
+| IsVariableLength | Missing | — |
+| ValueDefaultWidth | Dead field | `Primitive.defaultWidth` (always 0) |
+| OutlineSnapValueWidth | Missing | `Style.snap()` does ceil, not width-multiple rounding — deferred, see Phase 1 |
+| OutlineMaxLabelWidth | Missing | `RelationLayout.labelWidth` unbounded |
+| OutlineColumnMinWidth | Missing | No minimum enforced |
+| OutlineMinValueWidth | Missing | No minimum enforced |
+| TableMaxPrimitiveWidth | Missing | No cap before justification |
+| OutlineBulletStyle | Missing | No bullets rendered |
+| OutlineIndentWidth | Missing | No bullet indentation |
+
+## Research Findings
+
+### Finding 1: IsVariableLength Detection Is Data-Driven, Not Configurable
+
+**Source**: `PrimitiveLayout.measure()` lines 152-190, `Primitive.defaultWidth` field
+
+`PrimitiveLayout.measure()` already computes both `maxWidth` and `averageWidth` from the data:
+
+```java
+// Line 179-188
+double averageWidth = 0;
+averageCardinality = 1;
+if (data.size() > 0) {
+    averageCardinality = (int) Math.round((double) cardSum / data.size());
+    averageWidth = summedDataWidth / data.size();
+}
+columnWidth = Math.max(labelWidth,
+                       Style.snap(Math.max(getNode().getDefaultWidth(),
+                                           averageWidth)));
+```
+
+Currently, `columnWidth` **always** uses `averageWidth`, which is the variable-length behavior. For fixed-length fields (dates, phone numbers, status codes), `maxWidth` would be more appropriate since all values have similar width and should get uniform columns.
+
+`Primitive.defaultWidth` exists as a field (line 25) but is **never set** — always 0. It participates as a floor at line 187 but has no effect. This is the paper's `ValueDefaultWidth` property, currently dead code.
+
+**Heuristic**: `isVariableLength = (averageWidth > 0 && maxWidth / averageWidth > THRESHOLD)` where threshold ≈ 2.0. When `averageWidth <= 0` (empty dataset), default to `isVariableLength = true` (safe fallback — preserves current behavior). When max/avg ratio is low (< 2.0), data is uniform-width → use `maxWidth` for the column. When high, data varies → use `averageWidth` (current behavior).
+
+**Threshold derivation**: A date field "2026-01-01" has max/avg ≈ 1.01 (all values same length). A name field "Li" vs "Bartholomew Cunningham" has max/avg ≈ 7. Status codes ("OK", "ERROR", "PENDING") have max/avg ≈ 1.5. A threshold of 2.0 correctly classifies dates and status codes as fixed-length, and names and descriptions as variable-length. The threshold is not a stylesheet property — the paper treats IsVariableLength as a computed attribute.
+
+**Note**: RDR-001 removed the never-assigned `PrimitiveLayout.variableLength` field as dead code. This `isVariableLength` is a replacement with actual computation and behavioral impact, not a regression.
+
+**Impact on justification**: `PrimitiveLayout.compress()` (line 116-118) unconditionally sets `justifiedWidth = Style.snap(available)`, stretching all primitives to fill available space. For fixed-length fields, this wastes space. When `isVariableLength=false`, `compress()` should cap at `maxWidth` instead of stretching.
+
+**Estimate**: ~20-25 LoC. Boolean field, zero-guard, heuristic in `measure()`, conditional `columnWidth`, `compress()` behavior change, threshold constant, `clear()` reset.
+
+**Status**: Verified against code. Both `maxWidth` and `averageWidth` are already computed; the missing logic is the branching between them.
+
+### Finding 2: Width Guards Are Independent, Straightforward Caps
+
+**Source**: `RelationLayout.measure()` lines 335-338, `ColumnSet.compress()` lines 54-60, `PrimitiveLayout.compress()` line 117, `PrimitiveLayout.calculateTableColumnWidth()` lines 82-84
+
+Four independent width guards, each a simple cap or floor at a well-defined code point:
+
+1. **OutlineMaxLabelWidth**: `RelationLayout.measure()` computes `labelWidth` as `max(child.calculateLabelWidth())` at lines 335-338. Currently unbounded — a 200-character field name consumes the entire column. Fix: cap with `Math.min(labelWidth, style.getOutlineMaxLabelWidth())`. New `RelationStyle` property with default 200px (~14 characters at 14px base font — sufficient for typical field labels like "shipping_address" while preventing "user_profile_extended_metadata_description" from dominating). **~8 LoC.**
+
+2. **OutlineColumnMinWidth**: `ColumnSet.compress()` computes column count at lines 54-60 as `floor(justified / maxColumnWidth)`. No minimum width guard — `fieldWidth` (line 64) can reach zero or negative when `labelWidth` exceeds `columnWidth`. Fix: add `style.getOutlineColumnMinWidth()` as a floor in the column count divisor. New `RelationStyle` property with default 60px (~4 characters at 14px — enough to display abbreviated values without being unreadable). **~8 LoC.**
+
+3. **OutlineMinValueWidth**: `PrimitiveLayout.compress()` sets `justifiedWidth = Style.snap(available)` with no floor. If available space is very small, values become unreadable. Fix: `justifiedWidth = Style.snap(Math.max(available, style.getMinValueWidth()))`. New `PrimitiveStyle` property with default 30px (~2 characters at 14px — prevents zero-width rendering while allowing tight layouts). **~10 LoC.**
+
+4. **TableMaxPrimitiveWidth**: `PrimitiveLayout.tableColumnWidth()` (line 224-226) and `calculateTableColumnWidth()` (line 82-84) both return `columnWidth()` with no cap. A single wide column can dominate the table. Fix: cap with `Math.min(columnWidth(), style.getMaxTablePrimitiveWidth())` applied in `tableColumnWidth()` and `calculateTableColumnWidth()` only — NOT in `columnWidth()`, which is also used by outline mode. New `PrimitiveStyle` property, default unbounded (Double.MAX_VALUE). **~10 LoC.**
+
+All guards are independent — any can be implemented without the others. CSS configurability deferred to coordinate with RDR-006's approach (Java API only initially, CSS via RDR-002 Phase 2 when CssMetaData infrastructure is designed).
+
+**Estimate**: ~36 LoC total production code. Each guard is 2-3 lines of logic + property declaration.
+
+**Status**: Verified against code. All insertion points confirmed.
+
+### Finding 3: Outline Bullets Require Rendering + Width Budget Changes
+
+**Source**: `OutlineElement.java` line 76, `OutlineColumn.java`, `RelationLayout.measure()` line 335
+
+The outline rendering hierarchy is: `Outline` → `OutlineCell` → `Span` → `OutlineColumn` → `OutlineElement` (label + content cell).
+
+`OutlineElement` (line 76) builds its children as `getChildren().addAll(label, cell.getNode())`. Bullet insertion point: prepend a bullet `Label` before the existing label+cell pair. The bullet Label would use a new CSS class `.outline-bullet` for styling.
+
+Indentation: `OutlineColumn` controls column layout. Adding left padding to the column applies indentation uniformly to all elements.
+
+**Width budget impact**: `RelationLayout.measure()` computes `labelWidth` at lines 335-338 as the max of child label widths. Bullet width must be added to this budget: `labelWidth += style.getBulletWidth()`. Without this, bullets consume space from the value area, causing text truncation.
+
+Three new `RelationStyle` properties needed:
+- `bulletText` (String, default `""` — no bullet) — glyph to render (e.g., `"•"`, `"◦"`, `"▪"`)
+- `bulletWidth` (double, default 0) — width reserved for bullet in layout budget
+- `indentWidth` (double, default 0) — left padding on `OutlineColumn`
+
+No new classes required. CSS: add `.outline-bullet` rule in `default.css`. The bullet `Label` is created only when `bulletText` is non-empty.
+
+**Estimate**: ~25 LoC production code. Bullet rendering in `OutlineElement`, width budget in `RelationLayout.measure()`, padding in `OutlineColumn`, 3 properties in `RelationStyle`.
+
+**Status**: Verified against code. Rendering hierarchy confirmed; insertion points identified.
+
+## Proposed Solution
+
+### Constructor Strategy
+
+RelationStyle currently has a 10-param constructor (9 UI params + `maxAverageCardinality` from RDR-006). Adding 5 more params (Phases 2+3) would create a 15-param constructor — fragile and error-prone for same-type double args. To manage this:
+
+- **Phase 1**: No style changes needed (IsVariableLength is data-driven, computed in `PrimitiveLayout.measure()`).
+- **Phase 2**: Add new properties as non-final fields with hardcoded defaults and setters on `RelationStyle` and `PrimitiveStyle`. This avoids constructor churn while maintaining backward compatibility. `PrimitiveStyle` properties (`minValueWidth`, `maxTablePrimitiveWidth`) are declared on the abstract class with defaults; `PrimitiveTextStyle`'s constructor is unchanged.
+- **Phase 3**: Same pattern — non-final fields with defaults on `RelationStyle`.
+
+This is a deliberate departure from RelationStyle's current immutable-via-constructor pattern. The alternative (builder or config record) would be cleaner but is premature for 5 properties that will likely move to CSS once `CssMetaData` infrastructure is designed.
+
+### Phase 1: IsVariableLength + ValueDefaultWidth (Core)
+
+Add `IsVariableLength` detection to `PrimitiveLayout.measure()`:
+
+```java
+// Guard empty data: default to variable-length (safe fallback)
+if (averageWidth > 0) {
+    isVariableLength = (maxWidth / averageWidth > VARIABLE_LENGTH_THRESHOLD);
+} else {
+    isVariableLength = true;
+}
+```
+
+When `IsVariableLength`:
+- `ValueDefaultWidth` = `averageWidth` (current behavior, but now explicit)
+- Column grows to fill available space during justification
+
+When NOT `IsVariableLength`:
+- `ValueDefaultWidth` = `maxWidth` (ensures all values fit without wrapping)
+
+**OutlineSnapValueWidth**: Deferred — blocked pending IsVariableLength validation. Snapping fixed-width columns to value-width multiples (e.g., 78px date field → 78, 156, 234px columns) is a natural companion to IsVariableLength but adds complexity to `Style.snap()` which currently has no per-field context. Will be addressed in a follow-up RDR after Phase 1 validates the IsVariableLength heuristic.
+
+### Phase 2: Width Guards
+
+- `OutlineMaxLabelWidth`: Cap `RelationLayout.labelWidth` at configurable max (default 200px)
+- `OutlineColumnMinWidth`: Enforce minimum in `ColumnSet.compress()` column count calculation (default 60px)
+- `OutlineMinValueWidth`: Enforce minimum in `PrimitiveLayout.compress()` (default 30px)
+- `TableMaxPrimitiveWidth`: Cap `PrimitiveLayout.tableColumnWidth()` and `calculateTableColumnWidth()` for table mode only — `columnWidth()` is NOT modified (default MAX_VALUE)
+
+CSS configurability deferred — Java API only initially (coordinate with RDR-006 precedent).
+
+### Phase 3: Outline Bullets
+
+- Add bullet glyph rendering to `OutlineElement` (configurable: disc, circle, square, none)
+- Add indentation width property to `RelationStyle`, consumed by `OutlineElement`/`OutlineColumn`
+
+## Implementation Plan
+
+### Phase 1: IsVariableLength + ValueDefaultWidth (~20-25 LoC + tests)
+1. Add `isVariableLength` boolean field and `VARIABLE_LENGTH_THRESHOLD = 2.0` constant to `PrimitiveLayout`
+2. Reset `isVariableLength` in `clear()` (default: `true` for safe fallback)
+3. Compute in `PrimitiveLayout.measure()` lines 179-188: guard `averageWidth > 0`, then `isVariableLength = (maxWidth / averageWidth > VARIABLE_LENGTH_THRESHOLD)` after existing max/avg computation
+4. Branch `columnWidth` assignment: if variable-length, use `averageWidth` (current); if fixed-length, use `maxWidth`
+5. Update `PrimitiveLayout.compress()` line 117: when `!isVariableLength`, cap `justifiedWidth` at `Math.min(available, maxWidth)` instead of stretching to `available`
+6. Add unit tests for both branches with mock data, including empty dataset edge case
+
+### Phase 2: Width Guards (~36 LoC + tests)
+7. Add non-final fields with setters: `outlineMaxLabelWidth` (default 200) and `outlineColumnMinWidth` (default 60) to `RelationStyle`
+8. Add non-final fields with setters: `minValueWidth` (default 30) and `maxTablePrimitiveWidth` (default MAX_VALUE) to `PrimitiveStyle` (abstract class — no constructor changes needed for `PrimitiveTextStyle`)
+9. Apply `outlineMaxLabelWidth` cap in `RelationLayout.measure()` after line 338: `labelWidth = Math.min(labelWidth, style.getOutlineMaxLabelWidth())`
+10. Apply `outlineColumnMinWidth` floor in `ColumnSet.compress()` line 56-60: add to column count divisor
+11. Apply `minValueWidth` floor in `PrimitiveLayout.compress()` line 117
+12. Apply `maxTablePrimitiveWidth` cap in `PrimitiveLayout.tableColumnWidth()` and `calculateTableColumnWidth()` only — NOT in `columnWidth()` which affects outline mode
+13. CSS configurability deferred — Java API only initially (coordinate with RDR-006 precedent)
+
+### Phase 3: Outline Bullets (~25 LoC + tests)
+14. Add non-final fields with setters: `bulletText` (String, default ""), `bulletWidth` (double, default 0), `indentWidth` (double, default 0) to `RelationStyle`
+15. In `OutlineElement` constructor (line 76): prepend bullet `Label` when `bulletText` is non-empty
+16. In `OutlineColumn`: apply `indentWidth` as left padding
+17. In `RelationLayout.measure()` after line 338: add `style.getBulletWidth()` to `labelWidth` budget
+18. Add `.outline-bullet` CSS class in `default.css`
+19. Add unit tests for bullet rendering and width budget impact
+
+## Test Plan
+
+### Phase 1: IsVariableLength + ValueDefaultWidth
+- **Scenario**: Uniform-width data (dates: "2026-01-01" to "2026-12-31") → **Verify**: `isVariableLength=false`, `columnWidth=maxWidth`
+- **Scenario**: Variable-width data (names: "Al" to "Alexander Hamilton") → **Verify**: `isVariableLength=true`, `columnWidth=averageWidth`
+- **Scenario**: Fixed-length field during compress → **Verify**: `justifiedWidth` capped at `maxWidth`, not stretched
+- **Scenario**: Variable-length field during compress → **Verify**: `justifiedWidth` stretches to available (current behavior)
+- **Scenario**: Empty dataset (data.size()==0) → **Verify**: `isVariableLength=true` (safe fallback, no division by zero)
+- **Scenario**: Single-row dataset → **Verify**: max==avg, ratio ≈ 1.0, classified as fixed-length
+
+### Phase 2: Width Guards
+- **Scenario**: 200-character field label → **Verify**: capped at `outlineMaxLabelWidth`
+- **Scenario**: Very narrow available width → **Verify**: column count limited by `outlineColumnMinWidth`
+- **Scenario**: Tiny compress available → **Verify**: `minValueWidth` floor prevents zero-width values
+- **Scenario**: Wide table column → **Verify**: `maxTablePrimitiveWidth` cap applied
+
+### Phase 3: Outline Bullets
+- **Scenario**: `bulletText="•"` → **Verify**: bullet Label prepended in OutlineElement
+- **Scenario**: `bulletText=""` (default) → **Verify**: no bullet rendered
+- **Scenario**: Bullet + indentation → **Verify**: `labelWidth` budget includes `bulletWidth`
+
+## References
+
+- Bakke 2013, Table 1 (stylesheet properties)
+- T3: `kramer-gap-analysis-stylesheet-properties`

--- a/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSet.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSet.java
@@ -51,13 +51,15 @@ public class ColumnSet {
     public double compress(int cardinality, double justified,
                            RelationStyle style, double labelWidth) {
         Column firstColumn = columns.get(0);
+        double minColumnWidth = Math.max(
+            firstColumn.maxWidth(labelWidth)
+                + style.getElementHorizontalInset()
+                + style.getColumnHorizontalInset(),
+            style.getOutlineColumnMinWidth());
         int count = min(firstColumn.getFields()
                                    .size(),
                         max(1,
-                            (int) Math.floor(justified
-                                             / (firstColumn.maxWidth(labelWidth)
-                                                + style.getElementHorizontalInset()
-                                                + style.getColumnHorizontalInset()))));
+                            (int) Math.floor(justified / minColumnWidth)));
 
         // compression
         double columnWidth = Math.floor(justified / (double) count);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -42,7 +42,10 @@ import javafx.scene.layout.Region;
  *
  */
 public final class PrimitiveLayout extends SchemaNodeLayout {
+    static final double            VARIABLE_LENGTH_THRESHOLD = 2.0;
+
     protected int                  averageCardinality;
+    private boolean                isVariableLength          = true;
     protected double               maxWidth;
     protected final PrimitiveStyle style;
     private double                 cellHeight;
@@ -80,7 +83,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     @Override
     public double calculateTableColumnWidth() {
-        return columnWidth();
+        return Math.min(columnWidth(), style.getMaxTablePrimitiveWidth());
     }
 
     @Override
@@ -114,7 +117,13 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     @Override
     public void compress(double available) {
-        justifiedWidth = Style.snap(available);
+        double floor = style.getMinValueWidth();
+        double effective = Math.max(available, floor);
+        if (!isVariableLength && maxWidth > 0) {
+            justifiedWidth = Style.snap(Math.min(effective, maxWidth));
+        } else {
+            justifiedWidth = Style.snap(effective);
+        }
     }
 
     @Override
@@ -183,9 +192,17 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             averageWidth = summedDataWidth / data.size();
         }
 
+        // Paper §Table 1: IsVariableLength determines width strategy
+        if (averageWidth > 0) {
+            isVariableLength = (maxWidth / averageWidth > VARIABLE_LENGTH_THRESHOLD);
+        } else {
+            isVariableLength = true; // safe fallback for empty data
+        }
+
+        double effectiveWidth = isVariableLength ? averageWidth : maxWidth;
         columnWidth = Math.max(labelWidth,
                                Style.snap(Math.max(getNode().getDefaultWidth(),
-                                                   averageWidth)));
+                                                   effectiveWidth)));
         return columnWidth;
     }
 
@@ -222,7 +239,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     @Override
     public double tableColumnWidth() {
-        return columnWidth();
+        return Math.min(columnWidth(), style.getMaxTablePrimitiveWidth());
     }
 
     @Override
@@ -232,9 +249,21 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
                              justifiedWidth);
     }
 
+    public boolean isVariableLength() {
+        return isVariableLength;
+    }
+
     @Override
     protected void calculateRootHeight() {
         cellHeight(averageCardinality, justifiedWidth);
+    }
+
+    @Override
+    protected void clear() {
+        super.clear();
+        // isVariableLength must NOT be reset here — it is set in measure()
+        // and must survive through layout() into compress() in the
+        // autoLayout pipeline: measure → layout → compress.
     }
 
     protected double width(JsonNode row) {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -336,6 +336,10 @@ public final class RelationLayout extends SchemaNodeLayout {
                              .mapToDouble(child -> child.calculateLabelWidth())
                              .max()
                              .orElse(0.0);
+        // Paper Table 1: OutlineMaxLabelWidth cap
+        labelWidth = Math.min(labelWidth, style.getOutlineMaxLabelWidth());
+        // Paper Table 1: Bullet width budget
+        labelWidth += style.getBulletWidth();
         columnWidth = Style.snap(labelWidth + columnWidth);
         return columnWidth + style.getElementHorizontalInset()
                + style.getColumnHorizontalInset()

--- a/kramer/src/main/java/com/chiralbehaviors/layout/outline/OutlineColumn.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/outline/OutlineColumn.java
@@ -21,6 +21,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
+import javafx.geometry.Insets;
+
 import com.chiralbehaviors.layout.Column;
 import com.chiralbehaviors.layout.cell.Hit;
 import com.chiralbehaviors.layout.cell.LayoutContainer;
@@ -68,6 +70,10 @@ public class OutlineColumn extends VerticalCell<OutlineColumn>
              fields.add(item -> cell.updateItem(f.extractFrom(item)));
              getChildren().add(cell.getNode());
          });
+        double indent = style.getIndentWidth();
+        if (indent > 0) {
+            setPadding(new Insets(0, 0, 0, indent));
+        }
         setMinWidth(c.getWidth());
         setPrefWidth(c.getWidth());
         setMaxWidth(c.getWidth());

--- a/kramer/src/main/java/com/chiralbehaviors/layout/outline/OutlineElement.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/outline/OutlineElement.java
@@ -73,7 +73,17 @@ public class OutlineElement extends HorizontalCell<OutlineElement>
         cell.getNode()
             .setMaxHeight(elementHeight);
         Label label = layout.label(labelWidth, elementHeight);
-        getChildren().addAll(label, cell.getNode());
+        String bulletText = style.getBulletText();
+        if (!bulletText.isEmpty() && style.getBulletWidth() > 0) {
+            Label bullet = new Label(bulletText);
+            bullet.getStyleClass().add("outline-bullet");
+            bullet.setMinSize(style.getBulletWidth(), elementHeight);
+            bullet.setPrefSize(style.getBulletWidth(), elementHeight);
+            bullet.setMaxSize(style.getBulletWidth(), elementHeight);
+            getChildren().addAll(bullet, label, cell.getNode());
+        } else {
+            getChildren().addAll(label, cell.getNode());
+        }
 
     }
 

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
@@ -181,6 +181,8 @@ abstract public class PrimitiveStyle extends NodeStyle {
     }
 
     private final Insets listInsets;
+    private double      minValueWidth          = 30;
+    private double      maxTablePrimitiveWidth = Double.MAX_VALUE;
 
     public PrimitiveStyle(LabelStyle labelStyle, Insets listInsets) {
         super(labelStyle);
@@ -194,6 +196,22 @@ abstract public class PrimitiveStyle extends NodeStyle {
 
     public double getListVerticalInset() {
         return listInsets.getTop() + listInsets.getBottom();
+    }
+
+    public double getMinValueWidth() {
+        return minValueWidth;
+    }
+
+    public void setMinValueWidth(double minValueWidth) {
+        this.minValueWidth = minValueWidth;
+    }
+
+    public double getMaxTablePrimitiveWidth() {
+        return maxTablePrimitiveWidth;
+    }
+
+    public void setMaxTablePrimitiveWidth(double maxTablePrimitiveWidth) {
+        this.maxTablePrimitiveWidth = maxTablePrimitiveWidth;
     }
 
     abstract public double width(JsonNode row);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/RelationStyle.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/RelationStyle.java
@@ -33,18 +33,25 @@ import javafx.geometry.Insets;
  */
 public class RelationStyle extends NodeStyle {
 
-    private static final int DEFAULT_MAX_AVERAGE_CARDINALITY = 10;
+    private static final int    DEFAULT_MAX_AVERAGE_CARDINALITY = 10;
+    private static final double DEFAULT_OUTLINE_MAX_LABEL_WIDTH = 200;
+    private static final double DEFAULT_OUTLINE_COLUMN_MIN_WIDTH = 60;
 
-    private final Insets column;
-    private final Insets element;
-    private final int    maxAverageCardinality;
-    private final Insets nestedInsets;
-    private final Insets outline;
-    private final Insets outlineCell;
-    private final Insets row;
-    private final Insets rowCell;
-    private final Insets span;
-    private final Insets table;
+    private final Insets  column;
+    private final Insets  element;
+    private final int     maxAverageCardinality;
+    private final Insets  nestedInsets;
+    private final Insets  outline;
+    private final Insets  outlineCell;
+    private double        outlineMaxLabelWidth  = DEFAULT_OUTLINE_MAX_LABEL_WIDTH;
+    private double        outlineColumnMinWidth = DEFAULT_OUTLINE_COLUMN_MIN_WIDTH;
+    private String        bulletText            = "";
+    private double        bulletWidth           = 0;
+    private double        indentWidth           = 0;
+    private final Insets  row;
+    private final Insets  rowCell;
+    private final Insets  span;
+    private final Insets  table;
 
     public RelationStyle(LabelStyle labelStyle, NestedTable table,
                          NestedRow row, NestedCell rowCell, Outline outline,
@@ -154,6 +161,46 @@ public class RelationStyle extends NodeStyle {
 
     public double getTableVerticalInset() {
         return table.getTop() + table.getBottom();
+    }
+
+    public double getOutlineMaxLabelWidth() {
+        return outlineMaxLabelWidth;
+    }
+
+    public void setOutlineMaxLabelWidth(double outlineMaxLabelWidth) {
+        this.outlineMaxLabelWidth = outlineMaxLabelWidth;
+    }
+
+    public double getOutlineColumnMinWidth() {
+        return outlineColumnMinWidth;
+    }
+
+    public void setOutlineColumnMinWidth(double outlineColumnMinWidth) {
+        this.outlineColumnMinWidth = outlineColumnMinWidth;
+    }
+
+    public String getBulletText() {
+        return bulletText;
+    }
+
+    public void setBulletText(String bulletText) {
+        this.bulletText = bulletText;
+    }
+
+    public double getBulletWidth() {
+        return bulletWidth;
+    }
+
+    public void setBulletWidth(double bulletWidth) {
+        this.bulletWidth = bulletWidth;
+    }
+
+    public double getIndentWidth() {
+        return indentWidth;
+    }
+
+    public void setIndentWidth(double indentWidth) {
+        this.indentWidth = indentWidth;
     }
 
 }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutCompressTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutCompressTest.java
@@ -48,6 +48,11 @@ class RelationLayoutCompressTest {
         when(style.getNestedHorizontalInset()).thenReturn(0.0);
         when(style.getNestedInsets()).thenReturn(new Insets(0));
         when(style.getTableVerticalInset()).thenReturn(0.0);
+        when(style.getOutlineMaxLabelWidth()).thenReturn(200.0);
+        when(style.getOutlineColumnMinWidth()).thenReturn(60.0);
+        when(style.getBulletText()).thenReturn("");
+        when(style.getBulletWidth()).thenReturn(0.0);
+        when(style.getIndentWidth()).thenReturn(0.0);
         return style;
     }
 
@@ -60,6 +65,8 @@ class RelationLayoutCompressTest {
         when(primStyle.getLabelStyle()).thenReturn(labelStyle);
         when(primStyle.getHeight(anyDouble(), anyDouble())).thenReturn(20.0);
         when(primStyle.getListVerticalInset()).thenReturn(0.0);
+        when(primStyle.getMinValueWidth()).thenReturn(30.0);
+        when(primStyle.getMaxTablePrimitiveWidth()).thenReturn(Double.MAX_VALUE);
 
         PrimitiveLayout layout = new PrimitiveLayout(new Primitive(name), primStyle);
         layout.columnWidth = width;

--- a/kramer/src/test/java/com/chiralbehaviors/layout/StylesheetPropertyTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/StylesheetPropertyTest.java
@@ -1,0 +1,530 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import javafx.geometry.Insets;
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.LabelStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for RDR-002: Stylesheet Property System Completion
+ * - Phase 1: IsVariableLength + ValueDefaultWidth
+ * - Phase 2: Width Guards (OutlineMaxLabelWidth, OutlineColumnMinWidth,
+ *            OutlineMinValueWidth, TableMaxPrimitiveWidth)
+ * - Phase 3: Outline bullets (width budget)
+ */
+class StylesheetPropertyTest {
+
+    private static RelationStyle mockRelationStyle() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        RelationStyle style = mock(RelationStyle.class);
+        when(style.getLabelStyle()).thenReturn(labelStyle);
+        when(style.getOutlineHorizontalInset()).thenReturn(0.0);
+        when(style.getOutlineCellHorizontalInset()).thenReturn(0.0);
+        when(style.getSpanHorizontalInset()).thenReturn(0.0);
+        when(style.getColumnHorizontalInset()).thenReturn(0.0);
+        when(style.getElementHorizontalInset()).thenReturn(0.0);
+        when(style.getMaxAverageCardinality()).thenReturn(10);
+        when(style.getSpanVerticalInset()).thenReturn(0.0);
+        when(style.getColumnVerticalInset()).thenReturn(0.0);
+        when(style.getRowVerticalInset()).thenReturn(0.0);
+        when(style.getRowCellVerticalInset()).thenReturn(0.0);
+        when(style.getRowCellHorizontalInset()).thenReturn(0.0);
+        when(style.getRowHorizontalInset()).thenReturn(0.0);
+        when(style.getOutlineCellVerticalInset()).thenReturn(0.0);
+        when(style.getOutlineVerticalInset()).thenReturn(0.0);
+        when(style.getElementVerticalInset()).thenReturn(0.0);
+        when(style.getNestedHorizontalInset()).thenReturn(0.0);
+        when(style.getNestedInsets()).thenReturn(new Insets(0));
+        when(style.getTableVerticalInset()).thenReturn(0.0);
+        when(style.getOutlineMaxLabelWidth()).thenReturn(200.0);
+        when(style.getOutlineColumnMinWidth()).thenReturn(60.0);
+        when(style.getBulletText()).thenReturn("");
+        when(style.getBulletWidth()).thenReturn(0.0);
+        when(style.getIndentWidth()).thenReturn(0.0);
+        return style;
+    }
+
+    private static PrimitiveStyle mockPrimitiveStyle(double charWidth) {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        PrimitiveStyle primStyle = mock(PrimitiveStyle.class);
+        when(primStyle.getLabelStyle()).thenReturn(labelStyle);
+        when(primStyle.getHeight(anyDouble(), anyDouble())).thenReturn(20.0);
+        when(primStyle.getListVerticalInset()).thenReturn(0.0);
+        when(primStyle.getMinValueWidth()).thenReturn(30.0);
+        when(primStyle.getMaxTablePrimitiveWidth()).thenReturn(Double.MAX_VALUE);
+        // width(JsonNode) returns charWidth * text length
+        when(primStyle.width(any(JsonNode.class))).thenAnswer(inv -> {
+            JsonNode node = inv.getArgument(0);
+            String text = node.isTextual() ? node.textValue() : node.toString();
+            return charWidth * text.length();
+        });
+        return primStyle;
+    }
+
+    private static PrimitiveLayout makePrimitive(String name, double width) {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        PrimitiveStyle primStyle = mock(PrimitiveStyle.class);
+        when(primStyle.getLabelStyle()).thenReturn(labelStyle);
+        when(primStyle.getHeight(anyDouble(), anyDouble())).thenReturn(20.0);
+        when(primStyle.getListVerticalInset()).thenReturn(0.0);
+        when(primStyle.getMinValueWidth()).thenReturn(30.0);
+        when(primStyle.getMaxTablePrimitiveWidth()).thenReturn(Double.MAX_VALUE);
+
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive(name), primStyle);
+        layout.columnWidth = width;
+        layout.labelWidth = 0;
+        return layout;
+    }
+
+    // ---- Phase 1: IsVariableLength ----
+
+    /**
+     * Uniform-width data (dates) should be classified as fixed-length.
+     * max/avg ratio ≈ 1.0 < 2.0 threshold → isVariableLength=false
+     * columnWidth should use maxWidth (not averageWidth).
+     */
+    @Test
+    void uniformWidthDataClassifiedAsFixedLength() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0); // 7px per char
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("date"), style);
+
+        // All dates have same length (10 chars) → all same width (70px)
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("2026-01-01");
+        data.add("2026-06-15");
+        data.add("2026-12-31");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertFalse(layout.isVariableLength(),
+                    "Uniform-width data should be classified as fixed-length");
+        // columnWidth should be max(labelWidth, snap(max(defaultWidth, maxWidth)))
+        // maxWidth = 70, labelWidth = snap(10) = 10
+        assertTrue(layout.columnWidth >= 70,
+                   "Fixed-length columnWidth should use maxWidth (70)");
+    }
+
+    /**
+     * Variable-width data (names) should be classified as variable-length.
+     * max/avg ratio >> 2.0 → isVariableLength=true
+     * columnWidth should use averageWidth.
+     */
+    @Test
+    void variableWidthDataClassifiedAsVariableLength() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0); // 7px per char
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("name"), style);
+
+        // "Al" (2 chars, 14px), "Alexander Hamilton" (18 chars, 126px)
+        // max=126, avg=70, ratio=1.8... hmm that's < 2.0
+        // Let's use more extreme: "Al" (14px), "Alexander Bartholomew Cunningham" (32 chars, 224px)
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("Al");
+        data.add("Alexander Bartholomew Cunningham");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        // max=224, avg=(14+224)/2=119, ratio=224/119≈1.88 — still < 2.0
+        // Need more extreme: "A" + very long name
+        // Actually, let's just check with a wider spread
+        ArrayNode data2 = JsonNodeFactory.instance.arrayNode();
+        data2.add("A");           // 1 char, 7px
+        data2.add("Very Long Name With Many Characters"); // 35 chars, 245px
+
+        layout.measure(data2, n -> n, model);
+
+        // max=245, avg=(7+245)/2=126, ratio=245/126≈1.94... borderline
+        // Let me adjust to clearly cross threshold
+        ArrayNode data3 = JsonNodeFactory.instance.arrayNode();
+        data3.add("A");           // 1 char, 7px
+        data3.add("A");           // 1 char, 7px
+        data3.add("Very Long Name With Many Many Characters Here"); // 46 chars, 322px
+
+        layout.measure(data3, n -> n, model);
+
+        // max=322, avg=(7+7+322)/3=112, ratio=322/112≈2.88 > 2.0
+        assertTrue(layout.isVariableLength(),
+                   "Variable-width data should be classified as variable-length");
+    }
+
+    /**
+     * Empty dataset should default to isVariableLength=true (safe fallback).
+     * No division by zero.
+     */
+    @Test
+    void emptyDatasetDefaultsToVariableLength() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("empty"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode(); // empty
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertTrue(layout.isVariableLength(),
+                   "Empty dataset should default to variable-length (safe fallback)");
+    }
+
+    /**
+     * Single-row dataset: max==avg, ratio=1.0 → fixed-length.
+     */
+    @Test
+    void singleRowDatasetClassifiedAsFixedLength() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("single"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("hello");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertFalse(layout.isVariableLength(),
+                    "Single-row dataset should be fixed-length (max==avg, ratio=1.0)");
+    }
+
+    /**
+     * Fixed-length field during compress: justifiedWidth capped at maxWidth.
+     */
+    @Test
+    void fixedLengthCompressCapsAtMaxWidth() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("date"), style);
+
+        // All same width → fixed length
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("2026-01-01");
+        data.add("2026-06-15");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertFalse(layout.isVariableLength());
+        double maxW = layout.maxWidth; // should be 70
+
+        // Compress with much larger available width
+        layout.compress(500);
+
+        // justifiedWidth should be capped at maxWidth, not stretched to 500
+        assertTrue(layout.getJustifiedWidth() <= Style.snap(maxW),
+                   "Fixed-length compress should cap at maxWidth, not stretch to available");
+    }
+
+    /**
+     * Variable-length field during compress: stretches to available width.
+     */
+    @Test
+    void variableLengthCompressStretchesToAvailable() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("name"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("A");
+        data.add("A");
+        data.add("Very Long Name With Many Many Characters Here");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertTrue(layout.isVariableLength());
+
+        layout.compress(500);
+
+        assertEquals(Style.snap(500), layout.getJustifiedWidth(),
+                     "Variable-length compress should stretch to available");
+    }
+
+    /**
+     * Critical lifecycle test: isVariableLength must survive through the
+     * full measure() → layout() → compress() pipeline. layout() calls
+     * clear(), which previously reset isVariableLength to true — making
+     * the fixed-length cap dead code in production.
+     */
+    @Test
+    void fixedLengthSurvivesMeasureLayoutCompress() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("date"), style);
+
+        // All same width → fixed length (ratio = 1.0 < 2.0)
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("2026-01-01"); // 10 chars, 70px
+        data.add("2026-06-15"); // 10 chars, 70px
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+        assertFalse(layout.isVariableLength(), "Should be fixed-length after measure");
+
+        // layout() calls clear() internally
+        layout.layout(500);
+
+        // isVariableLength must survive the clear() in layout()
+        assertFalse(layout.isVariableLength(),
+                    "isVariableLength must survive layout()/clear()");
+
+        // compress() should still cap at maxWidth, not stretch to 500
+        layout.compress(500);
+        assertTrue(layout.getJustifiedWidth() <= Style.snap(70),
+                   "Fixed-length cap must survive full measure→layout→compress pipeline");
+    }
+
+    // ---- Phase 2: Width Guards ----
+
+    /**
+     * OutlineMaxLabelWidth: capped labelWidth allows children to share
+     * column sets; uncapped labelWidth forces separation.
+     */
+    @Test
+    void outlineMaxLabelWidthCapsLongLabels() {
+        RelationStyle style = mockRelationStyle();
+        when(style.getOutlineMaxLabelWidth()).thenReturn(50.0);
+
+        Relation parent = new Relation("parent");
+        parent.addChild(new Primitive("name"));
+        parent.addChild(new Primitive("email"));
+        RelationLayout layout = new RelationLayout(parent, style);
+
+        PrimitiveLayout prim1 = makePrimitive("name", 30);
+        PrimitiveLayout prim2 = makePrimitive("email", 30);
+        layout.children.clear();
+        layout.children.add(prim1);
+        layout.children.add(prim2);
+        layout.averageChildCardinality = 1;
+
+        // With capped labelWidth (50): childWidth = 50 + 30 = 80 < halfWidth(250)
+        layout.labelWidth = 50;
+        layout.compress(500);
+        assertEquals(1, layout.columnSets.size(),
+                     "Capped labelWidth (50) should allow children to share column set");
+
+        // Without cap: labelWidth=300, childWidth = 300 + 30 = 330 > halfWidth(250)
+        layout.labelWidth = 300;
+        layout.compress(500);
+        assertEquals(2, layout.columnSets.size(),
+                     "Uncapped labelWidth (300) forces separate column sets, proving cap is needed");
+    }
+
+    /**
+     * OutlineMinValueWidth: compress with tiny available should floor at minValueWidth.
+     */
+    @Test
+    void outlineMinValueWidthPreventsZeroWidth() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0);
+        when(style.getMinValueWidth()).thenReturn(30.0);
+
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("field"), style);
+        layout.columnWidth = 50;
+        layout.labelWidth = 0;
+
+        // Compress with very small available
+        layout.compress(5);
+
+        assertTrue(layout.getJustifiedWidth() >= Style.snap(30.0),
+                   "MinValueWidth should prevent width from going below 30px");
+    }
+
+    /**
+     * TableMaxPrimitiveWidth: cap should apply to tableColumnWidth() and
+     * calculateTableColumnWidth() but not columnWidth().
+     */
+    @Test
+    void tableMaxPrimitiveWidthCapsTableMethods() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0);
+        when(style.getMaxTablePrimitiveWidth()).thenReturn(100.0);
+
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("desc"), style);
+        layout.columnWidth = 200;
+        layout.labelWidth = 0;
+
+        // columnWidth() should NOT be capped (used by outline mode)
+        assertEquals(200, layout.columnWidth(),
+                     "columnWidth() should not be affected by table cap");
+
+        // tableColumnWidth() should be capped
+        assertEquals(100, layout.tableColumnWidth(),
+                     "tableColumnWidth() should be capped at 100");
+
+        // calculateTableColumnWidth() should also be capped
+        assertEquals(100, layout.calculateTableColumnWidth(),
+                     "calculateTableColumnWidth() should be capped at 100");
+    }
+
+    /**
+     * TableMaxPrimitiveWidth default (MAX_VALUE): no cap applied.
+     */
+    @Test
+    void tableMaxPrimitiveWidthDefaultNoCap() {
+        PrimitiveStyle style = mockPrimitiveStyle(7.0);
+        // default is MAX_VALUE — should not cap
+        when(style.getMaxTablePrimitiveWidth()).thenReturn(Double.MAX_VALUE);
+
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("desc"), style);
+        layout.columnWidth = 200;
+        layout.labelWidth = 0;
+
+        assertEquals(200, layout.tableColumnWidth(),
+                     "Default MAX_VALUE should not cap table column width");
+    }
+
+    // ---- Phase 3: Bullet Width Budget ----
+
+    /**
+     * Bullet width added to labelWidth changes column grouping in
+     * tight-width scenarios. With bulletWidth=15, labelWidth becomes 55
+     * instead of 40, pushing childWidth past halfWidth.
+     */
+    @Test
+    void bulletWidthAddedToLabelBudget() {
+        RelationStyle style = mockRelationStyle();
+        when(style.getBulletWidth()).thenReturn(15.0);
+
+        Relation parent = new Relation("parent");
+        parent.addChild(new Primitive("name"));
+        parent.addChild(new Primitive("email"));
+        RelationLayout layout = new RelationLayout(parent, style);
+
+        PrimitiveLayout prim1 = makePrimitive("name", 80);
+        PrimitiveLayout prim2 = makePrimitive("email", 80);
+        layout.children.clear();
+        layout.children.add(prim1);
+        layout.children.add(prim2);
+        layout.averageChildCardinality = 1;
+
+        // Without bullet: labelWidth=40, childWidth = 40+80 = 120 < halfWidth(125)
+        layout.labelWidth = 40;
+        layout.compress(250);
+        assertEquals(1, layout.columnSets.size(),
+                     "Without bullet addition, children should share column set");
+
+        // With bullet: labelWidth = 40+15 = 55, childWidth = 55+80 = 135 > halfWidth(125)
+        layout.labelWidth = 55;
+        layout.compress(250);
+        assertEquals(2, layout.columnSets.size(),
+                     "Bullet-augmented labelWidth should force separate column sets");
+    }
+
+    /**
+     * No bullet (default): bulletWidth=0 does not widen labelWidth.
+     */
+    @Test
+    void noBulletDoesNotAffectLayout() {
+        RelationStyle style = mockRelationStyle();
+        when(style.getBulletWidth()).thenReturn(0.0);
+
+        Relation parent = new Relation("parent");
+        parent.addChild(new Primitive("name"));
+        parent.addChild(new Primitive("email"));
+        RelationLayout layout = new RelationLayout(parent, style);
+
+        PrimitiveLayout prim1 = makePrimitive("name", 80);
+        PrimitiveLayout prim2 = makePrimitive("email", 80);
+        layout.children.clear();
+        layout.children.add(prim1);
+        layout.children.add(prim2);
+        layout.averageChildCardinality = 1;
+
+        // labelWidth = 40 + 0 (no bullet) = 40, childWidth = 40+80 = 120 < halfWidth(125)
+        layout.labelWidth = 40;
+        layout.compress(250);
+        assertEquals(1, layout.columnSets.size(),
+                     "Without bullet, children should share one column set");
+    }
+
+    // ---- RelationStyle property defaults ----
+
+    @Test
+    void relationStyleDefaultValues() {
+        RelationStyle style = new RelationStyle(
+            mock(LabelStyle.class),
+            mock(com.chiralbehaviors.layout.table.NestedTable.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.table.NestedRow.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.table.NestedCell.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.Outline.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.OutlineCell.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.OutlineColumn.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.Span.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.OutlineElement.class, RETURNS_DEEP_STUBS)
+        );
+
+        assertEquals(200.0, style.getOutlineMaxLabelWidth());
+        assertEquals(60.0, style.getOutlineColumnMinWidth());
+        assertEquals("", style.getBulletText());
+        assertEquals(0.0, style.getBulletWidth());
+        assertEquals(0.0, style.getIndentWidth());
+    }
+
+    @Test
+    void relationStyleSettersWork() {
+        RelationStyle style = new RelationStyle(
+            mock(LabelStyle.class),
+            mock(com.chiralbehaviors.layout.table.NestedTable.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.table.NestedRow.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.table.NestedCell.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.Outline.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.OutlineCell.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.OutlineColumn.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.Span.class, RETURNS_DEEP_STUBS),
+            mock(com.chiralbehaviors.layout.outline.OutlineElement.class, RETURNS_DEEP_STUBS)
+        );
+
+        style.setOutlineMaxLabelWidth(100);
+        style.setOutlineColumnMinWidth(80);
+        style.setBulletText("•");
+        style.setBulletWidth(12);
+        style.setIndentWidth(20);
+
+        assertEquals(100.0, style.getOutlineMaxLabelWidth());
+        assertEquals(80.0, style.getOutlineColumnMinWidth());
+        assertEquals("•", style.getBulletText());
+        assertEquals(12.0, style.getBulletWidth());
+        assertEquals(20.0, style.getIndentWidth());
+    }
+
+    // ---- PrimitiveStyle property defaults ----
+
+    @Test
+    void primitiveStyleDefaultValues() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        // Use concrete subclass PrimitiveTextStyle
+        PrimitiveStyle.PrimitiveTextStyle style =
+            new PrimitiveStyle.PrimitiveTextStyle(labelStyle, new Insets(0), labelStyle);
+
+        assertEquals(30.0, style.getMinValueWidth());
+        assertEquals(Double.MAX_VALUE, style.getMaxTablePrimitiveWidth());
+    }
+
+    @Test
+    void primitiveStyleSettersWork() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        PrimitiveStyle.PrimitiveTextStyle style =
+            new PrimitiveStyle.PrimitiveTextStyle(labelStyle, new Insets(0), labelStyle);
+
+        style.setMinValueWidth(50);
+        style.setMaxTablePrimitiveWidth(200);
+
+        assertEquals(50.0, style.getMinValueWidth());
+        assertEquals(200.0, style.getMaxTablePrimitiveWidth());
+    }
+}


### PR DESCRIPTION
## Summary
- **Phase 1**: IsVariableLength heuristic (max/avg > 2.0 threshold) with fixed-length compress cap and division-by-zero guard. Critical lifecycle bug fixed: `isVariableLength` no longer reset by `clear()` in the measure→layout→compress pipeline.
- **Phase 2**: Width guards — `minValueWidth` floor, `maxTablePrimitiveWidth` cap, `outlineMaxLabelWidth` cap, `outlineColumnMinWidth` minimum — applied at their respective layout code points.
- **Phase 3**: Outline bullet support — `bulletText`, `bulletWidth`, `indentWidth` on RelationStyle with rendering in OutlineElement and padding in OutlineColumn; bullet width added to label budget in RelationLayout.measure().

## Test plan
- [x] 17 new tests in StylesheetPropertyTest covering all 3 phases
- [x] Lifecycle test validates `isVariableLength` survives full measure→layout→compress pipeline
- [x] 9 existing RelationLayoutCompressTest updated with new style method stubs
- [x] Full `mvn clean install` passes (26 tests, 0 failures)
- [x] Code review remediated: clear() fix, bullet guard, field visibility, import cleanup