### PR TITLE
Phase C: SchemaPath + LayoutStylesheet + measure traversal wiring

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -129,8 +129,9 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
             return;
         }
         try {
-            layout = model.layout(top)
-                          .measure(data, model);
+            layout = model.layout(top);
+            layout.setSchemaPath(new SchemaPath(top.getField()));
+            layout.measure(data, model);
             measureResult = layout.getMeasureResult();
         } catch (Throwable e) {
             log.log(Level.SEVERE, "cannot measure data", e);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/DefaultLayoutStylesheet.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/DefaultLayoutStylesheet.java
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+
+/**
+ * Default implementation that delegates to the existing {@link Style} for
+ * CSS-derived styles and supports per-path property overrides.
+ */
+public class DefaultLayoutStylesheet implements LayoutStylesheet {
+
+    private final Style style;
+    private final Map<SchemaPath, Map<String, Object>> overrides = new HashMap<>();
+
+    public DefaultLayoutStylesheet(Style style) {
+        this.style = style;
+    }
+
+    public void setOverride(SchemaPath path, String property, Object value) {
+        overrides.computeIfAbsent(path, k -> new HashMap<>()).put(property, value);
+    }
+
+    public void clearOverrides() {
+        overrides.clear();
+    }
+
+    @Override
+    public double getDouble(SchemaPath path, String property,
+                            double defaultValue) {
+        var pathOverrides = overrides.get(path);
+        if (pathOverrides != null && pathOverrides.containsKey(property)) {
+            return ((Number) pathOverrides.get(property)).doubleValue();
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public int getInt(SchemaPath path, String property, int defaultValue) {
+        var pathOverrides = overrides.get(path);
+        if (pathOverrides != null && pathOverrides.containsKey(property)) {
+            return ((Number) pathOverrides.get(property)).intValue();
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public String getString(SchemaPath path, String property,
+                            String defaultValue) {
+        var pathOverrides = overrides.get(path);
+        if (pathOverrides != null && pathOverrides.containsKey(property)) {
+            return pathOverrides.get(property).toString();
+        }
+        return defaultValue;
+    }
+
+    @Override
+    public PrimitiveStyle primitiveStyle(SchemaPath path) {
+        return style.style(new Primitive(path.leaf()));
+    }
+
+    @Override
+    public RelationStyle relationStyle(SchemaPath path) {
+        return style.style(new Relation(path.leaf()));
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutStylesheet.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutStylesheet.java
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+
+/**
+ * Abstraction for layout property lookup by schema path. Enables per-path
+ * property overrides beyond what CSS alone provides.
+ *
+ * @see SchemaPath
+ * @see DefaultLayoutStylesheet
+ */
+public interface LayoutStylesheet {
+
+    double getDouble(SchemaPath path, String property, double defaultValue);
+
+    int getInt(SchemaPath path, String property, int defaultValue);
+
+    String getString(SchemaPath path, String property, String defaultValue);
+
+    PrimitiveStyle primitiveStyle(SchemaPath path);
+
+    RelationStyle relationStyle(SchemaPath path);
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -394,11 +394,16 @@ public final class RelationLayout extends SchemaNodeLayout {
         int singularChildren = 0;
         maxCardinality = datum.size();
 
+        SchemaPath parentPath = getSchemaPath();
         for (SchemaNode child : getNode().getChildren()) {
             Fold fold = model.layout(child)
                              .fold(datum, extractor, model);
-            children.add(fold.layout());
-            columnWidth = Style.snap(Math.max(columnWidth, fold.layout()
+            SchemaNodeLayout childLayout = fold.layout();
+            if (parentPath != null) {
+                childLayout.setSchemaPath(parentPath.child(child.getField()));
+            }
+            children.add(childLayout);
+            columnWidth = Style.snap(Math.max(columnWidth, childLayout
                                                                .measure(fold.datum(),
                                                                         n -> n,
                                                                         model)));

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
@@ -140,6 +140,7 @@ public abstract sealed class SchemaNodeLayout permits PrimitiveLayout, RelationL
 
     protected final SchemaNode node;
     protected boolean          rootLevel;
+    private SchemaPath         schemaPath;
 
     public SchemaNodeLayout(SchemaNode node, LabelStyle labelStyle) {
         this.node = node;
@@ -234,6 +235,14 @@ public abstract sealed class SchemaNodeLayout permits PrimitiveLayout, RelationL
     public abstract SchemaNode getNode();
 
     public abstract MeasureResult getMeasureResult();
+
+    public SchemaPath getSchemaPath() {
+        return schemaPath;
+    }
+
+    public void setSchemaPath(SchemaPath schemaPath) {
+        this.schemaPath = schemaPath;
+    }
 
     abstract public double justify(double justified);
 

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SchemaPath.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SchemaPath.java
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable path addressing a schema node within a schema tree.
+ * Solves the field-name uniqueness problem (RF-3): the same field name
+ * can appear at multiple nesting levels, but each SchemaPath is unique.
+ *
+ * @see com.chiralbehaviors.layout.schema.SchemaNode
+ */
+public record SchemaPath(List<String> segments) {
+
+    public SchemaPath {
+        segments = List.copyOf(Objects.requireNonNull(segments));
+    }
+
+    public SchemaPath(String root) {
+        this(List.of(root));
+    }
+
+    public SchemaPath child(String field) {
+        var extended = new ArrayList<>(segments);
+        extended.add(field);
+        return new SchemaPath(extended);
+    }
+
+    public String leaf() {
+        return segments.getLast();
+    }
+
+    /**
+     * CSS class uses the leaf field name for backward compatibility.
+     * Different nodes with the same field name get the same CSS rules.
+     */
+    public String cssClass() {
+        return leaf();
+    }
+
+    @Override
+    public String toString() {
+        return String.join("/", segments);
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SchemaPathTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SchemaPathTest.java
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class SchemaPathTest {
+
+    @Test
+    void rootPath() {
+        var path = new SchemaPath("root");
+        assertEquals(List.of("root"), path.segments());
+        assertEquals("root", path.leaf());
+        assertEquals("root", path.cssClass());
+        assertEquals("root", path.toString());
+    }
+
+    @Test
+    void childPath() {
+        var root = new SchemaPath("catalog");
+        var child = root.child("name");
+        assertEquals(List.of("catalog", "name"), child.segments());
+        assertEquals("name", child.leaf());
+        assertEquals("name", child.cssClass());
+        assertEquals("catalog/name", child.toString());
+    }
+
+    @Test
+    void deepNesting() {
+        var path = new SchemaPath("root").child("items").child("name");
+        assertEquals(List.of("root", "items", "name"), path.segments());
+        assertEquals("name", path.leaf());
+        assertEquals("root/items/name", path.toString());
+    }
+
+    @Test
+    void sameFieldDifferentPathsNotEqual() {
+        var path1 = new SchemaPath("root").child("name");
+        var path2 = new SchemaPath("root").child("items").child("name");
+        assertNotEquals(path1, path2,
+                        "Same field at different nesting levels must be different paths");
+        // But same CSS class
+        assertEquals(path1.cssClass(), path2.cssClass());
+    }
+
+    @Test
+    void equalPathsAreEqual() {
+        var path1 = new SchemaPath("root").child("name");
+        var path2 = new SchemaPath("root").child("name");
+        assertEquals(path1, path2);
+        assertEquals(path1.hashCode(), path2.hashCode());
+    }
+
+    @Test
+    void immutableSegments() {
+        var path = new SchemaPath("root");
+        assertThrows(UnsupportedOperationException.class,
+                     () -> path.segments().add("x"));
+    }
+
+    @Test
+    void schemaPathWiredThroughMeasure() {
+        var schema = new com.chiralbehaviors.layout.schema.Relation("catalog");
+        schema.addChild(new com.chiralbehaviors.layout.schema.Primitive("name"));
+        schema.addChild(new com.chiralbehaviors.layout.schema.Primitive("code"));
+
+        var relStyle = TestLayouts.mockRelationStyle();
+        var primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        var model = org.mockito.Mockito.mock(com.chiralbehaviors.layout.style.Style.class);
+        for (var child : schema.getChildren()) {
+            if (child instanceof com.chiralbehaviors.layout.schema.Primitive p) {
+                var pl = new PrimitiveLayout(p, primStyle);
+                org.mockito.Mockito.when(model.layout(p)).thenReturn(pl);
+            }
+        }
+        org.mockito.Mockito.when(model.layout(
+            org.mockito.ArgumentMatchers.any(com.chiralbehaviors.layout.schema.SchemaNode.class)))
+            .thenAnswer(inv -> {
+                var n = inv.getArgument(0);
+                if (n instanceof com.chiralbehaviors.layout.schema.Primitive p)
+                    return model.layout(p);
+                return model.layout((com.chiralbehaviors.layout.schema.Relation) n);
+            });
+
+        var layout = new RelationLayout(schema, relStyle);
+        layout.setSchemaPath(new SchemaPath("catalog"));
+
+        var data = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.arrayNode();
+        var row = com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.objectNode();
+        row.put("name", "Alice");
+        row.put("code", "A1");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+
+        assertEquals(new SchemaPath("catalog"), layout.getSchemaPath());
+        assertEquals(2, layout.children.size());
+        assertEquals(new SchemaPath("catalog").child("name"),
+                     layout.children.get(0).getSchemaPath());
+        assertEquals(new SchemaPath("catalog").child("code"),
+                     layout.children.get(1).getSchemaPath());
+    }
+
+    @Test
+    void defaultStylesheetOverrides() {
+        var stylesheet = new DefaultLayoutStylesheet(new com.chiralbehaviors.layout.style.Style());
+        var path = new SchemaPath("root").child("name");
+
+        assertEquals(42.0, stylesheet.getDouble(path, "width", 42.0),
+                     "No override should return default");
+
+        stylesheet.setOverride(path, "width", 100.0);
+        assertEquals(100.0, stylesheet.getDouble(path, "width", 42.0),
+                     "Override should take precedence");
+
+        stylesheet.clearOverrides();
+        assertEquals(42.0, stylesheet.getDouble(path, "width", 42.0),
+                     "After clear, default should return");
+    }
+}


### PR DESCRIPTION
## Summary
- **C1**: SchemaPath record for tree-position-aware node addressing (solves RF-3 field name uniqueness)
- **C2**: Wire SchemaPath through measure traversal — AutoLayout sets root, RelationLayout propagates to children
- **C1**: LayoutStylesheet interface + DefaultLayoutStylesheet with per-path property overrides

## Test plan
- [x] 8 new tests (path construction, equality, immutability, disambiguation, measure wiring, overrides)
- [x] 164 tests pass

References: Kramer-7wm (C1), Kramer-6un (C2), RDR-009