### PR TITLE
Wave 1 Batch 2: sort, p50/p90, list diff, SchemaPath derivation, navigation

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -132,7 +132,7 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         }
         try {
             layout = model.layout(top);
-            layout.setSchemaPath(new SchemaPath(top.getField()));
+            layout.buildPaths(new SchemaPath(top.getField()), model);
             layout.measure(data, model);
             measureResult = layout.getMeasureResult();
         } catch (Throwable e) {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutSearch.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutSearch.java
@@ -5,6 +5,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import com.chiralbehaviors.layout.cell.LayoutCell;
+import com.chiralbehaviors.layout.cell.control.FocusController;
+import com.chiralbehaviors.layout.flowless.VirtualFlow;
 import com.chiralbehaviors.layout.schema.Primitive;
 import com.chiralbehaviors.layout.schema.Relation;
 import com.chiralbehaviors.layout.schema.SchemaNode;
@@ -22,11 +25,19 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
  *   <li>{@code caseSensitive} — default {@code false} (case-insensitive)</li>
  *   <li>{@code wrapAround}    — default {@code true}  (wraps at end/start)</li>
  * </ul>
+ *
+ * <p>When constructed with a {@link VirtualFlow} and {@link FocusController},
+ * {@link #findNext()}, {@link #findPrevious()}, and
+ * {@link #navigateToResult(SearchResult)} will scroll the outermost flow to
+ * the matched row using {@link VirtualFlow#show(int)} (MinDistanceTo semantics)
+ * and update selection via {@link FocusController#navigateTo}.
  */
 public class LayoutSearch {
 
-    private final SchemaNode root;
-    private final JsonNode   data;
+    private final SchemaNode                  root;
+    private final JsonNode                    data;
+    private final VirtualFlow<LayoutCell<?>>  virtualFlow;
+    private final FocusController<LayoutCell<?>> focusController;
 
     private String  query;
     private boolean caseSensitive = false;
@@ -38,9 +49,30 @@ public class LayoutSearch {
     /** Cached list of all matches for the current query. Invalidated on query change. */
     private List<SearchResult> matchCache;
 
+    /**
+     * Creates a search without navigation capability.
+     * {@link #navigateToResult(SearchResult)} is a no-op.
+     */
     public LayoutSearch(SchemaNode root, JsonNode data) {
+        this(root, data, null, null);
+    }
+
+    /**
+     * Creates a search with navigation capability.
+     *
+     * @param root            schema root
+     * @param data            array data to search
+     * @param virtualFlow     outermost VirtualFlow for scrolling; may be {@code null}
+     * @param focusController focus/selection controller; may be {@code null}
+     */
+    @SuppressWarnings("unchecked")
+    public LayoutSearch(SchemaNode root, JsonNode data,
+                        VirtualFlow<? extends LayoutCell<?>> virtualFlow,
+                        FocusController<? extends LayoutCell<?>> focusController) {
         this.root = root;
         this.data = data;
+        this.virtualFlow = (VirtualFlow<LayoutCell<?>>) virtualFlow;
+        this.focusController = (FocusController<LayoutCell<?>>) focusController;
     }
 
     // -------------------------------------------------------------------------
@@ -78,9 +110,10 @@ public class LayoutSearch {
     // -------------------------------------------------------------------------
 
     /**
-     * Advances to the next match and returns it. Returns {@link Optional#empty()}
-     * when the query is blank, there are no matches, or wrap-around is disabled
-     * and the end has been reached.
+     * Advances to the next match, auto-navigates the VirtualFlow if one is
+     * configured, and returns the result.
+     *
+     * @return the next {@link SearchResult}, or empty when no match is found
      */
     public Optional<SearchResult> findNext() {
         if (isBlankQuery()) {
@@ -98,12 +131,16 @@ public class LayoutSearch {
             next = 0;
         }
         cursor = next;
-        return Optional.of(matches.get(cursor));
+        SearchResult result = matches.get(cursor);
+        navigateToResult(result);
+        return Optional.of(result);
     }
 
     /**
-     * Moves to the previous match and returns it. Returns {@link Optional#empty()}
-     * when the query is blank or there are no matches.
+     * Moves to the previous match, auto-navigates the VirtualFlow if one is
+     * configured, and returns the result.
+     *
+     * @return the previous {@link SearchResult}, or empty when no match is found
      */
     public Optional<SearchResult> findPrevious() {
         if (isBlankQuery()) {
@@ -121,7 +158,9 @@ public class LayoutSearch {
             prev = matches.size() - 1;
         }
         cursor = prev;
-        return Optional.of(matches.get(cursor));
+        SearchResult result = matches.get(cursor);
+        navigateToResult(result);
+        return Optional.of(result);
     }
 
     /**
@@ -133,6 +172,27 @@ public class LayoutSearch {
             return 0;
         }
         return getMatches().size();
+    }
+
+    /**
+     * Scrolls the outermost VirtualFlow to the row identified by
+     * {@code result.rowIndex()} using {@link VirtualFlow#show(int)}
+     * (MinDistanceTo semantics — minimal scroll) and selects the row via the
+     * FocusController.
+     *
+     * <p>This is a no-op when no VirtualFlow was supplied at construction time.
+     *
+     * @param result the search result to navigate to
+     */
+    public void navigateToResult(SearchResult result) {
+        if (virtualFlow == null) {
+            return;
+        }
+        int rowIndex = result.rowIndex();
+        virtualFlow.show(rowIndex);
+        if (focusController != null) {
+            focusController.navigateTo(virtualFlow, rowIndex);
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -19,6 +19,8 @@ package com.chiralbehaviors.layout;
 import static com.chiralbehaviors.layout.schema.SchemaNode.asList;
 import static com.chiralbehaviors.layout.style.Style.snap;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -54,6 +56,11 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     public PrimitiveLayout(Primitive p, PrimitiveStyle style) {
         super(p, style.getLabelStyle());
         this.style = style;
+    }
+
+    @Override
+    public void buildPaths(SchemaPath path, Style model) {
+        setSchemaPath(path);
     }
 
     public LayoutCell<?> buildCell(FocusTraversal<?> pt) {
@@ -148,6 +155,9 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         return columnWidth();
     }
 
+    /** Phase 1: minimum sample count required to compute percentile stats. */
+    private static final int MIN_SAMPLES = 30;
+
     @Override
     public double measure(JsonNode data, Function<JsonNode, JsonNode> extractor,
                           Style model) {
@@ -158,12 +168,17 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         columnWidth = 0;
         List<JsonNode> normalized = asList(data);
         int cardSum = 0;
+
+        // Collect all individual widths for percentile computation.
+        List<Double> allWidths = new ArrayList<>();
+
         for (JsonNode prim : normalized) {
             if (prim.isArray()) {
                 cardSum += prim.size();
                 double summedWidth = 0;
                 for (JsonNode row : prim) {
                     double w = width(row);
+                    allWidths.add(w);
                     summedWidth += w;
                     maxWidth = Math.max(maxWidth, w);
                 }
@@ -172,6 +187,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             } else {
                 cardSum += 1;
                 double w = width(prim);
+                allWidths.add(w);
                 summedDataWidth += w;
                 maxWidth = Math.max(maxWidth, w);
             }
@@ -190,15 +206,32 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             isVariableLength = true; // safe fallback for empty data
         }
 
-        double effectiveWidth = isVariableLength ? averageWidth : maxWidth;
-        dataWidth = Style.snap(Math.max(getNode().getDefaultWidth(),
-                                        effectiveWidth));
+        // Compute percentile stats when sample count is sufficient (Phase 1: minSamples=30).
+        ContentWidthStats contentStats = null;
+        int sampleCount = allWidths.size();
+        if (sampleCount >= MIN_SAMPLES) {
+            Collections.sort(allWidths);
+            double p50 = allWidths.get(sampleCount / 2);
+            double p90 = allWidths.get(sampleCount * 9 / 10);
+            contentStats = new ContentWidthStats(p50, p90, sampleCount, false);
+        }
+
+        // RF-3: p90 replaces averageWidth ONLY in isVariableLength==true branch,
+        // and only when we have sufficient samples. Fixed-length always uses maxWidth.
+        double effectiveWidth;
+        if (isVariableLength) {
+            effectiveWidth = (contentStats != null) ? contentStats.p90Width() : averageWidth;
+        } else {
+            effectiveWidth = maxWidth;
+        }
+
+        dataWidth = Style.snap(Math.max(getNode().getDefaultWidth(), effectiveWidth));
         columnWidth = Math.max(labelWidth, dataWidth);
 
         measureResult = new MeasureResult(
             labelWidth, columnWidth, dataWidth, maxWidth,
             averageCardinality, isVariableLength,
-            0, 0, null, List.of(), null
+            0, 0, null, List.of(), contentStats
         );
 
         return columnWidth;

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -18,11 +18,13 @@ package com.chiralbehaviors.layout;
 
 import static com.chiralbehaviors.layout.style.Style.*;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.cell.LayoutCell;
 import com.chiralbehaviors.layout.cell.control.FocusTraversal;
 import com.chiralbehaviors.layout.outline.Outline;
@@ -62,23 +64,103 @@ public final class RelationLayout extends SchemaNodeLayout {
         return flattened;
     }
 
+    /**
+     * Build a stable comparator for a single sort field. Numeric JSON nodes are
+     * compared numerically; all other values are compared lexicographically on
+     * their text representation. Null/missing values sort last.
+     */
+    static Comparator<JsonNode> fieldComparator(String field) {
+        return (a, b) -> {
+            JsonNode va = a == null ? null : a.get(field);
+            JsonNode vb = b == null ? null : b.get(field);
+            boolean missingA = va == null || va.isNull();
+            boolean missingB = vb == null || vb.isNull();
+            if (missingA && missingB) return 0;
+            if (missingA)             return 1;   // nulls last
+            if (missingB)             return -1;
+            if (va.isNumber() && vb.isNumber()) {
+                return Double.compare(va.asDouble(), vb.asDouble());
+            }
+            return va.asText().compareTo(vb.asText());
+        };
+    }
+
+    /**
+     * Derive a comparator from the relation's sortFields / autoSort configuration.
+     * Returns null when no sort is needed (autoSort=false, sortFields empty).
+     *
+     * Heuristic for autoSort with no sortFields: id > key > name > first primitive field.
+     */
+    static Comparator<JsonNode> buildSortComparator(Relation relation) {
+        List<String> fields = relation.getSortFields();
+        if (!fields.isEmpty()) {
+            Comparator<JsonNode> cmp = fieldComparator(fields.get(0));
+            for (int i = 1; i < fields.size(); i++) {
+                cmp = cmp.thenComparing(fieldComparator(fields.get(i)));
+            }
+            return cmp;
+        }
+        if (!relation.isAutoSort()) {
+            return null;
+        }
+        // Heuristic: pick first child primitive matching id > key > name
+        List<String> candidates = List.of("id", "key", "name");
+        for (String candidate : candidates) {
+            if (relation.getChild(candidate) != null) {
+                return fieldComparator(candidate);
+            }
+        }
+        // Fallback: first primitive child
+        return relation.getChildren().stream()
+                       .filter(c -> c instanceof com.chiralbehaviors.layout.schema.Primitive)
+                       .map(c -> fieldComparator(c.getField()))
+                       .findFirst()
+                       .orElse(null);
+    }
+
+    /**
+     * Sort an ArrayNode in-place using a stable sort. Returns the same instance.
+     */
+    static ArrayNode sortArrayNode(ArrayNode array, Comparator<JsonNode> cmp) {
+        if (cmp == null || array == null || array.size() <= 1) {
+            return array;
+        }
+        List<JsonNode> list = new ArrayList<>(array.size());
+        array.forEach(list::add);
+        list.sort(cmp);   // List.sort is stable
+        array.removeAll();
+        list.forEach(array::add);
+        return array;
+    }
+
     protected int                          averageChildCardinality;
     protected double                       cellHeight       = -1;
     protected final List<SchemaNodeLayout> children         = new ArrayList<>();
     protected double                       columnHeaderHeight;
     protected final List<ColumnSet>        columnSets       = new ArrayList<>();
-    protected Function<JsonNode, JsonNode> extractor;
+    protected Function<JsonNode, JsonNode>  extractor;
     protected int                          maxCardinality;
     protected int                          resolvedCardinality;
     protected final RelationStyle          style;
     protected double                       tableColumnWidth = 0;
     protected boolean                      useTable         = false;
     private MeasureResult                  measureResult;
+    /** Comparator derived from sortFields / autoSort; null when no sort is needed. */
+    private Comparator<JsonNode>           sortComparator;
 
     public RelationLayout(Relation r, RelationStyle style) {
         super(r, style.getLabelStyle());
         assert r != null && style != null;
         this.style = style;
+    }
+
+    @Override
+    public void buildPaths(SchemaPath path, Style model) {
+        setSchemaPath(path);
+        for (SchemaNode child : getNode().getChildren()) {
+            SchemaNodeLayout childLayout = model.layout(child);
+            childLayout.buildPaths(path.child(child.getField()), model);
+        }
     }
 
     @Override
@@ -272,8 +354,13 @@ public final class RelationLayout extends SchemaNodeLayout {
 
     @Override
     public JsonNode extractFrom(JsonNode datum) {
-        JsonNode extracted = extractor.apply(datum);
-        return node.extractFrom(extracted);
+        Function<JsonNode, JsonNode> ex = extractor != null ? extractor : n -> n;
+        JsonNode extracted = ex.apply(datum);
+        JsonNode result = node.extractFrom(extracted);
+        if (sortComparator != null && result instanceof ArrayNode arr) {
+            sortArrayNode(arr, sortComparator);
+        }
+        return result;
     }
 
     public void forEach(Consumer<? super SchemaNodeLayout> action) {
@@ -392,6 +479,18 @@ public final class RelationLayout extends SchemaNodeLayout {
                           Function<JsonNode, JsonNode> extractor, Style model) {
         clear();
         children.clear();
+        // Store extractor for build-phase extractFrom() calls that arrive
+        // when measure() is invoked outside the normal fold() pipeline.
+        if (this.extractor == null) {
+            this.extractor = extractor;
+        }
+        // Compute sort comparator once per measure phase; stored for extractFrom().
+        sortComparator = buildSortComparator(getNode());
+        // Sort the datum array before measuring children so that measurement
+        // reflects data order consistent with the build phase.
+        if (sortComparator != null && datum instanceof ArrayNode datumArray) {
+            sortArrayNode(datumArray, sortComparator);
+        }
         double sum = 0;
         columnWidth = 0;
         int singularChildren = 0;

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
@@ -258,6 +258,17 @@ public abstract sealed class SchemaNodeLayout permits PrimitiveLayout, RelationL
         return Style.snap(labelStyle.width(label));
     }
 
+    /**
+     * Derives and sets {@link SchemaPath} for this layout and all child layouts,
+     * walking the schema tree topology. Must be called after the layout is
+     * obtained from {@link com.chiralbehaviors.layout.style.Style#layout(com.chiralbehaviors.layout.schema.SchemaNode)}
+     * and before {@link #measure(com.fasterxml.jackson.databind.JsonNode, com.chiralbehaviors.layout.style.Style)}.
+     *
+     * @param path  the path for this node
+     * @param model factory used to obtain child layouts
+     */
+    public abstract void buildPaths(SchemaPath path, Style model);
+
     abstract public double layout(double width);
 
     abstract public double layoutWidth();

--- a/kramer/src/main/java/com/chiralbehaviors/layout/outline/Outline.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/outline/Outline.java
@@ -78,7 +78,15 @@ public class Outline extends VirtualFlow<OutlineCell> {
     public void updateItem(JsonNode item) {
         OptionalInt savedIndex = getFirstVisibleIndex();
         List<JsonNode> list = SchemaNode.asList(item);
-        items.setAll(list);
+        if (list.size() == items.size()) {
+            for (int i = 0; i < list.size(); i++) {
+                if (!list.get(i).equals(items.get(i))) {
+                    items.set(i, list.get(i));
+                }
+            }
+        } else {
+            items.setAll(list);
+        }
         if (!items.isEmpty()) {
             savedIndex.ifPresentOrElse(
                 idx -> showAsFirst(Math.min(idx, items.size() - 1)),

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedRow.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedRow.java
@@ -17,6 +17,7 @@
 package com.chiralbehaviors.layout.table;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.OptionalInt;
 
 import com.chiralbehaviors.layout.RelationLayout;
@@ -80,7 +81,16 @@ public class NestedRow extends VirtualFlow<NestedCell> {
     @Override
     public void updateItem(JsonNode item) {
         OptionalInt savedIndex = getFirstVisibleIndex();
-        items.setAll(NestedTable.itemsAsArray(item));
+        List<JsonNode> list = NestedTable.itemsAsArray(item);
+        if (list.size() == items.size()) {
+            for (int i = 0; i < list.size(); i++) {
+                if (!list.get(i).equals(items.get(i))) {
+                    items.set(i, list.get(i));
+                }
+            }
+        } else {
+            items.setAll(list);
+        }
         if (!items.isEmpty()) {
             savedIndex.ifPresentOrElse(
                 idx -> showAsFirst(Math.min(idx, items.size() - 1)),

--- a/kramer/src/test/java/com/chiralbehaviors/layout/ListDiffUpdateTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/ListDiffUpdateTest.java
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import com.chiralbehaviors.layout.cell.LayoutCell;
+import com.chiralbehaviors.layout.flowless.VirtualFlow;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+/**
+ * Tests for list diffing / incremental patching in updateItem().
+ *
+ * The patching strategy under test:
+ *   if (list.size() == items.size()) {
+ *       for (int i = 0; i < list.size(); i++) {
+ *           if (!list.get(i).equals(items.get(i))) {
+ *               items.set(i, list.get(i));
+ *           }
+ *       }
+ *   } else {
+ *       items.setAll(list);
+ *   }
+ */
+@ExtendWith(ApplicationExtension.class)
+class ListDiffUpdateTest {
+
+    private static final double CELL_HEIGHT = 30.0;
+    private static final double CELL_WIDTH  = 300.0;
+    private static final double VF_HEIGHT   = 100.0;
+
+    private VirtualFlow<TestCell> vf;
+
+    @Start
+    void start(Stage stage) {
+        ObservableList<JsonNode> items = FXCollections.observableArrayList();
+        vf = new VirtualFlow<>("default.css", CELL_WIDTH, CELL_HEIGHT,
+                               items, (item, focus) -> new TestCell(CELL_WIDTH, CELL_HEIGHT),
+                               null, Collections.emptyList());
+        StackPane root = new StackPane(vf);
+        stage.setScene(new Scene(root, CELL_WIDTH + 20, VF_HEIGHT));
+        stage.show();
+    }
+
+    /**
+     * Same-size update with no changed entries: list.set() must never be called.
+     */
+    @Test
+    void sameSizeNoChanges_triggersZeroItemSets() {
+        List<JsonNode> initial = buildList("a", "b", "c");
+
+        runOnFxAndWait(() -> applyPatchingUpdate(vf, initial));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        AtomicInteger setCount = new AtomicInteger(0);
+        runOnFxAndWait(() -> {
+            vf.getItems().addListener((ListChangeListener<JsonNode>) change -> {
+                while (change.next()) {
+                    if (change.wasReplaced() || change.wasAdded() || change.wasRemoved()) {
+                        setCount.incrementAndGet();
+                    }
+                }
+            });
+        });
+
+        // Re-apply identical data — nothing should change
+        runOnFxAndWait(() -> applyPatchingUpdate(vf, buildList("a", "b", "c")));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals(0, setCount.get(),
+                     "No item changes expected when same-size list has identical content");
+    }
+
+    /**
+     * Same-size update with exactly one different entry: exactly one item.set() call.
+     */
+    @Test
+    void sameSizeOneChange_triggersOneItemSet() {
+        List<JsonNode> initial = buildList("a", "b", "c");
+
+        runOnFxAndWait(() -> applyPatchingUpdate(vf, initial));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        AtomicInteger setCount = new AtomicInteger(0);
+        runOnFxAndWait(() -> {
+            vf.getItems().addListener((ListChangeListener<JsonNode>) change -> {
+                while (change.next()) {
+                    if (change.wasReplaced()) {
+                        setCount.addAndGet(change.getRemovedSize());
+                    }
+                }
+            });
+        });
+
+        // Only item at index 1 changes
+        runOnFxAndWait(() -> applyPatchingUpdate(vf, buildList("a", "X", "c")));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals(1, setCount.get(),
+                     "Exactly one item set expected when exactly one entry differs");
+        runOnFxAndWait(() -> {
+            assertEquals("\"X\"", vf.getItems().get(1).toString(),
+                         "Changed entry should be updated to X");
+        });
+    }
+
+    /**
+     * Size mismatch falls back to setAll(): the whole list is replaced at once.
+     */
+    @Test
+    void sizeMismatch_fallsBackToSetAll() {
+        List<JsonNode> initial = buildList("a", "b", "c");
+
+        runOnFxAndWait(() -> applyPatchingUpdate(vf, initial));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        AtomicInteger setAllCount = new AtomicInteger(0);
+        runOnFxAndWait(() -> {
+            vf.getItems().addListener((ListChangeListener<JsonNode>) change -> {
+                while (change.next()) {
+                    // setAll produces a single permutation/replace event covering all items
+                    if (change.wasReplaced() && change.getList().size() != initial.size()) {
+                        setAllCount.incrementAndGet();
+                    }
+                }
+            });
+        });
+
+        // Different size: 5 items vs 3
+        runOnFxAndWait(() -> applyPatchingUpdate(vf, buildList("a", "b", "c", "d", "e")));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            assertEquals(5, vf.getItems().size(), "Items should be replaced with 5-element list");
+        });
+    }
+
+    /**
+     * Empty incoming list: falls back to setAll(), items become empty. No exception.
+     */
+    @Test
+    void emptyIncomingList_handledCorrectly() {
+        List<JsonNode> initial = buildList("a", "b", "c");
+
+        runOnFxAndWait(() -> applyPatchingUpdate(vf, initial));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> applyPatchingUpdate(vf, Collections.emptyList()));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        runOnFxAndWait(() -> {
+            assertEquals(0, vf.getItems().size(), "Items should be empty after empty update");
+        });
+    }
+
+    // ---- Helpers ----
+
+    /**
+     * The incremental patching strategy extracted from Outline/NestedRow.updateItem().
+     */
+    private static void applyPatchingUpdate(VirtualFlow<?> flow, List<JsonNode> list) {
+        @SuppressWarnings("unchecked")
+        ObservableList<JsonNode> items = (ObservableList<JsonNode>) flow.getItems();
+        if (list.size() == items.size()) {
+            for (int i = 0; i < list.size(); i++) {
+                if (!list.get(i).equals(items.get(i))) {
+                    items.set(i, list.get(i));
+                }
+            }
+        } else {
+            items.setAll(list);
+        }
+    }
+
+    private static List<JsonNode> buildList(String... values) {
+        ObjectMapper mapper = new ObjectMapper();
+        List<JsonNode> list = new ArrayList<>();
+        for (String v : values) {
+            list.add(mapper.getNodeFactory().textNode(v));
+        }
+        return list;
+    }
+
+    private static void runOnFxAndWait(Runnable action) {
+        if (Platform.isFxApplicationThread()) {
+            action.run();
+        } else {
+            CountDownLatch latch = new CountDownLatch(1);
+            Platform.runLater(() -> {
+                try {
+                    action.run();
+                } finally {
+                    latch.countDown();
+                }
+            });
+            try {
+                assertTrue(latch.await(5, TimeUnit.SECONDS),
+                           "Timed out waiting for FX thread");
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted waiting for FX thread");
+            }
+        }
+    }
+
+    static class TestCell extends Pane implements LayoutCell<Pane> {
+        TestCell(double width, double height) {
+            setPrefSize(width, height);
+            setMinSize(width, height);
+            setMaxSize(width, height);
+        }
+
+        @Override
+        public Pane getNode() {
+            return this;
+        }
+
+        @Override
+        public boolean isReusable() {
+            return true;
+        }
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/NavigationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/NavigationTest.java
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.cell.LayoutCell;
+import com.chiralbehaviors.layout.cell.control.FocusController;
+import com.chiralbehaviors.layout.flowless.VirtualFlow;
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+import javafx.scene.layout.Pane;
+
+/**
+ * Tests for LayoutSearch.navigateToResult — verifies VirtualFlow and
+ * FocusController integration without requiring a live JavaFX scene.
+ */
+class NavigationTest {
+
+    private Relation                                       schema;
+    private com.fasterxml.jackson.databind.node.ArrayNode data;
+
+    @BeforeEach
+    void setUp() {
+        schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("code"));
+
+        data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 5; i++) {
+            var row = JsonNodeFactory.instance.objectNode();
+            row.put("name", "Name" + i);
+            row.put("code", "C" + i);
+            data.add(row);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // navigateToResult calls vf.show(rowIndex) — NOT showAsFirst
+    // -----------------------------------------------------------------------
+
+    @Test
+    void navigateToResult_callsShowOnVirtualFlow() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf = mock(VirtualFlow.class);
+        FocusController<LayoutCell<?>> fc = new FocusController<>(new Pane());
+
+        var search = new LayoutSearch(schema, data, vf, fc);
+
+        // Build a SearchResult directly to test navigateToResult in isolation
+        var path = new SchemaPath("items").child("name");
+        var result = new SearchResult(path, 2, "Name2", 0, 5);
+
+        search.navigateToResult(result);
+
+        verify(vf).show(2);               // MinDistanceTo semantics
+        verify(vf, never()).showAsFirst(2); // must NOT use showAsFirst
+    }
+
+    // -----------------------------------------------------------------------
+    // navigateToResult calls focusController.navigateTo(vf, rowIndex)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void navigateToResult_callsNavigateToOnFocusController() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf = mock(VirtualFlow.class);
+        @SuppressWarnings("unchecked")
+        FocusController<LayoutCell<?>> fc = mock(FocusController.class);
+
+        var search = new LayoutSearch(schema, data, vf, fc);
+
+        var path = new SchemaPath("items").child("name");
+        var result = new SearchResult(path, 3, "Name3", 0, 5);
+
+        search.navigateToResult(result);
+
+        verify(fc).navigateTo(vf, 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // navigateToResult with no VirtualFlow is a no-op
+    // -----------------------------------------------------------------------
+
+    @Test
+    void navigateToResult_noVirtualFlow_isNoOp() {
+        // Original two-arg constructor → no VF, no FC
+        var search = new LayoutSearch(schema, data);
+        var path = new SchemaPath("items").child("name");
+        var result = new SearchResult(path, 0, "Name0", 0, 5);
+
+        // Must not throw
+        assertDoesNotThrow(() -> search.navigateToResult(result));
+    }
+
+    // -----------------------------------------------------------------------
+    // findNext/findPrevious auto-navigate when a result is found
+    // -----------------------------------------------------------------------
+
+    @Test
+    void findNext_autoNavigates() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf = mock(VirtualFlow.class);
+        @SuppressWarnings("unchecked")
+        FocusController<LayoutCell<?>> fc = mock(FocusController.class);
+
+        var search = new LayoutSearch(schema, data, vf, fc);
+        search.setQuery("Name1");
+        Optional<SearchResult> result = search.findNext();
+        assertTrue(result.isPresent());
+
+        verify(vf).show(1);
+        verify(fc).navigateTo(vf, 1);
+    }
+
+    @Test
+    void findPrevious_autoNavigates() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf = mock(VirtualFlow.class);
+        @SuppressWarnings("unchecked")
+        FocusController<LayoutCell<?>> fc = mock(FocusController.class);
+
+        var search = new LayoutSearch(schema, data, vf, fc);
+        search.setQuery("Name4");
+        search.findNext(); // advance to row 4
+        reset(vf, fc);
+
+        Optional<SearchResult> prev = search.findPrevious();
+        assertTrue(prev.isPresent());
+        int row = prev.get().rowIndex();
+        verify(vf).show(row);
+        verify(fc).navigateTo(vf, row);
+    }
+
+    @Test
+    void findNext_noMatch_doesNotCallVf() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf = mock(VirtualFlow.class);
+        FocusController<LayoutCell<?>> fc = new FocusController<>(new Pane());
+
+        var search = new LayoutSearch(schema, data, vf, fc);
+        search.setQuery("zzz");
+        Optional<SearchResult> result = search.findNext();
+        assertFalse(result.isPresent());
+
+        verifyNoInteractions(vf);
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveStatsMeasureTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveStatsMeasureTest.java
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for Kramer-ufx: p50/p90 percentile computation in PrimitiveLayout.measure().
+ *
+ * Phase 1: minSamples = 30.
+ * - sampleCount >= 30: ContentWidthStats populated; p90 used as effectiveWidth for variable-length.
+ * - sampleCount < 30: contentStats null; averageWidth used (existing behaviour).
+ * - isVariableLength == false: maxWidth used regardless of sampleCount.
+ * - empty dataset: contentStats null.
+ */
+class PrimitiveStatsMeasureTest {
+
+    private static final int MIN_SAMPLES = 30;
+
+    // --- Helper: build array of text values with given char widths --
+
+    /**
+     * Adds {@code count} text values of exactly {@code charCount} characters each.
+     */
+    private static void addFixed(ArrayNode arr, int count, int charCount) {
+        String value = "x".repeat(charCount);
+        for (int i = 0; i < count; i++) {
+            arr.add(value);
+        }
+    }
+
+    /**
+     * Builds an array of 35 strings: 30 short (1 char) and 5 very long (20 chars).
+     * charWidth=1.0 so widths equal char counts.
+     * maxWidth=20, averageWidth ~ (30*1 + 5*20)/35 = 130/35 ≈ 3.71
+     * maxWidth/averageWidth ≈ 5.4 > variableLengthThreshold(2.0) → isVariableLength=true
+     */
+    private static ArrayNode buildVariableDataset() {
+        ArrayNode arr = JsonNodeFactory.instance.arrayNode();
+        addFixed(arr, 30, 1);  // 30 short
+        addFixed(arr, 5, 20);  // 5 long
+        return arr;
+    }
+
+    /**
+     * Builds an array of 35 strings all the same length (10 chars each).
+     * maxWidth/averageWidth = 1.0 < variableLengthThreshold(2.0) → isVariableLength=false
+     */
+    private static ArrayNode buildFixedDataset() {
+        ArrayNode arr = JsonNodeFactory.instance.arrayNode();
+        addFixed(arr, 35, 10);
+        return arr;
+    }
+
+    // --- Test 1: contentStats populated for dataset >= minSamples ---
+
+    @Test
+    void contentStatsPopulatedWhenSampleCountAtLeastMinSamples() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        Style model = mock(Style.class);
+
+        ArrayNode data = buildVariableDataset(); // 35 elements
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result.contentStats(),
+            "contentStats must be populated when sampleCount >= " + MIN_SAMPLES);
+        assertEquals(35, result.contentStats().sampleCount(),
+            "sampleCount should equal dataset size");
+    }
+
+    // --- Test 2: p50 and p90 are correctly computed ---
+
+    @Test
+    void p50AndP90AreCorrectlyComputed() {
+        // 35 values: widths [1,1,...1 (30 times), 20,20,...20 (5 times)]
+        // sorted: [1,1,...1,20,...20]  (charWidth=1.0)
+        // p50 index = 35/2 = 17 → value 1.0
+        // p90 index = 35*9/10 = 31 → value 20.0
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        Style model = mock(Style.class);
+
+        ArrayNode data = buildVariableDataset();
+        layout.measure(data, n -> n, model);
+
+        ContentWidthStats stats = layout.getMeasureResult().contentStats();
+        assertNotNull(stats);
+        assertEquals(1.0, stats.p50Width(), 1e-6, "p50 should be the median (1.0)");
+        assertEquals(20.0, stats.p90Width(), 1e-6, "p90 should be the 90th percentile (20.0)");
+    }
+
+    // --- Test 3: p90 used as effectiveWidth for variable-length (replaces averageWidth) ---
+
+    @Test
+    void p90UsedAsEffectiveWidthForVariableLengthWithSufficientSamples() {
+        // isVariableLength=true, sampleCount=35 (>= 30)
+        // effective width should be p90 (= 20.0), not averageWidth (~3.71)
+        // dataWidth = max(defaultWidth=0, p90=20.0) = 20.0
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        Style model = mock(Style.class);
+
+        ArrayNode data = buildVariableDataset();
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertTrue(result.isVariableLength(), "Dataset should be variable-length");
+        // dataWidth == p90 == 20.0 (snapped; snap is identity in tests)
+        assertEquals(20.0, result.dataWidth(), 1e-6,
+            "dataWidth should equal p90 for variable-length with >= 30 samples");
+    }
+
+    // --- Test 4: maxWidth retained for fixed-length columns ---
+
+    @Test
+    void maxWidthRetainedForFixedLengthColumns() {
+        // All 35 values are 10 chars → maxWidth=10, averageWidth=10
+        // maxWidth/averageWidth = 1.0 < 2.0 → isVariableLength=false
+        // effectiveWidth = maxWidth (unchanged)
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("timestamp"), style);
+        Style model = mock(Style.class);
+
+        ArrayNode data = buildFixedDataset();
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertFalse(result.isVariableLength(), "Uniform dataset should be fixed-length");
+        assertEquals(10.0, result.maxWidth(), 1e-6, "maxWidth should be 10.0");
+        assertEquals(10.0, result.dataWidth(), 1e-6,
+            "Fixed-length should use maxWidth, not p90");
+    }
+
+    // --- Test 5: dataset < minSamples uses existing averageWidth behaviour ---
+
+    @Test
+    void smallDatasetUsesAverageWidthBehaviourAndNullContentStats() {
+        // 5 elements: widths [1,1,1,1,20] (charWidth=1.0)
+        // maxWidth=20, averageWidth=(4+20)/5=4.8
+        // maxWidth/averageWidth ≈ 4.17 > 2.0 → isVariableLength=true
+        // sampleCount=5 < 30 → contentStats=null, effectiveWidth=averageWidth=4.8
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("short"), style);
+        Style model = mock(Style.class);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        addFixed(data, 4, 1);
+        addFixed(data, 1, 20);
+
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNull(result.contentStats(),
+            "contentStats must be null when sampleCount < " + MIN_SAMPLES);
+        assertTrue(result.isVariableLength());
+        // effectiveWidth = averageWidth = (4*1 + 20) / 5 = 4.8, snap(4.8) = 5.0
+        assertEquals(5.0, result.dataWidth(), 1e-6,
+            "Small dataset should use averageWidth (snapped) as effectiveWidth");
+    }
+
+    // --- Test 6: empty dataset produces null contentStats ---
+
+    @Test
+    void emptyDatasetProducesNullContentStats() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("empty"), style);
+        Style model = mock(Style.class);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNull(result.contentStats(), "Empty dataset should produce null contentStats");
+    }
+
+    // --- Test 7: converged=false for Phase 1 ---
+
+    @Test
+    void contentStatsConvergedIsFalsePhase1() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        Style model = mock(Style.class);
+
+        ArrayNode data = buildVariableDataset();
+        layout.measure(data, n -> n, model);
+
+        ContentWidthStats stats = layout.getMeasureResult().contentStats();
+        assertNotNull(stats);
+        assertFalse(stats.converged(), "Phase 1 hardcodes converged=false");
+    }
+
+    // --- Test 8: exactly minSamples elements triggers stats ---
+
+    @Test
+    void exactlyMinSamplesTriggersContentStats() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("boundary"), style);
+        Style model = mock(Style.class);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // 30 variable-length values: 20 short (1 char), 10 long (10 chars)
+        // maxWidth=10, averageWidth=(20+100)/30 = 4.0
+        // maxWidth/averageWidth = 2.5 > 2.0 → isVariableLength=true
+        addFixed(data, 20, 1);
+        addFixed(data, 10, 10);
+
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result.contentStats(),
+            "contentStats must be populated at exactly minSamples=" + MIN_SAMPLES);
+        assertEquals(30, result.contentStats().sampleCount());
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutSortTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutSortTest.java
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Tests for Kramer-090: stable sort in RelationLayout.measure() / extractFrom().
+ */
+class RelationLayoutSortTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private Style mockModel(Relation schema) {
+        Style model = mock(Style.class);
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        for (SchemaNode child : schema.getChildren()) {
+            if (child instanceof Primitive p) {
+                PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+                when(model.layout(p)).thenReturn(pl);
+            }
+        }
+        when(model.layout(any(SchemaNode.class))).thenAnswer(inv -> {
+            SchemaNode n = inv.getArgument(0);
+            if (n instanceof Primitive p) return model.layout(p);
+            return model.layout((Relation) n);
+        });
+        return model;
+    }
+
+    /** Build an ArrayNode of {name, score} objects in the given order. */
+    private ArrayNode buildData(String[][] rows) {
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (String[] row : rows) {
+            ObjectNode obj = JsonNodeFactory.instance.objectNode();
+            obj.put("name", row[0]);
+            obj.put("score", row[1]);
+            data.add(obj);
+        }
+        return data;
+    }
+
+    private RelationLayout buildLayout(Relation schema) {
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        return new RelationLayout(schema, relStyle);
+    }
+
+    /** Return field values from datum after measure, in order. */
+    private List<String> namesAfterMeasure(RelationLayout layout,
+                                           ArrayNode data,
+                                           Style model,
+                                           String field) {
+        // datum passed to measure() is the top-level array
+        // measure() operates on it directly
+        layout.measure(data, n -> n, model);
+        // Use extractFrom to retrieve sorted rows (build-phase path)
+        // wrap data in a parent object so extractFrom can field-extract it
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set(layout.getNode().getField(), data);
+        JsonNode extracted = layout.extractFrom(parent);
+        List<String> names = new java.util.ArrayList<>();
+        extracted.forEach(row -> names.add(row.get(field).asText()));
+        return names;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: autoSort=false (default) preserves original order
+    // -----------------------------------------------------------------------
+
+    @Test
+    void autoSortFalsePreservesOrder() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("score"));
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = buildData(new String[][] {
+            { "Charlie", "30" },
+            { "Alice",   "10" },
+            { "Bob",     "20" }
+        });
+
+        List<String> names = namesAfterMeasure(layout, data, model, "name");
+        // No sort configured — original order must be preserved
+        assertEquals(List.of("Charlie", "Alice", "Bob"), names,
+                     "autoSort=false must preserve insertion order");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: explicit sortFields sorts lexicographically
+    // -----------------------------------------------------------------------
+
+    @Test
+    void explicitSortFieldSortsLexicographically() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("score"));
+        schema.setSortFields(List.of("name"));
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = buildData(new String[][] {
+            { "Charlie", "30" },
+            { "Alice",   "10" },
+            { "Bob",     "20" }
+        });
+
+        List<String> names = namesAfterMeasure(layout, data, model, "name");
+        assertEquals(List.of("Alice", "Bob", "Charlie"), names,
+                     "sortFields=[name] must sort lexicographically");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: numeric sort fields sort numerically, not lexicographically
+    // -----------------------------------------------------------------------
+
+    @Test
+    void numericSortFieldSortsNumerically() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("score"));
+        schema.setSortFields(List.of("score"));
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        // Use integer values so lexicographic vs numeric order differs
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ObjectNode r1 = JsonNodeFactory.instance.objectNode();
+        r1.put("name", "Alpha");
+        r1.put("score", 9);       // integer node
+        data.add(r1);
+        ObjectNode r2 = JsonNodeFactory.instance.objectNode();
+        r2.put("name", "Beta");
+        r2.put("score", 100);
+        data.add(r2);
+        ObjectNode r3 = JsonNodeFactory.instance.objectNode();
+        r3.put("name", "Gamma");
+        r3.put("score", 20);
+        data.add(r3);
+
+        // Measure
+        layout.measure(data, n -> n, model);
+        // Build-phase extraction
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set("items", data);
+        JsonNode extracted = layout.extractFrom(parent);
+
+        List<Integer> scores = new java.util.ArrayList<>();
+        extracted.forEach(row -> scores.add(row.get("score").intValue()));
+
+        // Numeric order: 9, 20, 100 — NOT 100, 20, 9 (lexicographic)
+        assertEquals(List.of(9, 20, 100), scores,
+                     "Numeric sort fields must sort by numeric value, not string");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: missing/null sort field values sort last without NPE
+    // -----------------------------------------------------------------------
+
+    @Test
+    void nullAndMissingSortFieldsSortLast() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("rank"));
+        schema.setSortFields(List.of("rank"));
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ObjectNode r1 = JsonNodeFactory.instance.objectNode();
+        r1.put("name", "WithRank");
+        r1.put("rank", "A");
+        data.add(r1);
+        ObjectNode r2 = JsonNodeFactory.instance.objectNode();
+        r2.put("name", "NullRank");
+        r2.putNull("rank");         // explicit null
+        data.add(r2);
+        ObjectNode r3 = JsonNodeFactory.instance.objectNode();
+        r3.put("name", "MissingRank"); // field absent
+        data.add(r3);
+        ObjectNode r4 = JsonNodeFactory.instance.objectNode();
+        r4.put("name", "WithRankB");
+        r4.put("rank", "B");
+        data.add(r4);
+
+        List<String> names = assertDoesNotThrow(
+            () -> namesAfterMeasure(layout, data, model, "name"),
+            "Null/missing sort fields must not throw NPE"
+        );
+
+        // Rows with rank values come first; null/missing come last
+        assertEquals("WithRank",    names.get(0));
+        assertEquals("WithRankB",   names.get(1));
+        assertTrue(names.indexOf("NullRank")    >= 2,
+                   "null rank should sort last");
+        assertTrue(names.indexOf("MissingRank") >= 2,
+                   "missing rank should sort last");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: autoSort=true with no sortFields uses heuristic (id > key > name > first primitive)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void autoSortWithNoSortFieldsUsesHeuristicId() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("id"));
+        schema.addChild(new Primitive("label"));
+        schema.setAutoSort(true);
+        // sortFields left empty
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ObjectNode r1 = JsonNodeFactory.instance.objectNode();
+        r1.put("id", "C");
+        r1.put("label", "Charlie");
+        data.add(r1);
+        ObjectNode r2 = JsonNodeFactory.instance.objectNode();
+        r2.put("id", "A");
+        r2.put("label", "Alpha");
+        data.add(r2);
+        ObjectNode r3 = JsonNodeFactory.instance.objectNode();
+        r3.put("id", "B");
+        r3.put("label", "Beta");
+        data.add(r3);
+
+        layout.measure(data, n -> n, model);
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set("items", data);
+        JsonNode extracted = layout.extractFrom(parent);
+
+        List<String> ids = new java.util.ArrayList<>();
+        extracted.forEach(row -> ids.add(row.get("id").asText()));
+        assertEquals(List.of("A", "B", "C"), ids,
+                     "autoSort=true with no sortFields should use 'id' heuristic field");
+    }
+
+    @Test
+    void autoSortHeuristicFallsToName() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("value"));
+        schema.setAutoSort(true);
+        // no "id" or "key" child — should fall to "name"
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = buildData(new String[][] {
+            { "Zebra", "1" },
+            { "Apple", "2" },
+            { "Mango", "3" }
+        });
+
+        layout.measure(data, n -> n, model);
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set("items", data);
+        JsonNode extracted = layout.extractFrom(parent);
+
+        List<String> names = new java.util.ArrayList<>();
+        extracted.forEach(row -> names.add(row.get("name").asText()));
+        assertEquals(List.of("Apple", "Mango", "Zebra"), names,
+                     "autoSort=true with no id/key should fall back to 'name' field");
+    }
+
+    @Test
+    void autoSortHeuristicFallsToFirstPrimitive() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("code"));   // none of id/key/name
+        schema.addChild(new Primitive("desc"));
+        schema.setAutoSort(true);
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ObjectNode r1 = JsonNodeFactory.instance.objectNode();
+        r1.put("code", "ZZZ");
+        r1.put("desc", "Last");
+        data.add(r1);
+        ObjectNode r2 = JsonNodeFactory.instance.objectNode();
+        r2.put("code", "AAA");
+        r2.put("desc", "First");
+        data.add(r2);
+
+        layout.measure(data, n -> n, model);
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set("items", data);
+        JsonNode extracted = layout.extractFrom(parent);
+
+        List<String> codes = new java.util.ArrayList<>();
+        extracted.forEach(row -> codes.add(row.get("code").asText()));
+        assertEquals(List.of("AAA", "ZZZ"), codes,
+                     "autoSort=true with no heuristic match should fall back to first primitive field");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: sort is stable — equal keys preserve relative insertion order
+    // -----------------------------------------------------------------------
+
+    @Test
+    void sortIsStable() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("group"));
+        schema.addChild(new Primitive("seq"));
+        schema.setSortFields(List.of("group"));
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // Two rows with group "A" in order seq=1, seq=2 — stable sort must preserve
+        ObjectNode r1 = JsonNodeFactory.instance.objectNode();
+        r1.put("group", "A"); r1.put("seq", "1"); data.add(r1);
+        ObjectNode r2 = JsonNodeFactory.instance.objectNode();
+        r2.put("group", "B"); r2.put("seq", "3"); data.add(r2);
+        ObjectNode r3 = JsonNodeFactory.instance.objectNode();
+        r3.put("group", "A"); r3.put("seq", "2"); data.add(r3);
+
+        layout.measure(data, n -> n, model);
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set("items", data);
+        JsonNode extracted = layout.extractFrom(parent);
+
+        List<String> seqs = new java.util.ArrayList<>();
+        extracted.forEach(row -> seqs.add(row.get("seq").asText()));
+        // group A rows (seq 1,2) come first (stable), then group B (seq 3)
+        assertEquals(List.of("1", "2", "3"), seqs,
+                     "Sort must be stable: equal-key rows preserve insertion order");
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SchemaPathDerivationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SchemaPathDerivationTest.java
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.Style;
+
+/**
+ * Tests that SchemaPath is derived at construction time via buildPaths(),
+ * before measure() is called (Kramer-e1l).
+ */
+class SchemaPathDerivationTest {
+
+    // ---- Helper: build a Style mock that returns real layouts ----
+
+    private Style mockStyle(Relation root) {
+        Style model = mock(Style.class);
+        // Wire model.layout(SchemaNode) to return new layouts per node
+        when(model.layout(any(Primitive.class))).thenAnswer(inv -> {
+            Primitive p = inv.getArgument(0);
+            return new PrimitiveLayout(p, TestLayouts.mockPrimitiveStyle(7.0));
+        });
+        when(model.layout(any(Relation.class))).thenAnswer(inv -> {
+            Relation r = inv.getArgument(0);
+            return new RelationLayout(r, TestLayouts.mockRelationStyle());
+        });
+        when(model.layout(any(com.chiralbehaviors.layout.schema.SchemaNode.class))).thenAnswer(inv -> {
+            var n = inv.getArgument(0);
+            if (n instanceof Primitive p) return new PrimitiveLayout(p, TestLayouts.mockPrimitiveStyle(7.0));
+            return new RelationLayout((Relation) n, TestLayouts.mockRelationStyle());
+        });
+        return model;
+    }
+
+    @Test
+    void rootLayoutHasPathAfterBuildPaths() {
+        Relation schema = new Relation("catalog");
+        schema.addChild(new Primitive("name"));
+
+        Style model = mockStyle(schema);
+        RelationLayout layout = new RelationLayout(schema, TestLayouts.mockRelationStyle());
+
+        // Before buildPaths: path is null
+        assertNull(layout.getSchemaPath(), "SchemaPath must be null before buildPaths()");
+
+        // After buildPaths: path is set — no measure() needed
+        layout.buildPaths(new SchemaPath("catalog"), model);
+
+        assertNotNull(layout.getSchemaPath(), "SchemaPath must be non-null after buildPaths()");
+        assertEquals(new SchemaPath("catalog"), layout.getSchemaPath());
+    }
+
+    @Test
+    void childLayoutsHaveCorrectPathsAfterBuildPaths() {
+        Relation schema = new Relation("catalog");
+        Primitive namePrim = new Primitive("name");
+        Primitive codePrim = new Primitive("code");
+        schema.addChild(namePrim);
+        schema.addChild(codePrim);
+
+        // Use a Style that returns stable layouts (same instance per schema node)
+        PrimitiveLayout nameLayout = new PrimitiveLayout(namePrim, TestLayouts.mockPrimitiveStyle(7.0));
+        PrimitiveLayout codeLayout = new PrimitiveLayout(codePrim, TestLayouts.mockPrimitiveStyle(7.0));
+        RelationLayout relLayout = new RelationLayout(schema, TestLayouts.mockRelationStyle());
+
+        Style model = mock(Style.class);
+        when(model.layout(namePrim)).thenReturn(nameLayout);
+        when(model.layout(codePrim)).thenReturn(codeLayout);
+        when(model.layout(any(com.chiralbehaviors.layout.schema.SchemaNode.class))).thenAnswer(inv -> {
+            var n = inv.getArgument(0);
+            if (n == namePrim) return nameLayout;
+            if (n == codePrim) return codeLayout;
+            return relLayout;
+        });
+
+        relLayout.buildPaths(new SchemaPath("catalog"), model);
+
+        // Root
+        assertEquals(new SchemaPath("catalog"), relLayout.getSchemaPath());
+
+        // Children via schema traversal
+        assertEquals(new SchemaPath("catalog").child("name"), nameLayout.getSchemaPath());
+        assertEquals(new SchemaPath("catalog").child("code"), codeLayout.getSchemaPath());
+    }
+
+    @Test
+    void deepNestingPathsCorrect() {
+        // catalog -> items (Relation) -> id (Primitive)
+        Relation catalog = new Relation("catalog");
+        Relation items = new Relation("items");
+        Primitive idPrim = new Primitive("id");
+        items.addChild(idPrim);
+        catalog.addChild(items);
+
+        PrimitiveLayout idLayout = new PrimitiveLayout(idPrim, TestLayouts.mockPrimitiveStyle(7.0));
+        RelationLayout itemsLayout = new RelationLayout(items, TestLayouts.mockRelationStyle());
+        RelationLayout catalogLayout = new RelationLayout(catalog, TestLayouts.mockRelationStyle());
+
+        Style model = mock(Style.class);
+        when(model.layout(any(com.chiralbehaviors.layout.schema.SchemaNode.class))).thenAnswer(inv -> {
+            var n = inv.getArgument(0);
+            if (n == idPrim) return idLayout;
+            if (n == items) return itemsLayout;
+            return catalogLayout;
+        });
+
+        catalogLayout.buildPaths(new SchemaPath("catalog"), model);
+
+        assertEquals(new SchemaPath("catalog"), catalogLayout.getSchemaPath());
+        assertEquals(new SchemaPath("catalog").child("items"), itemsLayout.getSchemaPath());
+        assertEquals(new SchemaPath("catalog").child("items").child("id"), idLayout.getSchemaPath());
+    }
+
+    @Test
+    void primitiveLayoutHasPathAfterBuildPaths() {
+        Primitive prim = new Primitive("score");
+        PrimitiveLayout layout = new PrimitiveLayout(prim, TestLayouts.mockPrimitiveStyle(7.0));
+
+        assertNull(layout.getSchemaPath(), "SchemaPath must be null before buildPaths()");
+
+        Style model = mock(Style.class);
+        layout.buildPaths(new SchemaPath("score"), model);
+
+        assertNotNull(layout.getSchemaPath());
+        assertEquals(new SchemaPath("score"), layout.getSchemaPath());
+    }
+
+    @Test
+    void buildPathsIsIdempotentWithRewire() {
+        Relation schema = new Relation("root");
+        schema.addChild(new Primitive("value"));
+
+        PrimitiveLayout valueLayout = new PrimitiveLayout((Primitive) schema.getChildren().get(0),
+                                                           TestLayouts.mockPrimitiveStyle(7.0));
+        RelationLayout layout = new RelationLayout(schema, TestLayouts.mockRelationStyle());
+
+        Style model = mock(Style.class);
+        when(model.layout(any(com.chiralbehaviors.layout.schema.SchemaNode.class))).thenAnswer(inv -> {
+            var n = inv.getArgument(0);
+            if (n instanceof Primitive) return valueLayout;
+            return layout;
+        });
+
+        // First call
+        layout.buildPaths(new SchemaPath("root"), model);
+        assertEquals(new SchemaPath("root"), layout.getSchemaPath());
+        assertEquals(new SchemaPath("root").child("value"), valueLayout.getSchemaPath());
+
+        // Second call with different path - should rewire
+        layout.buildPaths(new SchemaPath("newRoot"), model);
+        assertEquals(new SchemaPath("newRoot"), layout.getSchemaPath());
+        assertEquals(new SchemaPath("newRoot").child("value"), valueLayout.getSchemaPath());
+    }
+
+    @Test
+    void pathsAvailableBeforeMeasure() {
+        // The key invariant: buildPaths() sets paths WITHOUT calling measure()
+        Relation schema = new Relation("orders");
+        Primitive amountPrim = new Primitive("amount");
+        Primitive statusPrim = new Primitive("status");
+        schema.addChild(amountPrim);
+        schema.addChild(statusPrim);
+
+        PrimitiveLayout amountLayout = new PrimitiveLayout(amountPrim, TestLayouts.mockPrimitiveStyle(7.0));
+        PrimitiveLayout statusLayout = new PrimitiveLayout(statusPrim, TestLayouts.mockPrimitiveStyle(7.0));
+        RelationLayout relLayout = new RelationLayout(schema, TestLayouts.mockRelationStyle());
+
+        Style model = mock(Style.class);
+        when(model.layout(any(com.chiralbehaviors.layout.schema.SchemaNode.class))).thenAnswer(inv -> {
+            var n = inv.getArgument(0);
+            if (n == amountPrim) return amountLayout;
+            if (n == statusPrim) return statusLayout;
+            return relLayout;
+        });
+
+        // Build paths WITHOUT calling measure()
+        relLayout.buildPaths(new SchemaPath("orders"), model);
+
+        // Verify paths are set before any measure() call
+        assertNotNull(relLayout.getSchemaPath());
+        assertNotNull(amountLayout.getSchemaPath());
+        assertNotNull(statusLayout.getSchemaPath());
+
+        // Verify correctness
+        assertEquals("orders", relLayout.getSchemaPath().leaf());
+        assertEquals("amount", amountLayout.getSchemaPath().leaf());
+        assertEquals("status", statusLayout.getSchemaPath().leaf());
+
+        // Verify MeasureResult is NOT yet set (no measure called)
+        assertNull(relLayout.getMeasureResult(), "measure() was not called, so MeasureResult should be null");
+        assertNull(amountLayout.getMeasureResult(), "measure() was not called, so MeasureResult should be null");
+    }
+}


### PR DESCRIPTION
## Summary
5 beads across 4 RDRs:

- **RDR-013** (Kramer-ufx): p50/p90 percentile width computation — completes Phase 1 of statistical content-width measurement
- **RDR-014** (Kramer-090): Stable sort in `RelationLayout.measure()` + `extractFrom()` with type-aware comparator
- **RDR-016** (Kramer-h7q): List diffing — in-place patch for same-size data updates in Outline + NestedRow
- **RDR-016** (Kramer-e1l): SchemaPath construction-time derivation via `buildPaths()` — cross-cutting prereq
- **RDR-017** (Kramer-npg): Top-level VirtualFlow navigation — `navigateToResult()` with `show()` + `navigateTo()`

## Test plan
- [x] 264 tests pass (31 new)
- [x] p50/p90: 8 tests (stats populated, variable-length p90, fixed-length maxWidth, small dataset fallback)
- [x] Sort: 8 tests (numeric, text, null-last, autoSort heuristic, build-path consistency)
- [x] List diff: 4 tests (no-change, one-change, size-mismatch fallback, empty)
- [x] SchemaPath: 6 tests (construction-time derivation, child paths, topology)
- [x] Navigation: 5 tests (show called, navigateTo called, no-VF no-op, auto-navigate on findNext)

Ref: Kramer-090, Kramer-ufx, Kramer-h7q, Kramer-e1l, Kramer-npg