### PR TITLE
RDR-009 Phase A: Fix style cache + immutable result records + MeasureResult dual-write

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/CompressResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/CompressResult.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+/**
+ * Immutable result of the compress phase. Captures justified geometry and
+ * column set assignments for outline mode. In outline mode, cellHeight is set
+ * here; in table mode it is set in HeightResult instead.
+ *
+ * @see SchemaNodeLayout#compress(double)
+ */
+public record CompressResult(
+    double justifiedWidth,
+    List<ColumnSet> columnSets,
+    double cellHeight,
+    List<CompressResult> childResults
+) {
+    public CompressResult {
+        columnSets = columnSets == null ? List.of() : List.copyOf(columnSets);
+        childResults = childResults == null ? List.of() : List.copyOf(childResults);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/HeightResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/HeightResult.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+/**
+ * Immutable result of the height computation phase. Captures final sizing
+ * after cellHeight/calculateRootHeight. In table mode, cellHeight is set here
+ * (via calculateTableHeight); in outline mode it was already set in
+ * CompressResult.
+ *
+ * @see SchemaNodeLayout#cellHeight(int, double)
+ */
+public record HeightResult(
+    double height,
+    double cellHeight,
+    int resolvedCardinality,
+    double columnHeaderHeight,
+    List<HeightResult> childResults
+) {
+    public HeightResult {
+        childResults = childResults == null ? List.of() : List.copyOf(childResults);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutResult.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+/**
+ * Immutable result of the layout phase. Captures the table-vs-outline decision
+ * and width-dependent layout geometry. Produced by layout(), recomputed per
+ * resize.
+ *
+ * @see SchemaNodeLayout#layout(double)
+ */
+public record LayoutResult(
+    boolean useTable,
+    boolean useVerticalHeader,
+    double tableColumnWidth,
+    double columnHeaderIndentation,
+    double constrainedColumnWidth,
+    List<LayoutResult> childResults
+) {
+    public LayoutResult {
+        childResults = childResults == null ? List.of() : List.copyOf(childResults);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Immutable result of the measure phase. Captures data-dependent state that
+ * persists across resize cycles. Produced by measure(), cached by AutoLayout.
+ *
+ * @see SchemaNodeLayout#measure(JsonNode, Function, com.chiralbehaviors.layout.style.Style)
+ */
+public record MeasureResult(
+    double labelWidth,
+    double columnWidth,
+    double dataWidth,
+    double maxWidth,
+    int averageCardinality,
+    boolean isVariableLength,
+    int averageChildCardinality,
+    int maxCardinality,
+    Function<JsonNode, JsonNode> extractor,
+    List<MeasureResult> childResults
+) {
+    public MeasureResult {
+        childResults = childResults == null ? List.of() : List.copyOf(childResults);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -49,6 +49,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     protected final PrimitiveStyle style;
     private double                 cellHeight;
     private boolean                useVerticalHeader         = false;
+    private MeasureResult          measureResult;
 
     public PrimitiveLayout(Primitive p, PrimitiveStyle style) {
         super(p, style.getLabelStyle());
@@ -208,6 +209,13 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         dataWidth = Style.snap(Math.max(getNode().getDefaultWidth(),
                                         effectiveWidth));
         columnWidth = Math.max(labelWidth, dataWidth);
+
+        measureResult = new MeasureResult(
+            labelWidth, columnWidth, dataWidth, maxWidth,
+            averageCardinality, isVariableLength,
+            0, 0, null, List.of()
+        );
+
         return columnWidth;
     }
 
@@ -264,6 +272,10 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     public boolean isUseVerticalHeader() {
         return useVerticalHeader;
+    }
+
+    public MeasureResult getMeasureResult() {
+        return measureResult;
     }
 
     void setUseVerticalHeader(boolean useVerticalHeader) {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -73,6 +73,7 @@ public final class RelationLayout extends SchemaNodeLayout {
     protected final RelationStyle          style;
     protected double                       tableColumnWidth = 0;
     protected boolean                      useTable         = false;
+    private MeasureResult                  measureResult;
 
     public RelationLayout(Relation r, RelationStyle style) {
         super(r, style.getLabelStyle());
@@ -298,6 +299,10 @@ public final class RelationLayout extends SchemaNodeLayout {
         return useTable;
     }
 
+    public MeasureResult getMeasureResult() {
+        return measureResult;
+    }
+
     @Override
     public double justify(double justifed) {
         justifyColumn(Style.snap(justifed - columnHeaderIndentation));
@@ -374,6 +379,22 @@ public final class RelationLayout extends SchemaNodeLayout {
         // Paper Table 1: Bullet width budget
         labelWidth += style.getBulletWidth();
         columnWidth = Style.snap(labelWidth + columnWidth);
+
+        List<MeasureResult> childResults = children.stream()
+            .map(c -> {
+                if (c instanceof PrimitiveLayout pl) return pl.getMeasureResult();
+                if (c instanceof RelationLayout rl) return rl.getMeasureResult();
+                return null;
+            })
+            .toList();
+
+        measureResult = new MeasureResult(
+            labelWidth, columnWidth, 0, 0,
+            0, false,
+            averageChildCardinality, maxCardinality,
+            extractor, childResults
+        );
+
         return columnWidth + style.getElementHorizontalInset()
                + style.getColumnHorizontalInset()
                + style.getSpanHorizontalInset()

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/Style.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/Style.java
@@ -17,10 +17,8 @@
 package com.chiralbehaviors.layout.style;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 
 import com.chiralbehaviors.layout.LayoutLabel;
 import com.chiralbehaviors.layout.PrimitiveLayout;
@@ -121,8 +119,8 @@ public class Style {
     private final LayoutObserver              observer;
 
     private final List<String>                styleSheets          = new ArrayList<>();
-    private final Map<String, PrimitiveStyle>          primitiveStyleCache  = new HashMap<>();
-    private final Map<String, RelationStyle>           relationStyleCache   = new HashMap<>();
+    private final IdentityHashMap<Primitive, PrimitiveStyle>  primitiveStyleCache  = new IdentityHashMap<>();
+    private final IdentityHashMap<Relation, RelationStyle>   relationStyleCache   = new IdentityHashMap<>();
     private final IdentityHashMap<SchemaNode, SchemaNodeLayout> layoutCache = new IdentityHashMap<>();
 
     public Style() {
@@ -167,7 +165,7 @@ public class Style {
     }
 
     public PrimitiveStyle style(Primitive p) {
-        return primitiveStyleCache.computeIfAbsent(p.getField(),
+        return primitiveStyleCache.computeIfAbsent(p,
                                                     k -> computePrimitiveStyle(p));
     }
 
@@ -210,7 +208,7 @@ public class Style {
     }
 
     public RelationStyle style(Relation r) {
-        return relationStyleCache.computeIfAbsent(r.getField(),
+        return relationStyleCache.computeIfAbsent(r,
                                                    k -> computeRelationStyle(r));
     }
 

--- a/kramer/src/test/java/com/chiralbehaviors/layout/ColumnSetEvaluationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/ColumnSetEvaluationTest.java
@@ -166,7 +166,7 @@ class ColumnSetEvaluationTest {
         layout.compress(width, useHalfWidthGuard);
         return new CompressResult(
             layout.columnSets.size(),
-            layout.cellHeight,
+            layout.getCellHeight(),
             layout.columnSets.stream()
                 .map(cs -> cs.getColumns().stream()
                     .mapToInt(c -> c.getFields().size()).sum())

--- a/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveMeasureResultTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveMeasureResultTest.java
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for A3: PrimitiveLayout MeasureResult dual-write.
+ * Verifies that measure() populates both mutable fields AND MeasureResult,
+ * and that MeasureResult survives layout()/clear().
+ */
+class PrimitiveMeasureResultTest {
+
+    @Test
+    void measureResultMatchesMutableFields() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("name"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("Alice");
+        data.add("Bob");
+        data.add("Charlie");
+
+        Style model = new Style();
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result, "MeasureResult should be populated after measure()");
+
+        assertEquals(layout.getLabelWidth(), result.labelWidth());
+        assertEquals(layout.columnWidth, result.columnWidth());
+        assertEquals(layout.dataWidth, result.dataWidth());
+        assertEquals(layout.maxWidth, result.maxWidth());
+        assertEquals(layout.averageCardinality, result.averageCardinality());
+        assertEquals(layout.isVariableLength(), result.isVariableLength());
+    }
+
+    @Test
+    void measureResultSurvivesLayoutClear() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("date"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("2026-01-01");
+        data.add("2026-06-15");
+
+        Style model = new Style();
+        layout.measure(data, n -> n, model);
+
+        MeasureResult before = layout.getMeasureResult();
+        assertNotNull(before);
+
+        // layout() calls clear() internally
+        layout.layout(500);
+
+        MeasureResult after = layout.getMeasureResult();
+        assertSame(before, after,
+                   "MeasureResult must survive layout()/clear()");
+    }
+
+    @Test
+    void emptyDataProducesVariableLengthFallback() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("empty"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode(); // empty
+
+        Style model = new Style();
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result);
+        assertTrue(result.isVariableLength(),
+                   "Empty data should default to variable-length (safe fallback)");
+    }
+
+    @Test
+    void getMeasureResultNullBeforeMeasure() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("x"), style);
+
+        assertNull(layout.getMeasureResult(),
+                   "MeasureResult should be null before measure() is called");
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RelationMeasureResultTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RelationMeasureResultTest.java
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for A4: RelationLayout MeasureResult dual-write.
+ */
+class RelationMeasureResultTest {
+
+    @Test
+    void measureResultPopulatedAfterMeasure() {
+        Relation schema = new Relation("catalog");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("code"));
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        Style model = new Style();
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        var row1 = JsonNodeFactory.instance.objectNode();
+        row1.put("name", "Alice");
+        row1.put("code", "A1");
+        data.add(row1);
+        var row2 = JsonNodeFactory.instance.objectNode();
+        row2.put("name", "Bob");
+        row2.put("code", "B2");
+        data.add(row2);
+
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result, "MeasureResult should be populated after measure()");
+
+        assertEquals(layout.getLabelWidth(), result.labelWidth());
+        assertEquals(layout.columnWidth, result.columnWidth());
+        assertEquals(layout.averageChildCardinality, result.averageChildCardinality());
+        assertEquals(layout.maxCardinality, result.maxCardinality());
+    }
+
+    @Test
+    void childResultsMatchChildren() {
+        Relation schema = new Relation("catalog");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("code"));
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        Style model = new Style();
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        var row = JsonNodeFactory.instance.objectNode();
+        row.put("name", "Alice");
+        row.put("code", "A1");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertEquals(2, result.childResults().size(),
+                     "childResults should match children count");
+
+        // Each child's MeasureResult should match
+        for (int i = 0; i < layout.children.size(); i++) {
+            SchemaNodeLayout child = layout.children.get(i);
+            MeasureResult childResult = result.childResults().get(i);
+            assertNotNull(childResult);
+            assertEquals(child.getLabelWidth(), childResult.labelWidth());
+        }
+    }
+
+    @Test
+    void measureResultSurvivesLayoutClear() {
+        Relation schema = new Relation("catalog");
+        schema.addChild(new Primitive("name"));
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        Style model = new Style();
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        var row = JsonNodeFactory.instance.objectNode();
+        row.put("name", "Alice");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+        MeasureResult before = layout.getMeasureResult();
+
+        layout.layout(500);
+
+        MeasureResult after = layout.getMeasureResult();
+        assertSame(before, after,
+                   "MeasureResult must survive layout()/clear()");
+    }
+
+    @Test
+    void getMeasureResultNullBeforeMeasure() {
+        Relation schema = new Relation("catalog");
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        assertNull(layout.getMeasureResult(),
+                   "MeasureResult should be null before measure()");
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/TestLayouts.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/TestLayouts.java
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import javafx.geometry.Insets;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.LabelStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Consolidated test factory for layout objects. Replaces per-file
+ * makePrimitive/mockRelationStyle/mockPrimitiveStyle helpers.
+ */
+public final class TestLayouts {
+
+    private TestLayouts() {}
+
+    /**
+     * Create a mock RelationStyle with all insets set to 0.
+     */
+    public static RelationStyle mockRelationStyle() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        RelationStyle style = mock(RelationStyle.class);
+        when(style.getLabelStyle()).thenReturn(labelStyle);
+        when(style.getOutlineHorizontalInset()).thenReturn(0.0);
+        when(style.getOutlineCellHorizontalInset()).thenReturn(0.0);
+        when(style.getSpanHorizontalInset()).thenReturn(0.0);
+        when(style.getColumnHorizontalInset()).thenReturn(0.0);
+        when(style.getElementHorizontalInset()).thenReturn(0.0);
+        when(style.getMaxAverageCardinality()).thenReturn(10);
+        when(style.getSpanVerticalInset()).thenReturn(0.0);
+        when(style.getColumnVerticalInset()).thenReturn(0.0);
+        when(style.getRowVerticalInset()).thenReturn(0.0);
+        when(style.getRowCellVerticalInset()).thenReturn(0.0);
+        when(style.getRowCellHorizontalInset()).thenReturn(0.0);
+        when(style.getRowHorizontalInset()).thenReturn(0.0);
+        when(style.getOutlineCellVerticalInset()).thenReturn(0.0);
+        when(style.getOutlineVerticalInset()).thenReturn(0.0);
+        when(style.getElementVerticalInset()).thenReturn(0.0);
+        when(style.getNestedHorizontalInset()).thenReturn(0.0);
+        when(style.getNestedInsets()).thenReturn(new Insets(0));
+        when(style.getTableVerticalInset()).thenReturn(0.0);
+        when(style.getOutlineMaxLabelWidth()).thenReturn(200.0);
+        when(style.getOutlineColumnMinWidth()).thenReturn(60.0);
+        when(style.getBulletText()).thenReturn("");
+        when(style.getBulletWidth()).thenReturn(0.0);
+        when(style.getIndentWidth()).thenReturn(0.0);
+        return style;
+    }
+
+    /**
+     * Create a mock PrimitiveStyle where width(JsonNode) returns
+     * charWidth * text.length().
+     */
+    public static PrimitiveStyle mockPrimitiveStyle(double charWidth) {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        PrimitiveStyle primStyle = mock(PrimitiveStyle.class);
+        when(primStyle.getLabelStyle()).thenReturn(labelStyle);
+        when(primStyle.getHeight(anyDouble(), anyDouble())).thenReturn(20.0);
+        when(primStyle.getListVerticalInset()).thenReturn(0.0);
+        when(primStyle.getMinValueWidth()).thenReturn(30.0);
+        when(primStyle.getMaxTablePrimitiveWidth()).thenReturn(Double.MAX_VALUE);
+        when(primStyle.getVerticalHeaderThreshold()).thenReturn(1.5);
+        when(primStyle.getVariableLengthThreshold()).thenReturn(2.0);
+        when(primStyle.getOutlineSnapValueWidth()).thenReturn(0.0);
+        when(primStyle.width(any(JsonNode.class))).thenAnswer(inv -> {
+            JsonNode node = inv.getArgument(0);
+            String text = node.isTextual() ? node.textValue() : node.toString();
+            return charWidth * text.length();
+        });
+        return primStyle;
+    }
+
+    /**
+     * Create a PrimitiveLayout with pre-set widths (bypasses measure()).
+     */
+    public static PrimitiveLayout makePrimitive(String name, double width) {
+        return makePrimitive(name, width, width, 0);
+    }
+
+    /**
+     * Create a PrimitiveLayout with pre-set dataWidth, columnWidth, and labelWidth.
+     */
+    public static PrimitiveLayout makePrimitive(String name, double dataWidth,
+                                                 double columnWidth,
+                                                 double labelWidth) {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        PrimitiveStyle primStyle = mock(PrimitiveStyle.class);
+        when(primStyle.getLabelStyle()).thenReturn(labelStyle);
+        when(primStyle.getHeight(anyDouble(), anyDouble())).thenReturn(20.0);
+        when(primStyle.getListVerticalInset()).thenReturn(0.0);
+        when(primStyle.getMinValueWidth()).thenReturn(30.0);
+        when(primStyle.getMaxTablePrimitiveWidth()).thenReturn(Double.MAX_VALUE);
+        when(primStyle.getVerticalHeaderThreshold()).thenReturn(1.5);
+        when(primStyle.getVariableLengthThreshold()).thenReturn(2.0);
+        when(primStyle.getOutlineSnapValueWidth()).thenReturn(0.0);
+
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive(name), primStyle);
+        layout.columnWidth = columnWidth;
+        layout.dataWidth = dataWidth;
+        layout.labelWidth = labelWidth;
+        return layout;
+    }
+
+    /**
+     * Create a child RelationLayout with pre-set widths and table mode.
+     */
+    public static RelationLayout makeChildRelation(String name, double width,
+                                                     boolean useTable) {
+        RelationStyle childStyle = mockRelationStyle();
+        RelationLayout layout = new RelationLayout(new Relation(name), childStyle);
+        layout.columnWidth = width;
+        layout.useTable = useTable;
+        layout.tableColumnWidth = width;
+        layout.labelWidth = 0;
+        layout.maxCardinality = 3;
+        layout.averageChildCardinality = 2;
+        return layout;
+    }
+
+    /**
+     * Create a RelationLayout with pre-set children, labelWidth, and cardinality.
+     */
+    public static RelationLayout makeRelation(String name, double labelWidth,
+                                               int averageChildCardinality,
+                                               PrimitiveLayout... children) {
+        RelationStyle style = mockRelationStyle();
+        Relation schema = new Relation(name);
+        for (var c : children) {
+            schema.addChild(new Primitive(c.getField()));
+        }
+        RelationLayout layout = new RelationLayout(schema, style);
+        layout.children.clear();
+        for (var c : children) {
+            layout.children.add(c);
+        }
+        layout.labelWidth = labelWidth;
+        layout.averageChildCardinality = averageChildCardinality;
+        return layout;
+    }
+}


### PR DESCRIPTION
## Summary
- **T0**: Fix F7 style cache keys from `HashMap<String,...>` to `IdentityHashMap<SchemaNode,...>` — fixes latent bug where same-named primitives at different nesting levels shared cached styles
- **A1**: Define 4 immutable phase result records: MeasureResult, LayoutResult, CompressResult, HeightResult
- **A2**: Create TestLayouts test factory utility; fix `cellHeight` direct field read in ColumnSetEvaluationTest
- **A3**: PrimitiveLayout.measure() dual-write — populates MeasureResult alongside mutable fields
- **A4**: RelationLayout.measure() dual-write — populates MeasureResult with recursive childResults tree

## Breaking changes
None. All changes are additive — existing mutable fields retained alongside new records.

## Test plan
- [x] 150 tests pass (142 existing + 8 new MeasureResult tests)
- [x] Full `mvn -pl kramer test` green
- [x] PrimitiveLayout: MeasureResult matches mutable fields, survives clear(), handles empty data
- [x] RelationLayout: MeasureResult childResults tree matches children list

References: RDR-009, Kramer-4lu (epic), Kramer-e7h/rgy/5bw/20b/r57