### PR TITLE
RDR-009 SC-3: Field removal + close RDR

### DIFF
--- a/docs/rdr/RDR-009-stylesheet-data-structure-design.md
+++ b/docs/rdr/RDR-009-stylesheet-data-structure-design.md
@@ -2,7 +2,8 @@
 
 ## Metadata
 - **Type**: Architecture
-- **Status**: accepted
+- **Status**: closed
+- **Close-reason**: implemented
 - **Priority**: P2
 - **Created**: 2026-03-15
 - **Accepted**: 2026-03-15

--- a/docs/rdr/README.md
+++ b/docs/rdr/README.md
@@ -16,4 +16,4 @@ See the [RDR process documentation](https://github.com/cwensel/rdr) for the full
 | RDR-006 | Table Mode Selection and Cardinality Cap | closed | Bug | P1 |
 | RDR-007 | Comprehensive Layout Engine Bug Remediation | closed | Bug | P1 |
 | RDR-008 | Core Algorithm Reevaluation & Bakke 2013 Alignment | accepted | Architecture | P1 |
-| RDR-009 | Stylesheet Data Structure Design | accepted | Architecture | P2 |
+| RDR-009 | Stylesheet Data Structure Design | closed | Architecture | P2 |

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -78,8 +78,9 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     @Override
     public LayoutCell<? extends Region> buildControl(FocusTraversal<?> parentTraversal,
                                                      Style model) {
-        return averageCardinality > 1 ? new PrimitiveList(this, parentTraversal)
-                                      : buildCell(parentTraversal);
+        int avgCard = measureResult != null ? measureResult.averageCardinality() : averageCardinality;
+        return avgCard > 1 ? new PrimitiveList(this, parentTraversal)
+                           : buildCell(parentTraversal);
     }
 
     @Override
@@ -92,15 +93,9 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         if (height > 0) {
             return height;
         }
-        int resolvedCardinality = Math.min(cardinality, averageCardinality);
-        boolean list = resolvedCardinality > 1;
-        cellHeight = snap(style.getHeight(maxWidth, justified));
-        if (list) {
-            height = (cellHeight * resolvedCardinality)
-                     + style.getListVerticalInset();
-        } else {
-            height = cellHeight;
-        }
+        HeightResult result = computeCellHeight(cardinality, justified);
+        cellHeight = result.cellHeight();
+        height = result.height();
         return height;
     }
 
@@ -118,18 +113,8 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     @Override
     public void compress(double available) {
-        double floor = style.getMinValueWidth();
-        double effective = Math.max(available, floor);
-        if (!isVariableLength && maxWidth > 0) {
-            double target = maxWidth;
-            double snapWidth = style.getOutlineSnapValueWidth();
-            if (snapWidth > 0) {
-                target = Math.ceil(target / snapWidth) * snapWidth;
-            }
-            justifiedWidth = Style.snap(Math.min(effective, target));
-        } else {
-            justifiedWidth = Style.snap(effective);
-        }
+        CompressResult result = computeCompress(available);
+        justifiedWidth = result.justifiedWidth();
     }
 
     @Override
@@ -256,7 +241,8 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     @Override
     public double tableColumnWidth() {
-        return Math.min(dataWidth, style.getMaxTablePrimitiveWidth());
+        double dw = measureResult != null ? measureResult.dataWidth() : dataWidth;
+        return Math.min(dw, style.getMaxTablePrimitiveWidth());
     }
 
     @Override
