### PR TITLE
Fix cursor recovery, add getBoolean(), correct RDR docs

### DIFF
--- a/docs/rdr/RDR-015-alternative-rendering-modes.md
+++ b/docs/rdr/RDR-015-alternative-rendering-modes.md
@@ -93,7 +93,7 @@ The sub-record is stored in `MeasureResult` and persists across resize cycles, c
 BAR mode height = one label line height (single-line, no wrapping). This is consistent with `PrimitiveTextStyle.getHeight(maxWidth, justified)` when `maxWidth <= justified` (no wrapping needed). `computeCellHeight()` dispatches on render mode:
 
 ```java
-case BAR -> snap(style.getSingleLineHeight());  // fixed: one line, no wrapping
+case BAR -> snap(style.getHeight(0, justified));  // fixed: one line via labelStyle.getHeight()
 case TEXT -> snap(style.getHeight(maxWidth, justified));  // existing wrapping logic
 ```
 

--- a/docs/rdr/RDR-019-tufte-sparkline-rendering.md
+++ b/docs/rdr/RDR-019-tufte-sparkline-rendering.md
@@ -87,28 +87,30 @@ public class PrimitiveSparklineStyle extends PrimitiveStyle {
     // "sparkline-line-width" — double, stroke width in pixels (default: 1.0)
     // "sparkline-band-opacity" — double, IQR band fill opacity (default: 0.15)
 
+    // NOTE: Real signature is build(FocusTraversal<?> pt, PrimitiveLayout p).
+    // Data arrives later via updateItem(JsonNode). The cell must render the
+    // sparkline inside updateItem(), not build(). Pseudocode below shows the
+    // rendering logic that goes in the cell's updateItem() method.
+
     @Override
-    public Node build(JsonNode data, PrimitiveLayout layout) {
-        if (!data.isArray()) return fallbackToText(data, layout);
-
-        double[] values = extractNumericSeries(data);
-        SparklineStats stats = layout.getMeasureResult().sparklineStats();
-
-        // Create Polyline scaled to cell dimensions:
-        // x: evenly spaced across justifiedWidth
-        // y: scaled between seriesMin -> seriesMax within cellHeight
-        Polyline line = new Polyline();
-        // ... scale and populate points
-
-        // Tufte band (IQR reference):
-        Rectangle band = new Rectangle(0, yQ3, width, yQ1 - yQ3);
-        band.setOpacity(bandOpacity);
-
-        // End marker:
-        Circle endDot = new Circle(xLast, yLast, 1.5);
-
-        return new StackPane(band, line, endDot);
+    public LayoutCell<?> build(FocusTraversal<?> pt, PrimitiveLayout layout) {
+        return new SparklineCell(layout, pt);
     }
+
+    // Inside SparklineCell.updateItem(JsonNode item):
+    //   if (!item.isArray()) { fallbackToText(item); return; }
+    //   double[] values = extractNumericSeries(item);
+    //   SparklineStats stats = layout.getMeasureResult().sparklineStats();
+    //
+    //   Polyline line = new Polyline();
+    //   // x: evenly spaced across justifiedWidth
+    //   // y: scaled between seriesMin -> seriesMax within cellHeight
+    //
+    //   Rectangle band = new Rectangle(0, yQ3, width, yQ1 - yQ3);
+    //   band.setOpacity(bandOpacity);
+    //
+    //   Circle endDot = new Circle(xLast, yLast, 1.5);
+    //   getChildren().setAll(band, line, endDot);
 }
 ```
 

--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -201,6 +201,8 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
             return;
         }
         LayoutCell<?> old = control;
+        // Save cursor state before unbind (which nulls it)
+        var savedCursor = controller.getCursorState();
         // Clear old keyboard bindings before rebuilding the control tree;
         // new VirtualFlows will re-register via bindKeyboard in their constructors.
         controller.unbind();
@@ -223,7 +225,7 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
 
         // Recover cursor position after layout rebuild.
         // Find the first VirtualFlow in the new tree for cursor recovery.
-        findVirtualFlow(node).ifPresent(controller::recoverCursor);
+        findVirtualFlow(node).ifPresent(vf -> controller.recoverCursor(savedCursor, vf));
     }
 
     /**

--- a/kramer/src/main/java/com/chiralbehaviors/layout/DefaultLayoutStylesheet.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/DefaultLayoutStylesheet.java
@@ -61,6 +61,16 @@ public class DefaultLayoutStylesheet implements LayoutStylesheet {
     }
 
     @Override
+    public boolean getBoolean(SchemaPath path, String property,
+                              boolean defaultValue) {
+        var pathOverrides = overrides.get(path);
+        if (pathOverrides != null && pathOverrides.containsKey(property)) {
+            return (Boolean) pathOverrides.get(property);
+        }
+        return defaultValue;
+    }
+
+    @Override
     public PrimitiveStyle primitiveStyle(SchemaPath path) {
         return style.style(new Primitive(path.leaf()));
     }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutStylesheet.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutStylesheet.java
@@ -19,6 +19,8 @@ public interface LayoutStylesheet {
 
     String getString(SchemaPath path, String property, String defaultValue);
 
+    boolean getBoolean(SchemaPath path, String property, boolean defaultValue);
+
     PrimitiveStyle primitiveStyle(SchemaPath path);
 
     RelationStyle relationStyle(SchemaPath path);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/cell/control/FocusController.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/cell/control/FocusController.java
@@ -105,6 +105,10 @@ public class FocusController<C extends LayoutCell<?>>
     private volatile FocusTraversalNode<?> current;
     private volatile CursorState           cursorState;
 
+    public CursorState getCursorState() {
+        return cursorState;
+    }
+
     private final List<Node>               boundNodes = new ArrayList<>();
     private final Node                     node;
 
@@ -192,16 +196,18 @@ public class FocusController<C extends LayoutCell<?>>
      * Recover cursor position after a layout rebuild. Called by AutoLayout
      * after autoLayout() replaces the control tree. Re-derives scene position
      * from the stored data identity by scanning the new VirtualFlow's items.
+     *
+     * @param saved the cursor state captured before unbind(); may be null
+     * @param newFlow the new VirtualFlow to recover into
      */
-    public void recoverCursor(VirtualFlow<?> newFlow) {
-        CursorState cs = cursorState;
-        if (cs == null || newFlow == null) {
+    public void recoverCursor(CursorState saved, VirtualFlow<?> newFlow) {
+        if (saved == null || newFlow == null) {
             return;
         }
         // Find the item by identity in the new flow
         var items = newFlow.getItems();
         for (int i = 0; i < items.size(); i++) {
-            if (items.get(i) == cs.dataIdentity()) {
+            if (items.get(i) == saved.dataIdentity()) {
                 newFlow.show(i);
                 selectCellAt(newFlow, i);
                 return;
@@ -211,9 +217,6 @@ public class FocusController<C extends LayoutCell<?>>
         cursorState = null;
     }
 
-    CursorState getCursorState() {
-        return cursorState;
-    }
 
     void setCursorState(CursorState state) {
         this.cursorState = state;

--- a/kramer/src/test/java/com/chiralbehaviors/layout/StylesheetPropertyTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/StylesheetPropertyTest.java
@@ -728,6 +728,22 @@ class StylesheetPropertyTest {
                      "After clear, getString should return default");
     }
 
+    @Test
+    void defaultLayoutStylesheetGetBooleanDefault() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("root");
+        assertFalse(sheet.getBoolean(path, "hide-if-empty", false));
+        assertTrue(sheet.getBoolean(path, "visible", true));
+    }
+
+    @Test
+    void defaultLayoutStylesheetGetBooleanOverride() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("root");
+        sheet.setOverride(path, "hide-if-empty", true);
+        assertTrue(sheet.getBoolean(path, "hide-if-empty", false));
+    }
+
     /**
      * F4: Snap disabled (default 0.0) should behave like before.
      */

--- a/kramer/src/test/java/com/chiralbehaviors/layout/cell/control/CursorNavigationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/cell/control/CursorNavigationTest.java
@@ -213,22 +213,21 @@ class CursorNavigationTest {
     void testRecoverCursorWithNullState_noOp() {
         assertNull(controller.getCursorState());
         VirtualFlow<?> vf = mock(VirtualFlow.class);
-        assertDoesNotThrow(() -> controller.recoverCursor(vf));
+        assertDoesNotThrow(() -> controller.recoverCursor(null, vf));
     }
 
     @Test
     void testRecoverCursorWithNullFlow_noOp() {
-        controller.setCursorState(new CursorState("data", null, 0,
-            new Point2D(100, 100), new BoundingBox(0, 0, 80, 30)));
-        assertDoesNotThrow(() -> controller.recoverCursor(null));
-        assertNotNull(controller.getCursorState(), "State should be preserved");
+        var saved = new CursorState("data", null, 0,
+            new Point2D(100, 100), new BoundingBox(0, 0, 80, 30));
+        assertDoesNotThrow(() -> controller.recoverCursor(saved, null));
     }
 
     @Test
     void testRecoverCursorClearsStateWhenIdentityNotFound() {
         JsonNode identity = TextNode.valueOf("missing");
-        controller.setCursorState(new CursorState(identity, null, 0,
-            new Point2D(100, 100), new BoundingBox(0, 0, 80, 30)));
+        var saved = new CursorState(identity, null, 0,
+            new Point2D(100, 100), new BoundingBox(0, 0, 80, 30));
 
         VirtualFlow<LayoutCell<?>> vf = mock(VirtualFlow.class);
         ObservableList<JsonNode> items = FXCollections.observableArrayList(
@@ -236,7 +235,7 @@ class CursorNavigationTest {
         when(vf.getItems()).thenReturn(items);
         when(vf.getItemCount()).thenReturn(2);
 
-        controller.recoverCursor(vf);
+        controller.recoverCursor(saved, vf);
         assertNull(controller.getCursorState(),
                    "cursorState should be cleared when identity is not found");
     }


### PR DESCRIPTION
## Summary
- **Cursor recovery bug fix** (Kramer-rdu): `unbind()` was nulling `cursorState` before `recoverCursor()` could use it. Now saves state to local before unbind, passes explicitly. Selection survives resize.
- **LayoutStylesheet.getBoolean()** (Kramer-4sg): Missing method that blocks RDR-014 and RDR-018 boolean property lookups. Added to interface + DefaultLayoutStylesheet.
- **RDR doc corrections**: RDR-015 `getSingleLineHeight()` → `style.getHeight(0, justified)`. RDR-019 `build()` signature corrected to real `(FocusTraversal, PrimitiveLayout)` with data via `updateItem()`.

## Test plan
- [x] 193 tests pass
- [x] 2 new getBoolean tests (default + override)
- [x] 3 cursor recovery tests updated for new signature
- [x] Bead Kramer-517 created for LayoutStylesheet pipeline wiring (future)

Ref: Kramer-rdu, Kramer-4sg