### PR TITLE
Fix vertical scrolling and add TestFX headless tests

### DIFF
--- a/kramer/pom.xml
+++ b/kramer/pom.xml
@@ -40,6 +40,45 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testfx</groupId>
+            <artifactId>testfx-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testfx</groupId>
+            <artifactId>testfx-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testfx</groupId>
+            <artifactId>openjfx-monocle</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>
+                        --add-opens javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
+                        --add-opens javafx.graphics/com.sun.glass.ui=ALL-UNNAMED
+                        --add-opens javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED
+                        --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
+                        -Djava.awt.headless=true
+                        -Dtestfx.robot=glass
+                        -Dtestfx.headless=true
+                        -Dprism.order=sw
+                        -Dprism.text=t2k
+                        -Dglass.platform=Monocle
+                        -Dmonocle.platform=Headless
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -194,7 +194,7 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         // Clear old keyboard bindings before rebuilding the control tree;
         // new VirtualFlows will re-register via bindKeyboard in their constructors.
         controller.unbind();
-        control = layout.autoLayout(width, controller, model);
+        control = layout.autoLayout(width, getHeight(), controller, model);
         Region node = control.getNode();
 
         setTopAnchor(node, 0d);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -98,8 +98,29 @@ public final class RelationLayout extends SchemaNodeLayout {
     }
 
     public double baseRowCellHeight(double extended) {
-        return Style.snap(extended - style.getRowCellVerticalInset()
-                          - style.getRowVerticalInset());
+        return Style.snap(extended - style.getRowCellVerticalInset());
+    }
+
+    private static final double HEIGHT_DISTRIBUTION_CAP = 0.5;
+
+    @Override
+    protected void distributeExtraHeight(double availableHeight) {
+        if (!useTable || availableHeight <= 0 || height <= 0
+            || availableHeight <= height || resolvedCardinality <= 0) {
+            return;
+        }
+        double deficit = availableHeight - height;
+        double perRow = deficit / resolvedCardinality;
+        // Soft cap: don't let any row grow more than 50% beyond its
+        // computed height, preventing a single line swimming in space.
+        double maxExtra = cellHeight * HEIGHT_DISTRIBUTION_CAP;
+        if (perRow > maxExtra) {
+            perRow = maxExtra;
+            deficit = perRow * resolvedCardinality;
+        }
+        if (deficit >= 1.0) {
+            adjustHeight(deficit);
+        }
     }
 
     @Override

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
@@ -153,15 +153,31 @@ public abstract sealed class SchemaNodeLayout permits PrimitiveLayout, RelationL
     public LayoutCell<? extends Region> autoLayout(double width,
                                                    FocusTraversal<?> parentTraversal,
                                                    Style model) {
+        return autoLayout(width, 0, parentTraversal, model);
+    }
+
+    public LayoutCell<? extends Region> autoLayout(double width,
+                                                   double availableHeight,
+                                                   FocusTraversal<?> parentTraversal,
+                                                   Style model) {
         double justified = Style.snap(width);
         layout(justified);
         compress(justified);
         calculateRootHeight();
+        distributeExtraHeight(availableHeight);
         rootLevel = true;
         LayoutCell<? extends Region> control = buildControl(parentTraversal,
                                                              model);
         rootLevel = false;
         return control;
+    }
+
+    /**
+     * Distribute extra viewport height among rows. Applies a soft cap
+     * so individual rows don't grow excessively for aberrant inputs.
+     */
+    protected void distributeExtraHeight(double availableHeight) {
+        // default: no distribution for primitives or when height unavailable
     }
 
     abstract public LayoutCell<? extends Region> buildColumn(double rendered,

--- a/kramer/src/main/java/com/chiralbehaviors/layout/flowless/ScrollHandler.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/flowless/ScrollHandler.java
@@ -25,6 +25,7 @@ import static org.fxmisc.wellbehaved.event.template.InputMapTemplate.unless;
 
 import org.fxmisc.wellbehaved.event.template.InputMapTemplate;
 
+import javafx.event.EventHandler;
 import javafx.scene.input.InputEvent;
 import javafx.scene.input.ScrollEvent;
 
@@ -36,10 +37,7 @@ public class ScrollHandler {
     private static final InputMapTemplate<ScrollHandler, InputEvent> DEFAULT_INPUT_MAP;
     static {
         DEFAULT_INPUT_MAP = unless(h -> h.isDisabled(),
-                                   sequence(consume(ScrollEvent.SCROLL,
-                                                    (handler,
-                                                     evt) -> handler.scroll(evt)),
-                                            consume(keyPressed(PAGE_UP),
+                                   sequence(consume(keyPressed(PAGE_UP),
                                                     (handler,
                                                      evt) -> handler.scrollUp()),
                                             consume(keyPressed(PAGE_DOWN),
@@ -47,12 +45,14 @@ public class ScrollHandler {
                                                      evt) -> handler.scrollDown())));
     }
 
-    private VirtualFlow<?>  flow;
-    private Runnable        afterPageScroll;
+    private VirtualFlow<?>                    flow;
+    private Runnable                          afterPageScroll;
+    private final EventHandler<ScrollEvent>   scrollEventHandler;
 
     public ScrollHandler(VirtualFlow<?> flow) {
         assert flow != null;
         this.flow = flow;
+        scrollEventHandler = this::handleScroll;
         bind();
     }
 
@@ -62,6 +62,17 @@ public class ScrollHandler {
 
     public void bind() {
         InputMapTemplate.installOverride(DEFAULT_INPUT_MAP, this, c -> flow);
+        flow.addEventHandler(ScrollEvent.SCROLL, scrollEventHandler);
+    }
+
+    private void handleScroll(ScrollEvent evt) {
+        if (flow.isDisabled()) {
+            return;
+        }
+        if (flow.canScrollVertically()) {
+            scroll(evt);
+            evt.consume();
+        }
     }
 
     public boolean isDisabled() {
@@ -84,6 +95,7 @@ public class ScrollHandler {
 
     public void unbind() {
         InputMapTemplate.uninstall(DEFAULT_INPUT_MAP, this, c -> flow);
+        flow.removeEventHandler(ScrollEvent.SCROLL, scrollEventHandler);
     }
 
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/flowless/SizeTracker.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/flowless/SizeTracker.java
@@ -75,7 +75,8 @@ final class SizeTracker {
 
         this.averageLengthEstimate = Val.constant(height);
 
-        this.totalLengthEstimate = Val.constant(height * cells.size());
+        this.totalLengthEstimate = Val.create(() -> height * cells.size(),
+                                                   cells);
 
         Val<Integer> firstVisibleIndex = Val.create(() -> cells.getMemoizedCount() == 0 ? null
                                                                                         : cells.indexOfMemoizedItem(0),

--- a/kramer/src/main/java/com/chiralbehaviors/layout/flowless/TargetPosition.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/flowless/TargetPosition.java
@@ -174,6 +174,11 @@ final class StartOffStart implements TargetPosition {
     }
 
     @Override
+    public String toString() {
+        return String.format("StartOffStart(item=%d, offset=%.1f)", itemIndex, offsetFromStart);
+    }
+
+    @Override
     public void accept(TargetPositionVisitor visitor) {
         visitor.visit(this);
     }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/flowless/VirtualFlow.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/flowless/VirtualFlow.java
@@ -614,6 +614,12 @@ public class VirtualFlow<C extends LayoutCell<?>>
         }
     }
 
+    public boolean canScrollVertically() {
+        double total = totalLengthEstimateProperty().getOrElse(0.0);
+        double viewportLength = sizeTracker.getViewportLength();
+        return total > viewportLength;
+    }
+
     void scrollLength(double deltaLength) {
         setLengthOffset(lengthOffsetEstimate.getValue() + deltaLength);
     }
@@ -633,7 +639,7 @@ public class VirtualFlow<C extends LayoutCell<?>>
 
         double diff = pixels - current;
         if (diff == 0) {
-            // do nothing
+            // no change
         } else if (Math.abs(diff) < length) { // distance less than one screen
             navigator.scrollCurrentPositionBy(diff);
         } else {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/outline/Outline.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/outline/Outline.java
@@ -76,6 +76,10 @@ public class Outline extends VirtualFlow<OutlineCell> {
     public void updateItem(JsonNode item) {
         List<JsonNode> list = SchemaNode.asList(item);
         items.setAll(list);
+        // Reset scroll to top after populating items
+        if (!items.isEmpty()) {
+            showAsFirst(0);
+        }
         pseudoClassStateChanged(PSEUDO_CLASS_FILLED, item != null);
         pseudoClassStateChanged(PSEUDO_CLASS_EMPTY, item == null);
     }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/LabelStyle.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/LabelStyle.java
@@ -18,11 +18,8 @@ package com.chiralbehaviors.layout.style;
 
 import com.chiralbehaviors.layout.LayoutLabel;
 
-import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.scene.control.Label;
-import javafx.scene.shape.Rectangle;
-import javafx.scene.shape.Shape;
 import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 import javafx.scene.text.TextBoundsType;
@@ -34,16 +31,12 @@ import javafx.scene.text.TextBoundsType;
 public class LabelStyle {
     public static final String LAYOUT_LABEL = "layout-label";
 
-    private static double getLineHeight(Font font, TextBoundsType boundsType) {
+    private static double getLineHeight(Font font) {
         Text text = new Text("WgTy");
         text.setFont(font);
-        text.setBoundsType(boundsType);
-        Bounds tb = text.getBoundsInLocal();
-        return Shape.intersect(text,
-                               new Rectangle(tb.getMinX(), tb.getMinY(),
-                                             tb.getWidth(), tb.getHeight()))
-                    .getBoundsInLocal()
-                    .getHeight();
+        text.setBoundsType(TextBoundsType.LOGICAL);
+        return text.getBoundsInLocal()
+                   .getHeight();
     }
 
     private final Font   font;
@@ -53,8 +46,7 @@ public class LabelStyle {
     public LabelStyle(Label label) {
         Insets lInsets = label.getInsets();
         insets = lInsets;
-        lineHeight = getLineHeight(label.getFont(),
-                                   TextBoundsType.LOGICAL_VERTICAL_CENTER);
+        lineHeight = getLineHeight(label.getFont());
         font = label.getFont();
     }
 

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedRow.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedRow.java
@@ -78,6 +78,10 @@ public class NestedRow extends VirtualFlow<NestedCell> {
     @Override
     public void updateItem(JsonNode item) {
         items.setAll(NestedTable.itemsAsArray(item));
+        // Reset scroll to top after populating items
+        if (!items.isEmpty()) {
+            showAsFirst(0);
+        }
         getNode().pseudoClassStateChanged(PSEUDO_CLASS_FILLED, item != null);
         getNode().pseudoClassStateChanged(PSEUDO_CLASS_EMPTY, item == null);
     }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/flowless/VirtualFlowScrollTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/flowless/VirtualFlowScrollTest.java
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout.flowless;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import com.chiralbehaviors.layout.cell.LayoutCell;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.EventHandler;
+import javafx.scene.Scene;
+import javafx.scene.input.ScrollEvent;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+/**
+ * Tests for VirtualFlow scrolling mechanics using TestFX headless mode.
+ * Covers: SizeTracker reactivity, canScrollVertically, scrollYBy offset
+ * changes, ScrollHandler event consumption, and nested VF scroll isolation.
+ */
+@ExtendWith(ApplicationExtension.class)
+class VirtualFlowScrollTest {
+
+    private static final double CELL_HEIGHT = 30.0;
+    private static final double CELL_WIDTH  = 200.0;
+    private static final double VF_HEIGHT   = 100.0;
+
+    private VirtualFlow<TestCell> vf;
+    private StackPane             root;
+
+    @Start
+    void start(Stage stage) {
+        root = new StackPane();
+        vf = createVirtualFlow();
+        root.getChildren().add(vf);
+
+        Scene scene = new Scene(root, 300, VF_HEIGHT);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    // --- SizeTracker reactivity ---
+
+    @Test
+    void totalLengthEstimateUpdatesWhenItemsAdded(FxRobot robot) {
+        runOnFxAndWait(() -> {
+            double totalBefore = vf.totalLengthEstimateProperty().getOrElse(0.0);
+            assertEquals(0.0, totalBefore, 0.01, "Empty VF should have 0 total length");
+
+            addItemsAndReset(vf, 10);
+        });
+
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+
+        runOnFxAndWait(() -> {
+            double totalAfter = vf.totalLengthEstimateProperty().getOrElse(0.0);
+            assertEquals(10 * CELL_HEIGHT, totalAfter, 0.01,
+                         "Total length should equal item count * cell height");
+        });
+    }
+
+    // --- canScrollVertically ---
+
+    @Test
+    void canScrollVertically_falseWhenContentFits(FxRobot robot) {
+        runOnFxAndWait(() -> addItemsAndReset(vf, 2));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+
+        runOnFxAndWait(() -> {
+            assertFalse(vf.canScrollVertically(),
+                        "Should not be scrollable when content fits viewport");
+        });
+    }
+
+    @Test
+    void canScrollVertically_trueWhenContentOverflows(FxRobot robot) {
+        runOnFxAndWait(() -> addItemsAndReset(vf, 10));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+
+        runOnFxAndWait(() -> {
+            assertTrue(vf.canScrollVertically(),
+                       "Should be scrollable when content overflows viewport");
+        });
+    }
+
+    // --- scrollYBy changes offset ---
+
+    @Test
+    void scrollYByChangesLengthOffset(FxRobot robot) {
+        runOnFxAndWait(() -> addItemsAndReset(vf, 10));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            double before = vf.lengthOffsetEstimateProperty().getValue();
+            assertEquals(0.0, before, 0.01, "Offset should start at 0");
+            vf.scrollYBy(15);
+        });
+
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            double after = vf.lengthOffsetEstimateProperty().getValue();
+            assertEquals(15.0, after, 1.0,
+                         "Offset should change after scrollYBy");
+        });
+    }
+
+    @Test
+    void scrollYByClampsToMax(FxRobot robot) {
+        runOnFxAndWait(() -> addItemsAndReset(vf, 10));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> vf.scrollYBy(10000));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            double total = vf.totalLengthEstimateProperty().getOrElse(0.0);
+            double vpLen = vf.getLayoutBounds().getHeight();
+            double max = total - vpLen;
+            double offset = vf.lengthOffsetEstimateProperty().getValue();
+            assertTrue(offset <= max + 1.0,
+                       "Offset should be clamped to max=" + max + " but was " + offset);
+            assertTrue(offset >= max - 1.0,
+                       "Offset should be near max=" + max + " but was " + offset);
+        });
+    }
+
+    // --- ScrollHandler event consumption ---
+
+    /**
+     * When a scrollable VF receives a scroll event, it should scroll and
+     * consume the event (preventing parent handlers from seeing it).
+     * We verify by installing a handler on the parent that tracks bubbled events.
+     */
+    @Test
+    void scrollEventConsumedWhenScrollable(FxRobot robot) {
+        runOnFxAndWait(() -> addItemsAndReset(vf, 10));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        AtomicReference<Boolean> parentSawEvent = new AtomicReference<>(false);
+        EventHandler<ScrollEvent> parentHandler = evt -> parentSawEvent.set(true);
+
+        runOnFxAndWait(() -> {
+            assertTrue(vf.canScrollVertically(), "Precondition: VF should be scrollable");
+
+            // Install a handler on parent to detect if event bubbles up
+            root.addEventHandler(ScrollEvent.SCROLL, parentHandler);
+
+            ScrollEvent event = createScrollEvent(-30);
+            vf.fireEvent(event);
+        });
+
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            root.removeEventHandler(ScrollEvent.SCROLL, parentHandler);
+
+            // The VF should have consumed the event, so parent should NOT see it
+            assertFalse(parentSawEvent.get(),
+                        "Parent should not see scroll event when child VF consumes it");
+        });
+    }
+
+    @Test
+    void scrollEventBubblesToParentWhenNotScrollable(FxRobot robot) {
+        runOnFxAndWait(() -> addItemsAndReset(vf, 2));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        AtomicReference<Boolean> parentSawEvent = new AtomicReference<>(false);
+        EventHandler<ScrollEvent> parentHandler = evt -> parentSawEvent.set(true);
+
+        runOnFxAndWait(() -> {
+            assertFalse(vf.canScrollVertically(), "Precondition: VF should not be scrollable");
+
+            root.addEventHandler(ScrollEvent.SCROLL, parentHandler);
+
+            ScrollEvent event = createScrollEvent(-30);
+            vf.fireEvent(event);
+        });
+
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            root.removeEventHandler(ScrollEvent.SCROLL, parentHandler);
+
+            // The VF should NOT consume the event, so parent SHOULD see it
+            assertTrue(parentSawEvent.get(),
+                       "Parent should see scroll event when child VF cannot scroll");
+        });
+    }
+
+    // --- Nested VF scroll isolation ---
+
+    @Test
+    void nestedScrollableVfConsumesEventBeforeParent(FxRobot robot) {
+        VirtualFlow<InnerVfCell> outerVf = createOuterVirtualFlow();
+
+        runOnFxAndWait(() -> {
+            root.getChildren().clear();
+            root.getChildren().add(outerVf);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> addItemsAndReset(outerVf, 10));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> outerVf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        AtomicReference<Boolean> outerSawEvent = new AtomicReference<>(false);
+        EventHandler<ScrollEvent> outerHandler = evt -> outerSawEvent.set(true);
+
+        runOnFxAndWait(() -> {
+            assertTrue(outerVf.canScrollVertically(),
+                       "Precondition: outer VF should be scrollable");
+
+            // Track whether the outer VF's parent sees the event
+            root.addEventHandler(ScrollEvent.SCROLL, outerHandler);
+
+            outerVf.getFirstVisibleIndex().ifPresent(idx -> {
+                outerVf.getCellIfVisible(idx).ifPresent(cell -> {
+                    VirtualFlow<TestCell> innerVf = cell.getInnerVf();
+                    if (innerVf != null) {
+                        innerVf.layout();
+                        if (innerVf.canScrollVertically()) {
+                            ScrollEvent event = createScrollEvent(-15);
+                            innerVf.fireEvent(event);
+                        }
+                    }
+                });
+            });
+        });
+
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            root.removeEventHandler(ScrollEvent.SCROLL, outerHandler);
+
+            // If inner VF consumed the event, the outer's parent should not see it
+            assertFalse(outerSawEvent.get(),
+                        "Outer parent should not see scroll event when inner VF consumes it");
+        });
+    }
+
+    // --- Helpers ---
+
+    private VirtualFlow<TestCell> createVirtualFlow() {
+        ObservableList<JsonNode> items = FXCollections.observableArrayList();
+        return new VirtualFlow<>("default.css", CELL_WIDTH, CELL_HEIGHT,
+                                 items, (item, focus) -> new TestCell(CELL_WIDTH, CELL_HEIGHT),
+                                 null, Collections.emptyList());
+    }
+
+    private VirtualFlow<InnerVfCell> createOuterVirtualFlow() {
+        ObservableList<JsonNode> items = FXCollections.observableArrayList();
+        return new VirtualFlow<>("default.css", CELL_WIDTH, CELL_HEIGHT * 2,
+                                 items, (item, focus) -> new InnerVfCell(CELL_WIDTH, CELL_HEIGHT),
+                                 null, Collections.emptyList());
+    }
+
+    private static <C extends LayoutCell<?>> void addItemsAndReset(VirtualFlow<C> vf, int count) {
+        for (int i = 0; i < count; i++) {
+            vf.getItems().add(IntNode.valueOf(i));
+        }
+        if (!vf.getItems().isEmpty()) {
+            vf.showAsFirst(0);
+        }
+    }
+
+    private static ScrollEvent createScrollEvent(double deltaY) {
+        return new ScrollEvent(ScrollEvent.SCROLL,
+                               0, 0,    // x, y
+                               0, 0,    // screenX, screenY
+                               false,   // shiftDown
+                               false,   // controlDown
+                               false,   // altDown
+                               false,   // metaDown
+                               false,   // direct
+                               false,   // inertia
+                               0, deltaY, // deltaX, deltaY
+                               0, 0,    // totalDeltaX, totalDeltaY
+                               ScrollEvent.HorizontalTextScrollUnits.NONE, 0,
+                               ScrollEvent.VerticalTextScrollUnits.NONE, 0,
+                               0, null);
+    }
+
+    private static void runOnFxAndWait(Runnable action) {
+        if (Platform.isFxApplicationThread()) {
+            action.run();
+        } else {
+            CountDownLatch latch = new CountDownLatch(1);
+            Platform.runLater(() -> {
+                try {
+                    action.run();
+                } finally {
+                    latch.countDown();
+                }
+            });
+            try {
+                assertTrue(latch.await(5, TimeUnit.SECONDS),
+                           "Timed out waiting for FX thread");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted waiting for FX thread");
+            }
+        }
+    }
+
+    /**
+     * A minimal LayoutCell for testing — a Pane with fixed dimensions.
+     */
+    static class TestCell extends Pane implements LayoutCell<Pane> {
+        TestCell(double width, double height) {
+            setPrefSize(width, height);
+            setMinSize(width, height);
+            setMaxSize(width, height);
+        }
+
+        @Override
+        public Pane getNode() {
+            return this;
+        }
+
+        @Override
+        public boolean isReusable() {
+            return true;
+        }
+    }
+
+    /**
+     * A LayoutCell that contains an inner VirtualFlow, for testing nested scroll.
+     */
+    static class InnerVfCell extends Pane implements LayoutCell<Pane> {
+        private final VirtualFlow<TestCell> innerVf;
+
+        InnerVfCell(double width, double cellHeight) {
+            double innerHeight = cellHeight * 2;
+            setPrefSize(width, innerHeight);
+            setMinSize(width, innerHeight);
+            setMaxSize(width, innerHeight);
+
+            ObservableList<JsonNode> innerItems = FXCollections.observableArrayList();
+            innerVf = new VirtualFlow<>("default.css", width, cellHeight / 2,
+                                        innerItems,
+                                        (item, focus) -> new TestCell(width, cellHeight / 2),
+                                        null, Collections.emptyList());
+            innerVf.setPrefSize(width, innerHeight);
+            innerVf.setMinSize(width, innerHeight);
+            innerVf.setMaxSize(width, innerHeight);
+            getChildren().add(innerVf);
+
+            // Add enough items to make inner VF scrollable
+            for (int i = 0; i < 20; i++) {
+                innerItems.add(IntNode.valueOf(i));
+            }
+            innerVf.showAsFirst(0);
+        }
+
+        VirtualFlow<TestCell> getInnerVf() {
+            return innerVf;
+        }
+
+        @Override
+        public Pane getNode() {
+            return this;
+        }
+
+        @Override
+        public boolean isReusable() {
+            return true;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,24 @@
 				<version>5.22.0</version>
 			</dependency>
 			<dependency>
+				<groupId>org.testfx</groupId>
+				<artifactId>testfx-core</artifactId>
+				<version>4.0.18</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.testfx</groupId>
+				<artifactId>testfx-junit5</artifactId>
+				<version>4.0.18</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.testfx</groupId>
+				<artifactId>openjfx-monocle</artifactId>
+				<version>21.0.2</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
 				<groupId>org.openjfx</groupId>
 				<artifactId>javafx-controls</artifactId>
 				<version>25.0.1</version>


### PR DESCRIPTION
## Summary
- Fix vertical scrolling in nested VirtualFlow hierarchy — root VF was consuming all scroll events via capturing-phase InputMapTemplate handler, preventing nested VFs from scrolling
- Fix SizeTracker totalLengthEstimate reactivity (Val.constant → Val.create)  
- Fix initial scroll position (showAsFirst(0) after item population)
- Add height measurement fixes (M1/M2) and viewport space distribution
- Add TestFX headless test infrastructure with 8 scroll-specific tests

## Changes

### Scroll fix (3 commits)
- **ScrollHandler**: Move scroll handling from `InputMapTemplate.installOverride` (capturing phase) to `addEventHandler` (bubbling phase) with `canScrollVertically()` guard
- **SizeTracker**: Change `totalLengthEstimate` from `Val.constant` to reactive `Val.create`
- **VirtualFlow**: Add `canScrollVertically()` method
- **Outline/NestedRow**: Reset scroll to top via `showAsFirst(0)` after items populated

### TestFX infrastructure
- Add `testfx-core:4.0.18`, `testfx-junit5:4.0.18`, `openjfx-monocle:21.0.2` as test dependencies
- Configure surefire for headless Monocle execution
- `VirtualFlowScrollTest` with 8 tests covering SizeTracker reactivity, canScrollVertically, scrollYBy, event consumption, and nested VF isolation

## Test plan
- [x] All 8 new VirtualFlowScrollTest tests pass headless
- [x] All existing tests pass (`mvn clean install`)
- [ ] Manual verification of scroll behavior in StandaloneDemo