### PR TITLE
Phase B2: RelationLayout result-returning compute methods

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -303,6 +303,51 @@ public final class RelationLayout extends SchemaNodeLayout {
         return measureResult;
     }
 
+    public LayoutResult computeLayout(double width) {
+        layout(width);
+        return new LayoutResult(
+            useTable,
+            false,
+            tableColumnWidth,
+            columnHeaderIndentation,
+            columnWidth,
+            children.stream()
+                .map(c -> {
+                    if (c instanceof PrimitiveLayout pl) return pl.computeLayout(width);
+                    if (c instanceof RelationLayout rl) return rl.computeLayout(width);
+                    return null;
+                })
+                .toList()
+        );
+    }
+
+    public CompressResult computeCompress(double justified) {
+        compress(justified);
+        return new CompressResult(
+            justifiedWidth,
+            List.copyOf(columnSets),
+            cellHeight,
+            children.stream()
+                .map(c -> {
+                    if (c instanceof PrimitiveLayout pl) return pl.computeCompress(justified);
+                    if (c instanceof RelationLayout rl) return rl.computeCompress(justified);
+                    return null;
+                })
+                .toList()
+        );
+    }
+
+    public HeightResult computeCellHeight(int cardinality, double justified) {
+        double h = cellHeight(cardinality, justified);
+        return new HeightResult(
+            h,
+            cellHeight,
+            resolvedCardinality,
+            columnHeaderHeight,
+            List.of()
+        );
+    }
+
     @Override
     public double justify(double justifed) {
         justifyColumn(Style.snap(justifed - columnHeaderIndentation));

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RelationComputeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RelationComputeTest.java
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for B2: RelationLayout compute* result-returning methods.
+ */
+class RelationComputeTest {
+
+    private Style mockStyleModel(Relation schema) {
+        Style model = mock(Style.class);
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        for (SchemaNode child : schema.getChildren()) {
+            if (child instanceof Primitive p) {
+                PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+                when(model.layout(p)).thenReturn(pl);
+            }
+        }
+        when(model.layout((SchemaNode) org.mockito.ArgumentMatchers.any())).thenAnswer(inv -> {
+            SchemaNode n = inv.getArgument(0);
+            if (n instanceof Primitive p) return model.layout(p);
+            return model.layout((Relation) n);
+        });
+        return model;
+    }
+
+    @Test
+    void computeLayoutCapturesTableDecision() {
+        Relation schema = new Relation("catalog");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("code"));
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        Style model = mockStyleModel(schema);
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        var row = JsonNodeFactory.instance.objectNode();
+        row.put("name", "Alice");
+        row.put("code", "A1");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+
+        LayoutResult result = layout.computeLayout(800);
+        assertNotNull(result);
+        assertEquals(layout.isUseTable(), result.useTable());
+    }
+
+    @Test
+    void computeCompressCapturesColumnSets() {
+        Relation schema = new Relation("parent");
+        schema.addChild(new Primitive("f1"));
+        schema.addChild(new Primitive("f2"));
+        schema.addChild(new Primitive("f3"));
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        Style model = mockStyleModel(schema);
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        var row = JsonNodeFactory.instance.objectNode();
+        row.put("f1", "a");
+        row.put("f2", "b");
+        row.put("f3", "c");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+        layout.layout(500);
+
+        CompressResult result = layout.computeCompress(500);
+        assertNotNull(result);
+        assertTrue(result.justifiedWidth() > 0);
+    }
+
+    @Test
+    void computeCellHeightCapturesHeight() {
+        Relation schema = new Relation("parent");
+        schema.addChild(new Primitive("f1"));
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        Style model = mockStyleModel(schema);
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        var row = JsonNodeFactory.instance.objectNode();
+        row.put("f1", "value");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+        layout.layout(500);
+        layout.compress(500);
+
+        HeightResult result = layout.computeCellHeight(1, 500);
+        assertNotNull(result);
+        assertTrue(result.height() > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `computeLayout()`, `computeCompress()`, `computeCellHeight()` to RelationLayout
- Delegates to existing mutable methods then captures state as immutable records
- "Wrap the mutation" approach avoids duplicating complex children interaction logic

## Test plan
- [x] 3 new tests verify compute results capture correct state
- [x] 156 tests pass locally

References: Kramer-2ci (B2), RDR-009