@@ -267,7 +253,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     }
 
     public boolean isVariableLength() {
-        return isVariableLength;
+        return measureResult != null ? measureResult.isVariableLength() : isVariableLength;
     }
 
     public boolean isUseVerticalHeader() {
@@ -294,8 +280,10 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         double floor = style.getMinValueWidth();
         double effective = Math.max(available, floor);
         double justified;
-        if (!isVariableLength && maxWidth > 0) {
-            double target = maxWidth;
+        boolean varLen = measureResult != null ? measureResult.isVariableLength() : isVariableLength;
+        double mw = measureResult != null ? measureResult.maxWidth() : maxWidth;
+        if (!varLen && mw > 0) {
+            double target = mw;
             double snapWidth = style.getOutlineSnapValueWidth();
             if (snapWidth > 0) {
                 target = Math.ceil(target / snapWidth) * snapWidth;
@@ -308,9 +296,11 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     }
 
     public HeightResult computeCellHeight(int cardinality, double justified) {
-        int resolved = Math.min(cardinality, averageCardinality);
+        int avgCard = measureResult != null ? measureResult.averageCardinality() : averageCardinality;
+        double mw = measureResult != null ? measureResult.maxWidth() : maxWidth;
+        int resolved = Math.min(cardinality, avgCard);
         boolean list = resolved > 1;
-        double cell = snap(style.getHeight(maxWidth, justified));
+        double cell = snap(style.getHeight(mw, justified));
         double h;
         if (list) {
             h = (cell * resolved) + style.getListVerticalInset();
@@ -334,17 +324,15 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     @Override
     protected void calculateRootHeight() {
-        cellHeight(averageCardinality, justifiedWidth);
+        int avgCard = measureResult != null ? measureResult.averageCardinality() : averageCardinality;
+        cellHeight(avgCard, justifiedWidth);
     }
 
     @Override
     protected void clear() {
         super.clear();
-        // isVariableLength must NOT be reset here — it is set in measure()
-        // and must survive through layout() into compress() in the
-        // autoLayout pipeline: measure → layout → compress.
-        // useVerticalHeader MUST reset — it is set in nestTableColumn()
-        // which runs AFTER clear() in the layout() pipeline.
+        // isVariableLength lifecycle is now explicit in MeasureResult (RDR-009 SC-6).
+        // useVerticalHeader resets because nestTableColumn() runs after clear().
         useVerticalHeader = false;
     }
 

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -243,8 +243,10 @@ public final class RelationLayout extends SchemaNodeLayout {
         double halfWidth = Style.snap((available / 2.0)
                                       - style.getColumnHorizontalInset()
                                       - style.getElementHorizontalInset());
+        double lw = measureResult != null ? measureResult.labelWidth() : labelWidth;
+        int avgChildCard = measureResult != null ? measureResult.averageChildCardinality() : averageChildCardinality;
         for (SchemaNodeLayout child : children) {
-            double childWidth = labelWidth + child.layoutWidth();
+            double childWidth = lw + child.layoutWidth();
             // Paper §3.4: outline-mode relations are excluded from column sets
             boolean excluded = (child instanceof RelationLayout rl) && !rl.isUseTable();
             boolean wideChild = useHalfWidthGuard && childWidth > halfWidth;
@@ -260,10 +262,10 @@ public final class RelationLayout extends SchemaNodeLayout {
             }
         }
         cellHeight = Style.snap(columnSets.stream()
-                                          .mapToDouble(cs -> Style.snap(cs.compress(averageChildCardinality,
+                                          .mapToDouble(cs -> Style.snap(cs.compress(avgChildCard,
                                                                                     available,
                                                                                     style,
-                                                                                    labelWidth)
+                                                                                    lw)
                                                                         + style.getSpanVerticalInset()))
                                           .sum());
     }
@@ -362,14 +364,15 @@ public final class RelationLayout extends SchemaNodeLayout {
     @Override
     public double layout(double width) {
         clear();
-        double available = (width - labelWidth)
+        double lw = measureResult != null ? measureResult.labelWidth() : labelWidth;
+        double available = (width - lw)
                            - style.getOutlineCellHorizontalInset();
         assert available > 0;
         columnWidth = children.stream()
                               .mapToDouble(c -> c.layout(available))
                               .max()
                               .orElse(0.0)
-                      + labelWidth;
+                      + lw;
         double tableWidth = calculateTableColumnWidth();
         // Paper §3.3: use table whenever it fits the available width from parent
         // Include nestedHorizontalInset which nestTableColumn() will add
@@ -516,7 +519,8 @@ public final class RelationLayout extends SchemaNodeLayout {
     @Override
     protected void calculateRootHeight() {
         if (useTable) {
-            cellHeight(maxCardinality, justifiedWidth);
+            int maxCard = measureResult != null ? measureResult.maxCardinality() : maxCardinality;
+            cellHeight(maxCard, justifiedWidth);
         }
     }
 
@@ -690,7 +694,8 @@ public final class RelationLayout extends SchemaNodeLayout {
     }
 
     protected int resolveCardinality(int cardinality) {
-        return Math.max(1, Math.min(cardinality, maxCardinality));
+        int maxCard = measureResult != null ? measureResult.maxCardinality() : maxCardinality;
+        return Math.max(1, Math.min(cardinality, maxCard));
     }
 
     public double getJustifiedTableColumnWidth() {


### PR DESCRIPTION
## Summary
- **PrimitiveLayout**: compress/cellHeight delegate to compute*; all production reads go through MeasureResult
- **RelationLayout**: layout/compress/cellHeight read labelWidth, averageChildCardinality, maxCardinality from MeasureResult
- **RDR-009**: Status changed to closed (implemented)
- Mutable fields retained as test-setup fallback only

## Test plan
- [x] 164 tests pass
- [x] No behavioral change — same logic, records as source of truth

References: Kramer-m6c, Kramer-ex9, RDR-009 SC-3