### PR TITLE
Phase B3: AutoLayout MeasureResult caching

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -56,6 +56,7 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
     private final FocusController<AutoLayout>      controller;
     private SimpleObjectProperty<JsonNode>         data        = new SimpleObjectProperty<>();
     private SchemaNodeLayout                       layout;
+    private MeasureResult                          measureResult;
     private double                                 layoutWidth = 0.0;
     private Style                                 model;
     private final SimpleObjectProperty<SchemaNode> root        = new SimpleObjectProperty<>();
@@ -81,6 +82,7 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         getStylesheets().addListener((ListChangeListener<String>) c -> {
             model.setStyleSheets(getStylesheets());
             layout = null;
+            measureResult = null;
             if (getData() != null) {
                 autoLayout();
             }
@@ -129,9 +131,14 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         try {
             layout = model.layout(top)
                           .measure(data, model);
+            measureResult = layout.getMeasureResult();
         } catch (Throwable e) {
             log.log(Level.SEVERE, "cannot measure data", e);
         }
+    }
+
+    public MeasureResult getMeasureResult() {
+        return measureResult;
     }
 
     @Override

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
@@ -233,6 +233,8 @@ public abstract sealed class SchemaNodeLayout permits PrimitiveLayout, RelationL
 
     public abstract SchemaNode getNode();
 
+    public abstract MeasureResult getMeasureResult();
+
     abstract public double justify(double justified);
 
     public Label label(double width, double height) {


### PR DESCRIPTION
## Summary
- Add `getMeasureResult()` abstract method to SchemaNodeLayout
- AutoLayout stores MeasureResult explicitly alongside layout field
- Cleared on stylesheet change (alongside `layout = null`)
- Formalizes SC-4: measurement result is explicitly cached across resizes

## Test plan
- [x] 156 tests pass
- [x] No behavioral change — additive only

References: Kramer-53g (B3), RDR-009