### PR TITLE
Wave 1 Batch 1: ContentWidthStats, sortFields, scroll fix, version counter, LayoutSearch, navigateTo

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -256,6 +256,16 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         return null;
     }
 
+    /**
+     * Returns the outermost VirtualFlow in the current control tree, if any.
+     * Useful for programmatic navigation via {@link FocusController#navigateTo}.
+     *
+     * @return the first VirtualFlow found by depth-first search, or empty
+     */
+    public Optional<VirtualFlow<?>> getOutermostVirtualFlow() {
+        return control == null ? Optional.empty() : findVirtualFlow(control.getNode());
+    }
+
     private Optional<VirtualFlow<?>> findVirtualFlow(javafx.scene.Node node) {
         if (node instanceof VirtualFlow<?> vf) {
             return Optional.of(vf);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/ContentWidthStats.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/ContentWidthStats.java
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+/**
+ * Statistical summary of observed content widths from the measure phase.
+ * Captures percentile data used by the adaptive layout algorithm to choose
+ * between outline and table rendering modes.
+ *
+ * @param p50Width     median (50th percentile) content width in pixels
+ * @param p90Width     90th percentile content width in pixels
+ * @param sampleCount  number of data values sampled
+ * @param converged    true when the sample set is stable enough to trust
+ */
+public record ContentWidthStats(double p50Width, double p90Width, int sampleCount, boolean converged) {
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/DefaultLayoutStylesheet.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/DefaultLayoutStylesheet.java
@@ -18,17 +18,25 @@ public class DefaultLayoutStylesheet implements LayoutStylesheet {
 
     private final Style style;
     private final Map<SchemaPath, Map<String, Object>> overrides = new HashMap<>();
+    private long version = 0;
 
     public DefaultLayoutStylesheet(Style style) {
         this.style = style;
     }
 
+    @Override
+    public long getVersion() {
+        return version;
+    }
+
     public void setOverride(SchemaPath path, String property, Object value) {
         overrides.computeIfAbsent(path, k -> new HashMap<>()).put(property, value);
+        version++;
     }
 
     public void clearOverrides() {
         overrides.clear();
+        version++;
     }
 
     @Override

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutSearch.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutSearch.java
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+/**
+ * Text search over the flat array of rows produced by a schema + data pair.
+ *
+ * <p>The search is row-major: for each row, primitive fields are visited in
+ * schema depth-first order. Matches are enumerated lazily by cursor position.
+ *
+ * <p>Flags:
+ * <ul>
+ *   <li>{@code caseSensitive} — default {@code false} (case-insensitive)</li>
+ *   <li>{@code wrapAround}    — default {@code true}  (wraps at end/start)</li>
+ * </ul>
+ */
+public class LayoutSearch {
+
+    private final SchemaNode root;
+    private final JsonNode   data;
+
+    private String  query;
+    private boolean caseSensitive = false;
+    private boolean wrapAround    = true;
+
+    /** Index into the full match list; -1 means "before first findNext". */
+    private int cursor = -1;
+
+    /** Cached list of all matches for the current query. Invalidated on query change. */
+    private List<SearchResult> matchCache;
+
+    public LayoutSearch(SchemaNode root, JsonNode data) {
+        this.root = root;
+        this.data = data;
+    }
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+        invalidateCache();
+    }
+
+    public boolean isCaseSensitive() {
+        return caseSensitive;
+    }
+
+    public void setCaseSensitive(boolean caseSensitive) {
+        this.caseSensitive = caseSensitive;
+        invalidateCache();
+    }
+
+    public boolean isWrapAround() {
+        return wrapAround;
+    }
+
+    public void setWrapAround(boolean wrapAround) {
+        this.wrapAround = wrapAround;
+    }
+
+    // -------------------------------------------------------------------------
+    // Search operations
+    // -------------------------------------------------------------------------
+
+    /**
+     * Advances to the next match and returns it. Returns {@link Optional#empty()}
+     * when the query is blank, there are no matches, or wrap-around is disabled
+     * and the end has been reached.
+     */
+    public Optional<SearchResult> findNext() {
+        if (isBlankQuery()) {
+            return Optional.empty();
+        }
+        List<SearchResult> matches = getMatches();
+        if (matches.isEmpty()) {
+            return Optional.empty();
+        }
+        int next = cursor + 1;
+        if (next >= matches.size()) {
+            if (!wrapAround) {
+                return Optional.empty();
+            }
+            next = 0;
+        }
+        cursor = next;
+        return Optional.of(matches.get(cursor));
+    }
+
+    /**
+     * Moves to the previous match and returns it. Returns {@link Optional#empty()}
+     * when the query is blank or there are no matches.
+     */
+    public Optional<SearchResult> findPrevious() {
+        if (isBlankQuery()) {
+            return Optional.empty();
+        }
+        List<SearchResult> matches = getMatches();
+        if (matches.isEmpty()) {
+            return Optional.empty();
+        }
+        int prev = cursor - 1;
+        if (prev < 0) {
+            if (!wrapAround) {
+                return Optional.empty();
+            }
+            prev = matches.size() - 1;
+        }
+        cursor = prev;
+        return Optional.of(matches.get(cursor));
+    }
+
+    /**
+     * Returns the total number of matches across all rows and fields for the
+     * current query.
+     */
+    public int countMatches() {
+        if (isBlankQuery()) {
+            return 0;
+        }
+        return getMatches().size();
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    private boolean isBlankQuery() {
+        return query == null || query.isBlank();
+    }
+
+    private void invalidateCache() {
+        matchCache = null;
+        cursor = -1;
+    }
+
+    private List<SearchResult> getMatches() {
+        if (matchCache == null) {
+            matchCache = buildMatches();
+        }
+        return matchCache;
+    }
+
+    /**
+     * Builds the full ordered list of matches for the current query.
+     * Guard: if data is not an array, returns an empty list.
+     */
+    private List<SearchResult> buildMatches() {
+        if (data == null || !data.isArray()) {
+            return List.of();
+        }
+        ArrayNode array = (ArrayNode) data;
+        String needle = caseSensitive ? query : query.toLowerCase();
+
+        List<SchemaPath> primitiveFields = new ArrayList<>();
+        collectPrimitiveFields(root, new SchemaPath(root.getField()), primitiveFields);
+
+        List<SearchResult> results = new ArrayList<>();
+        for (int rowIdx = 0; rowIdx < array.size(); rowIdx++) {
+            JsonNode row = array.get(rowIdx);
+            for (SchemaPath fieldPath : primitiveFields) {
+                // Navigate to the field value using the path segments relative to root
+                // The path starts with the root field name, so skip segment 0 when extracting
+                JsonNode value = extractValue(row, fieldPath);
+                String text = SchemaNode.asText(value);
+                if (text == null || text.isEmpty()) {
+                    continue;
+                }
+                String haystack = caseSensitive ? text : text.toLowerCase();
+                int idx = haystack.indexOf(needle);
+                if (idx >= 0) {
+                    results.add(new SearchResult(fieldPath, rowIdx, text, idx, needle.length()));
+                }
+            }
+        }
+        return results;
+    }
+
+    /**
+     * Walks the schema tree depth-first and collects paths to all Primitive leaves.
+     */
+    private void collectPrimitiveFields(SchemaNode node, SchemaPath path,
+                                        List<SchemaPath> out) {
+        if (node instanceof Primitive) {
+            out.add(path);
+        } else if (node instanceof Relation relation) {
+            for (SchemaNode child : relation.getChildren()) {
+                collectPrimitiveFields(child, path.child(child.getField()), out);
+            }
+        }
+    }
+
+    /**
+     * Extracts the value for a given field path from a single row object.
+     * The path segments include the root segment at index 0, which corresponds to
+     * the top-level array element, so we start navigation from segment 1.
+     */
+    private JsonNode extractValue(JsonNode row, SchemaPath fieldPath) {
+        List<String> segments = fieldPath.segments();
+        // segments[0] is the root field name (the array field); row is already one element
+        // so we navigate from segments[1] onward
+        JsonNode current = row;
+        for (int i = 1; i < segments.size(); i++) {
+            if (current == null || current.isNull()) {
+                return null;
+            }
+            current = current.get(segments.get(i));
+        }
+        return current;
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutStylesheet.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutStylesheet.java
@@ -13,6 +13,8 @@ import com.chiralbehaviors.layout.style.RelationStyle;
  */
 public interface LayoutStylesheet {
 
+    long getVersion();
+
     double getDouble(SchemaPath path, String property, double defaultValue);
 
     int getInt(SchemaPath path, String property, int defaultValue);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
@@ -22,7 +22,8 @@ public record MeasureResult(
     int averageChildCardinality,
     int maxCardinality,
     Function<JsonNode, JsonNode> extractor,
-    List<MeasureResult> childResults
+    List<MeasureResult> childResults,
+    ContentWidthStats contentStats
 ) {
     public MeasureResult {
         childResults = childResults == null ? List.of() : List.copyOf(childResults);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/NavigationPath.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/NavigationPath.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+/**
+ * Represents a navigable path through the layout, used for selection and
+ * cursor positioning. Each step identifies a field and the row within it.
+ */
+public record NavigationPath(List<NavigationStep> steps) {
+
+    public NavigationPath {
+        steps = List.copyOf(steps);
+    }
+
+    /**
+     * A single step: the schema field and the row index within that field's data.
+     */
+    public record NavigationStep(SchemaPath field, int rowIndex) {
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -198,7 +198,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         measureResult = new MeasureResult(
             labelWidth, columnWidth, dataWidth, maxWidth,
             averageCardinality, isVariableLength,
-            0, 0, null, List.of()
+            0, 0, null, List.of(), null
         );
 
         return columnWidth;

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -445,7 +445,7 @@ public final class RelationLayout extends SchemaNodeLayout {
             labelWidth, columnWidth, 0, 0,
             0, false,
             averageChildCardinality, maxCardinality,
-            extractor, childResults
+            extractor, childResults, null
         );
 
         return columnWidth + style.getElementHorizontalInset()

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SearchResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SearchResult.java
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+/**
+ * Identifies a single text match within the layout data.
+ *
+ * @param path         the schema path of the field that contains the match
+ * @param rowIndex     the zero-based row index within the array data
+ * @param matchedValue the full cell value in which the match was found
+ * @param matchStart   the start offset of the match within matchedValue
+ * @param matchLength  the length of the matched substring
+ */
+public record SearchResult(SchemaPath path, int rowIndex, String matchedValue,
+                           int matchStart, int matchLength) {
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/cell/control/FocusController.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/cell/control/FocusController.java
@@ -386,6 +386,18 @@ public class FocusController<C extends LayoutCell<?>>
     }
 
     /**
+     * Navigate to the cell at the given index in the VirtualFlow, updating
+     * both the selection model and the cursor state. Public entry point for
+     * programmatic navigation.
+     *
+     * @param vf    the VirtualFlow to navigate within
+     * @param index the zero-based cell index to select
+     */
+    public void navigateTo(VirtualFlow<?> vf, int index) {
+        selectCellAt(vf, index);
+    }
+
+    /**
      * Select a cell at the given index in the VirtualFlow, updating both
      * the selection model and the cursor state.
      */

--- a/kramer/src/main/java/com/chiralbehaviors/layout/outline/Outline.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/outline/Outline.java
@@ -19,6 +19,7 @@ package com.chiralbehaviors.layout.outline;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.OptionalInt;
 
 import com.chiralbehaviors.layout.ColumnSet;
 import com.chiralbehaviors.layout.RelationLayout;
@@ -75,11 +76,14 @@ public class Outline extends VirtualFlow<OutlineCell> {
 
     @Override
     public void updateItem(JsonNode item) {
+        OptionalInt savedIndex = getFirstVisibleIndex();
         List<JsonNode> list = SchemaNode.asList(item);
         items.setAll(list);
-        // Reset scroll to top after populating items
         if (!items.isEmpty()) {
-            showAsFirst(0);
+            savedIndex.ifPresentOrElse(
+                idx -> showAsFirst(Math.min(idx, items.size() - 1)),
+                () -> showAsFirst(0)
+            );
         }
         pseudoClassStateChanged(PSEUDO_CLASS_FILLED, item != null);
         pseudoClassStateChanged(PSEUDO_CLASS_EMPTY, item == null);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/schema/Relation.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/schema/Relation.java
@@ -26,9 +26,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  */
 public non-sealed class Relation extends SchemaNode {
-    private boolean                autoFold = true;
-    private final List<SchemaNode> children = new ArrayList<>();
+    private boolean                autoFold   = true;
+    private boolean                autoSort   = false;
+    private final List<SchemaNode> children   = new ArrayList<>();
     private Relation               fold;
+    private List<String>           sortFields = List.of();
 
     public Relation(String label) {
         super(label);
@@ -80,6 +82,22 @@ public non-sealed class Relation extends SchemaNode {
         this.fold = (fold && children.size() == 1
                      && children.get(0) instanceof Relation r) ? r
                                                                : null;
+    }
+
+    public List<String> getSortFields() {
+        return sortFields;
+    }
+
+    public boolean isAutoSort() {
+        return autoSort;
+    }
+
+    public void setAutoSort(boolean autoSort) {
+        this.autoSort = autoSort;
+    }
+
+    public void setSortFields(List<String> sortFields) {
+        this.sortFields = sortFields == null ? List.of() : List.copyOf(sortFields);
     }
 
     @Override

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedRow.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedRow.java
@@ -17,6 +17,7 @@
 package com.chiralbehaviors.layout.table;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 
 import com.chiralbehaviors.layout.RelationLayout;
 import com.chiralbehaviors.layout.SchemaPath;
@@ -78,10 +79,13 @@ public class NestedRow extends VirtualFlow<NestedCell> {
 
     @Override
     public void updateItem(JsonNode item) {
+        OptionalInt savedIndex = getFirstVisibleIndex();
         items.setAll(NestedTable.itemsAsArray(item));
-        // Reset scroll to top after populating items
         if (!items.isEmpty()) {
-            showAsFirst(0);
+            savedIndex.ifPresentOrElse(
+                idx -> showAsFirst(Math.min(idx, items.size() - 1)),
+                () -> showAsFirst(0)
+            );
         }
         getNode().pseudoClassStateChanged(PSEUDO_CLASS_FILLED, item != null);
         getNode().pseudoClassStateChanged(PSEUDO_CLASS_EMPTY, item == null);

--- a/kramer/src/test/java/com/chiralbehaviors/layout/ContentWidthStatsTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/ContentWidthStatsTest.java
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import static org.mockito.Mockito.mock;
+
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Tests for ContentWidthStats record and its integration into MeasureResult.
+ */
+class ContentWidthStatsTest {
+
+    // --- ContentWidthStats record construction and accessors ---
+
+    @Test
+    void constructionAndAccessors() {
+        ContentWidthStats stats = new ContentWidthStats(42.0, 95.0, 100, true);
+
+        assertEquals(42.0, stats.p50Width());
+        assertEquals(95.0, stats.p90Width());
+        assertEquals(100, stats.sampleCount());
+        assertTrue(stats.converged());
+    }
+
+    @Test
+    void notConverged() {
+        ContentWidthStats stats = new ContentWidthStats(10.0, 20.0, 5, false);
+
+        assertFalse(stats.converged());
+        assertEquals(5, stats.sampleCount());
+    }
+
+    @Test
+    void zeroSampleCount() {
+        ContentWidthStats stats = new ContentWidthStats(0.0, 0.0, 0, false);
+
+        assertEquals(0, stats.sampleCount());
+        assertEquals(0.0, stats.p50Width());
+        assertEquals(0.0, stats.p90Width());
+    }
+
+    @Test
+    void equalityAndHashCode() {
+        ContentWidthStats a = new ContentWidthStats(50.0, 90.0, 10, true);
+        ContentWidthStats b = new ContentWidthStats(50.0, 90.0, 10, true);
+        ContentWidthStats c = new ContentWidthStats(50.0, 90.0, 10, false);
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
+
+    // --- MeasureResult backward compatibility: null contentStats ---
+
+    @Test
+    void measureResultWithNullContentStats() {
+        MeasureResult result = new MeasureResult(
+            10.0, 20.0, 15.0, 25.0,
+            1, false,
+            0, 0,
+            null, List.of(),
+            null
+        );
+
+        assertNull(result.contentStats(),
+                   "contentStats should be null when not provided");
+        assertEquals(10.0, result.labelWidth());
+        assertEquals(20.0, result.columnWidth());
+    }
+
+    @Test
+    void measureResultWithContentStats() {
+        ContentWidthStats stats = new ContentWidthStats(30.0, 60.0, 50, true);
+        MeasureResult result = new MeasureResult(
+            10.0, 20.0, 15.0, 25.0,
+            1, false,
+            0, 0,
+            null, List.of(),
+            stats
+        );
+
+        assertNotNull(result.contentStats());
+        assertEquals(stats, result.contentStats());
+        assertEquals(30.0, result.contentStats().p50Width());
+        assertEquals(60.0, result.contentStats().p90Width());
+        assertEquals(50, result.contentStats().sampleCount());
+        assertTrue(result.contentStats().converged());
+    }
+
+    @Test
+    void primitiveLayoutMeasureResultHasNullContentStats() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("value"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("hello");
+        data.add("world");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result);
+        assertNull(result.contentStats(),
+                   "PrimitiveLayout should pass null contentStats (not yet implemented)");
+    }
+
+    @Test
+    void relationLayoutMeasureResultHasNullContentStats() {
+        // Verify RelationLayout measure() produces null contentStats (placeholder)
+        // We check via a direct MeasureResult construction as RelationLayout
+        // integration tests already cover measure() invocation patterns.
+        MeasureResult result = new MeasureResult(
+            5.0, 10.0, 0.0, 0.0,
+            0, false,
+            2, 5,
+            Function.identity(), List.of(),
+            null
+        );
+
+        assertNull(result.contentStats(),
+                   "Relation MeasureResult should accept null contentStats");
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutSearchTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutSearchTest.java
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+class LayoutSearchTest {
+
+    private Relation schema;
+    private com.fasterxml.jackson.databind.node.ArrayNode data;
+
+    @BeforeEach
+    void setUp() {
+        schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("code"));
+
+        data = JsonNodeFactory.instance.arrayNode();
+        var row0 = JsonNodeFactory.instance.objectNode();
+        row0.put("name", "Alice");
+        row0.put("code", "A1");
+        data.add(row0);
+
+        var row1 = JsonNodeFactory.instance.objectNode();
+        row1.put("name", "Bob");
+        row1.put("code", "B2");
+        data.add(row1);
+
+        var row2 = JsonNodeFactory.instance.objectNode();
+        row2.put("name", "Alice B");
+        row2.put("code", "A3");
+        data.add(row2);
+    }
+
+    @Test
+    void nullQueryReturnsEmpty() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery(null);
+        assertEquals(Optional.empty(), search.findNext());
+    }
+
+    @Test
+    void blankQueryReturnsEmpty() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("   ");
+        assertEquals(Optional.empty(), search.findNext());
+    }
+
+    @Test
+    void emptyQueryReturnsEmpty() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("");
+        assertEquals(Optional.empty(), search.findNext());
+    }
+
+    @Test
+    void findNextReturnsFirstMatch() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("Alice");
+        Optional<SearchResult> result = search.findNext();
+        assertTrue(result.isPresent());
+        assertEquals(0, result.get().rowIndex());
+        assertEquals("Alice", result.get().matchedValue());
+        assertEquals(0, result.get().matchStart());
+        assertEquals(5, result.get().matchLength());
+    }
+
+    @Test
+    void findNextAdvancesToNextMatch() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("Alice");
+        search.findNext(); // row 0, name "Alice"
+        Optional<SearchResult> second = search.findNext();
+        assertTrue(second.isPresent());
+        // "Alice B" at row 2 is the next occurrence
+        assertEquals(2, second.get().rowIndex());
+        assertEquals("Alice B", second.get().matchedValue());
+        assertEquals(0, second.get().matchStart());
+    }
+
+    @Test
+    void findPreviousWrapsAround() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("Alice");
+        // Go to first match
+        search.findNext();
+        // Go backward from first match should wrap to last occurrence of "Alice"
+        Optional<SearchResult> prev = search.findPrevious();
+        assertTrue(prev.isPresent());
+        assertEquals(2, prev.get().rowIndex());
+    }
+
+    @Test
+    void findNextWrapsAround() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("Alice");
+        search.findNext(); // row 0
+        search.findNext(); // row 2
+        Optional<SearchResult> wrapped = search.findNext(); // should wrap to row 0
+        assertTrue(wrapped.isPresent());
+        assertEquals(0, wrapped.get().rowIndex());
+    }
+
+    @Test
+    void countMatchesReturnsTotalAcrossAllRowsAndFields() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("A");
+        // "Alice" in row 0 name -> "A" at index 0
+        // "A1"   in row 0 code -> "A" at index 0
+        // "Alice B" in row 2 name -> "A" at index 0
+        // "A3"   in row 2 code -> "A" at index 0
+        // Total = 4
+        assertEquals(4, search.countMatches());
+    }
+
+    @Test
+    void countMatchesNoMatch() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("zzz");
+        assertEquals(0, search.countMatches());
+    }
+
+    @Test
+    void caseSensitiveModeDistinguishesCasing() {
+        var search = new LayoutSearch(schema, data);
+        search.setCaseSensitive(true);
+        search.setQuery("alice"); // lowercase
+        assertEquals(0, search.countMatches());
+
+        search.setQuery("Alice");
+        assertEquals(2, search.countMatches()); // row0 name, row2 name
+    }
+
+    @Test
+    void caseInsensitiveModeDefault() {
+        var search = new LayoutSearch(schema, data);
+        // default is case-insensitive
+        search.setQuery("alice");
+        assertEquals(2, search.countMatches());
+    }
+
+    @Test
+    void nonArrayDataReturnsNoResults() {
+        var objectNode = JsonNodeFactory.instance.objectNode();
+        objectNode.put("name", "Alice");
+        objectNode.put("code", "A1");
+
+        var search = new LayoutSearch(schema, objectNode);
+        search.setQuery("Alice");
+        assertEquals(0, search.countMatches());
+        assertEquals(Optional.empty(), search.findNext());
+    }
+
+    @Test
+    void noMatchReturnsEmpty() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("zzz");
+        assertEquals(Optional.empty(), search.findNext());
+        assertEquals(Optional.empty(), search.findPrevious());
+    }
+
+    @Test
+    void schemaPathIsCorrect() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("A1");
+        Optional<SearchResult> result = search.findNext();
+        assertTrue(result.isPresent());
+        assertEquals(new SchemaPath("items").child("code"), result.get().path());
+        assertEquals(0, result.get().rowIndex());
+    }
+
+    @Test
+    void getQueryReflectsSetQuery() {
+        var search = new LayoutSearch(schema, data);
+        search.setQuery("test");
+        assertEquals("test", search.getQuery());
+    }
+
+    @Test
+    void wrapAroundCanBeDisabled() {
+        var search = new LayoutSearch(schema, data);
+        search.setWrapAround(false);
+        search.setQuery("Alice");
+        search.findNext(); // row 0
+        search.findNext(); // row 2
+        // No more matches and wrap is off
+        Optional<SearchResult> result = search.findNext();
+        assertEquals(Optional.empty(), result);
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/OutlineScrollPreservationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/OutlineScrollPreservationTest.java
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import com.chiralbehaviors.layout.cell.LayoutCell;
+import com.chiralbehaviors.layout.flowless.VirtualFlow;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+/**
+ * Tests that scroll position is preserved by the ifPresentOrElse pattern used
+ * in Outline.updateItem() and NestedRow.updateItem().
+ *
+ * These tests operate directly on VirtualFlow (the base class) to verify the
+ * scroll-preservation logic without requiring the full Outline/NestedRow
+ * constructor infrastructure. The pattern under test is:
+ *
+ *   OptionalInt saved = getFirstVisibleIndex();
+ *   items.setAll(newItems);
+ *   if (!items.isEmpty()) {
+ *       saved.ifPresentOrElse(
+ *           idx -> showAsFirst(Math.min(idx, items.size() - 1)),
+ *           () -> showAsFirst(0));
+ *   }
+ */
+@ExtendWith(ApplicationExtension.class)
+class OutlineScrollPreservationTest {
+
+    private static final double CELL_HEIGHT = 30.0;
+    private static final double CELL_WIDTH  = 300.0;
+    private static final double VF_HEIGHT   = 100.0;
+
+    private VirtualFlow<TestCell> vf;
+    private StackPane             root;
+
+    @Start
+    void start(Stage stage) {
+        root = new StackPane();
+        ObservableList<JsonNode> items = FXCollections.observableArrayList();
+        vf = new VirtualFlow<>("default.css", CELL_WIDTH, CELL_HEIGHT,
+                               items, (item, focus) -> new TestCell(CELL_WIDTH, CELL_HEIGHT),
+                               null, Collections.emptyList());
+        root.getChildren().add(vf);
+        stage.setScene(new Scene(root, CELL_WIDTH + 20, VF_HEIGHT));
+        stage.show();
+    }
+
+    /**
+     * First population: getFirstVisibleIndex() returns empty (nothing rendered),
+     * so ifPresentOrElse must call showAsFirst(0).
+     * After layout, first visible index should be 0.
+     */
+    @Test
+    void firstPopulation_showsFromZero() {
+        List<JsonNode> data = buildList(10);
+
+        runOnFxAndWait(() -> applyScrollPreservingUpdate(vf, data));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            OptionalInt idx = vf.getFirstVisibleIndex();
+            assertTrue(idx.isPresent(), "First visible index should be present after population");
+            assertEquals(0, idx.getAsInt(), "First population should start at index 0");
+        });
+    }
+
+    /**
+     * After scrolling to index 3, a second updateItem with the same-size data
+     * must preserve the scroll position at 3 (not reset to 0).
+     */
+    @Test
+    void updateItem_preservesScrollAfterScroll() {
+        List<JsonNode> data = buildList(10);
+
+        // Initial population
+        runOnFxAndWait(() -> applyScrollPreservingUpdate(vf, data));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Scroll to index 3
+        runOnFxAndWait(() -> vf.showAsFirst(3));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Confirm scroll position
+        runOnFxAndWait(() -> {
+            OptionalInt idx = vf.getFirstVisibleIndex();
+            assertTrue(idx.isPresent(), "Index should be present after scrolling");
+            assertEquals(3, idx.getAsInt(), "Should be at index 3 before second updateItem");
+        });
+
+        // Re-populate with same-size data (the key scenario)
+        runOnFxAndWait(() -> applyScrollPreservingUpdate(vf, buildList(10)));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Scroll position must be preserved
+        runOnFxAndWait(() -> {
+            OptionalInt idx = vf.getFirstVisibleIndex();
+            assertTrue(idx.isPresent(), "Index should be present after second updateItem");
+            assertEquals(3, idx.getAsInt(),
+                         "Scroll position should be preserved after updateItem with same-size data");
+        });
+    }
+
+    /**
+     * When new data has fewer items than the saved scroll index, the index must
+     * be clamped to items.size()-1 (no IndexOutOfBoundsException).
+     */
+    @Test
+    void updateItem_clampsIndexWhenDataShrinks() {
+        // Start with 10 items, scroll to index 7
+        runOnFxAndWait(() -> applyScrollPreservingUpdate(vf, buildList(10)));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> vf.showAsFirst(7));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Update with only 3 items — saved index 7 is out of range
+        runOnFxAndWait(() -> applyScrollPreservingUpdate(vf, buildList(3)));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            OptionalInt idx = vf.getFirstVisibleIndex();
+            assertTrue(idx.isPresent(), "Index should be present after shrink update");
+            assertTrue(idx.getAsInt() <= 2,
+                       "Index should be clamped to max valid (2) but was " + idx.getAsInt());
+        });
+    }
+
+    /**
+     * Empty item list: updateItem with null/empty data should not call showAsFirst.
+     * This verifies the !items.isEmpty() guard.
+     */
+    @Test
+    void updateItem_emptyData_noShowAsFirst() {
+        // Populate then clear
+        runOnFxAndWait(() -> applyScrollPreservingUpdate(vf, buildList(5)));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        // Update with empty list — should not throw, items should be empty
+        runOnFxAndWait(() -> applyScrollPreservingUpdate(vf, Collections.emptyList()));
+        WaitForAsyncUtils.waitForFxEvents();
+        runOnFxAndWait(() -> vf.layout());
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            assertEquals(0, vf.getItemCount(), "Item count should be 0 after empty update");
+        });
+    }
+
+    // ---- Helpers ----
+
+    /**
+     * Applies the scroll-preserving update pattern from Outline.updateItem()
+     * and NestedRow.updateItem().
+     */
+    private static void applyScrollPreservingUpdate(VirtualFlow<?> flow, List<JsonNode> newItems) {
+        OptionalInt savedIndex = flow.getFirstVisibleIndex();
+        flow.getItems().setAll(newItems);
+        if (!flow.getItems().isEmpty()) {
+            savedIndex.ifPresentOrElse(
+                idx -> flow.showAsFirst(Math.min(idx, flow.getItems().size() - 1)),
+                () -> flow.showAsFirst(0)
+            );
+        }
+    }
+
+    private static List<JsonNode> buildList(int size) {
+        ObjectMapper mapper = new ObjectMapper();
+        ArrayNode arr = mapper.createArrayNode();
+        for (int i = 0; i < size; i++) {
+            arr.add("item-" + i);
+        }
+        List<JsonNode> list = new ArrayList<>();
+        arr.forEach(list::add);
+        return list;
+    }
+
+    private static void runOnFxAndWait(Runnable action) {
+        if (Platform.isFxApplicationThread()) {
+            action.run();
+        } else {
+            CountDownLatch latch = new CountDownLatch(1);
+            Platform.runLater(() -> {
+                try {
+                    action.run();
+                } finally {
+                    latch.countDown();
+                }
+            });
+            try {
+                assertTrue(latch.await(5, TimeUnit.SECONDS),
+                           "Timed out waiting for FX thread");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted waiting for FX thread");
+            }
+        }
+    }
+
+    static class TestCell extends Pane implements LayoutCell<Pane> {
+        TestCell(double width, double height) {
+            setPrefSize(width, height);
+            setMinSize(width, height);
+            setMaxSize(width, height);
+        }
+
+        @Override
+        public Pane getNode() {
+            return this;
+        }
+
+        @Override
+        public boolean isReusable() {
+            return true;
+        }
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RelationSortFieldsTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RelationSortFieldsTest.java
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Relation;
+
+/**
+ * Tests for Relation.sortFields and Relation.autoSort properties.
+ */
+class RelationSortFieldsTest {
+
+    @Test
+    void sortFieldsDefaultsToEmptyList() {
+        var r = new Relation("items");
+        assertNotNull(r.getSortFields());
+        assertTrue(r.getSortFields().isEmpty());
+    }
+
+    @Test
+    void autoSortDefaultsFalse() {
+        var r = new Relation("items");
+        assertFalse(r.isAutoSort());
+    }
+
+    @Test
+    void setSortFieldsRoundtrip() {
+        var r = new Relation("items");
+        var fields = List.of("name", "age");
+        r.setSortFields(fields);
+        assertEquals(fields, r.getSortFields());
+    }
+
+    @Test
+    void setAutoSortRoundtrip() {
+        var r = new Relation("items");
+        r.setAutoSort(true);
+        assertTrue(r.isAutoSort());
+        r.setAutoSort(false);
+        assertFalse(r.isAutoSort());
+    }
+
+    @Test
+    void setSortFieldsToNullNormalizesToEmpty() {
+        var r = new Relation("items");
+        r.setSortFields(null);
+        assertNotNull(r.getSortFields());
+        assertTrue(r.getSortFields().isEmpty());
+    }
+
+    @Test
+    void sortFieldsListIsDefensiveCopy() {
+        var r = new Relation("items");
+        var fields = List.of("x", "y");
+        r.setSortFields(fields);
+        // Returned list is equal but independent (List.copyOf or similar)
+        assertEquals(fields, r.getSortFields());
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/StylesheetPropertyTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/StylesheetPropertyTest.java
@@ -744,6 +744,58 @@ class StylesheetPropertyTest {
         assertTrue(sheet.getBoolean(path, "hide-if-empty", false));
     }
 
+    // ---- Kramer-63n: Version counter ----
+
+    @Test
+    void versionStartsAtZero() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        assertEquals(0L, sheet.getVersion(), "Initial version should be 0");
+    }
+
+    @Test
+    void setOverrideIncrementsVersion() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("root");
+
+        sheet.setOverride(path, "minValueWidth", 50.0);
+        assertEquals(1L, sheet.getVersion(), "setOverride should increment version to 1");
+
+        sheet.setOverride(path, "bulletText", "•");
+        assertEquals(2L, sheet.getVersion(), "Second setOverride should increment version to 2");
+    }
+
+    @Test
+    void clearOverridesIncrementsVersion() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("root");
+
+        sheet.setOverride(path, "minValueWidth", 50.0);
+        long versionBefore = sheet.getVersion();
+
+        sheet.clearOverrides();
+        assertEquals(versionBefore + 1, sheet.getVersion(),
+                     "clearOverrides should increment version");
+    }
+
+    @Test
+    void multipleSetOverrideCallsIncrementMonotonically() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath pathA = new SchemaPath("a");
+        SchemaPath pathB = new SchemaPath("b");
+
+        long prev = sheet.getVersion();
+        for (int i = 0; i < 5; i++) {
+            sheet.setOverride(pathA, "prop", i);
+            long curr = sheet.getVersion();
+            assertTrue(curr > prev, "Version must increase monotonically at step " + i);
+            prev = curr;
+        }
+
+        sheet.setOverride(pathB, "other", "val");
+        assertTrue(sheet.getVersion() > prev,
+                   "Version must increase for override on different path");
+    }
+
     /**
      * F4: Snap disabled (default 0.0) should behave like before.
      */

--- a/kramer/src/test/java/com/chiralbehaviors/layout/cell/control/FocusControllerWiringTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/cell/control/FocusControllerWiringTest.java
@@ -248,6 +248,19 @@ class FocusControllerWiringTest {
         assertTrue(controller.isDisabled());
     }
 
+    // --- navigateTo() public API ---
+
+    @Test
+    void testNavigateTo_isPublicApi() throws NoSuchMethodException {
+        // Verify navigateTo(VirtualFlow<?>, int) is declared public on FocusController
+        var method = FocusController.class.getMethod("navigateTo",
+                                                     com.chiralbehaviors.layout.flowless.VirtualFlow.class,
+                                                     int.class);
+        assertNotNull(method, "navigateTo(VirtualFlow<?>, int) must be a public method");
+        assertTrue(java.lang.reflect.Modifier.isPublic(method.getModifiers()),
+                   "navigateTo must be public");
+    }
+
     // --- Helper ---
 
     private FocusTraversalNode<?> mockFTN(Bias bias) {


### PR DESCRIPTION
## Summary
6 beads across 4 RDRs, all independent — implemented in parallel:

- **RDR-013** (Kramer-s03): `ContentWidthStats` record + nullable `MeasureResult` wiring
- **RDR-013** (Kramer-63n): `getVersion()` on `LayoutStylesheet`, `version++` on `setOverride`/`clearOverrides`
- **RDR-014** (Kramer-464): `sortFields`/`autoSort` properties on `Relation` (opt-in default)
- **RDR-016** (Kramer-mdl): Scroll preservation in `Outline` + `NestedRow` via `OptionalInt`
- **RDR-017** (Kramer-41y): `LayoutSearch` + `SearchResult` + `NavigationPath` with schema depth-first search
- **RDR-017** (Kramer-dx7): `FocusController.navigateTo()` + `AutoLayout.getOutermostVirtualFlow()`

## Test plan
- [x] 232 tests pass (39 new)
- [x] ContentWidthStats: 8 tests (record, equality, null compat)
- [x] sortFields: 6 tests (defaults, roundtrip, null normalization)
- [x] Scroll preservation: 4 tests (first population, re-population, shrink clamp, empty)
- [x] Version counter: 4 tests (initial, increment, clear, monotonic)
- [x] LayoutSearch: 16 tests (blank query, find next/prev, wrap, case-insensitive, countMatches, non-array guard)
- [x] navigateTo: 1 reflective test (public API verification)