### PR TITLE
Phase B1: PrimitiveLayout result-returning compute methods

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -278,6 +278,48 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         return measureResult;
     }
 
+    public LayoutResult computeLayout(double width) {
+        clear();
+        return new LayoutResult(
+            false,              // useTable — primitives never use table mode
+            useVerticalHeader,  // preserved from nestTableColumn if set
+            0,                  // tableColumnWidth — not applicable
+            columnHeaderIndentation,
+            width,              // constrainedColumnWidth
+            List.of()
+        );
+    }
+
+    public CompressResult computeCompress(double available) {
+        double floor = style.getMinValueWidth();
+        double effective = Math.max(available, floor);
+        double justified;
+        if (!isVariableLength && maxWidth > 0) {
+            double target = maxWidth;
+            double snapWidth = style.getOutlineSnapValueWidth();
+            if (snapWidth > 0) {
+                target = Math.ceil(target / snapWidth) * snapWidth;
+            }
+            justified = Style.snap(Math.min(effective, target));
+        } else {
+            justified = Style.snap(effective);
+        }
+        return new CompressResult(justified, List.of(), 0, List.of());
+    }
+
+    public HeightResult computeCellHeight(int cardinality, double justified) {
+        int resolved = Math.min(cardinality, averageCardinality);
+        boolean list = resolved > 1;
+        double cell = snap(style.getHeight(maxWidth, justified));
+        double h;
+        if (list) {
+            h = (cell * resolved) + style.getListVerticalInset();
+        } else {
+            h = cell;
+        }
+        return new HeightResult(h, cell, resolved, 0, List.of());
+    }
+
     void setUseVerticalHeader(boolean useVerticalHeader) {
         this.useVerticalHeader = useVerticalHeader;
     }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveComputeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveComputeTest.java
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for B1: PrimitiveLayout compute* result-returning methods.
+ */
+class PrimitiveComputeTest {
+
+    @Test
+    void computeCompressMatchesMutableCompress() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("date"), style);
+
+        // Fixed-length data
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("2026-01-01");
+        data.add("2026-06-15");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+        layout.layout(500);
+
+        // Mutable path
+        layout.compress(500);
+        double mutableJustified = layout.getJustifiedWidth();
+
+        // Reset and use compute path
+        layout.layout(500); // re-clear
+        CompressResult result = layout.computeCompress(500);
+
+        assertEquals(mutableJustified, result.justifiedWidth(),
+                     "computeCompress should produce same justifiedWidth as compress");
+    }
+
+    @Test
+    void computeCellHeightMatchesMutable() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("name"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("Alice");
+        data.add("Bob");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+        layout.layout(500);
+        layout.compress(500);
+
+        // Mutable path
+        double mutableHeight = layout.cellHeight(1, 500);
+
+        // Compute path
+        HeightResult result = layout.computeCellHeight(1, 500);
+
+        assertEquals(mutableHeight, result.height(),
+                     "computeCellHeight should produce same height");
+        assertEquals(layout.getCellHeight(), result.cellHeight(),
+                     "computeCellHeight should produce same cellHeight");
+    }
+
+    @Test
+    void computeLayoutReturnsResult() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("x"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("hello");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        LayoutResult result = layout.computeLayout(500);
+        assertNotNull(result);
+        // PrimitiveLayout doesn't use table mode
+        assertFalse(result.useTable());
+    }
+}


### PR DESCRIPTION
## Summary
- Add `computeLayout()`, `computeCompress()`, `computeCellHeight()` to PrimitiveLayout
- Parallel API — existing mutable methods unchanged
- Each compute method returns an immutable record (LayoutResult, CompressResult, HeightResult)

## Test plan
- [x] 3 new tests verify compute results match mutable method outputs
- [x] 153 tests pass locally

References: Kramer-4dk (B1), RDR-009