### PR TITLE
Wave 1 Batch 3: SearchBar, layout cache, nested nav, sort integration test

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -17,6 +17,8 @@
 package com.chiralbehaviors.layout;
 
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -36,6 +38,8 @@ import javafx.beans.property.Property;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ListChangeListener;
 import javafx.geometry.Point2D;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Region;
 
@@ -52,15 +56,21 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
     private static final java.util.logging.Logger  log         = Logger.getLogger(AutoLayout.class.getCanonicalName());
     private static final String                    STYLE_SHEET = "auto-layout.css";
 
-    private LayoutCell<? extends Region>           control;
-    private final FocusController<AutoLayout>      controller;
-    private SimpleObjectProperty<JsonNode>         data        = new SimpleObjectProperty<>();
-    private SchemaNodeLayout                       layout;
-    private MeasureResult                          measureResult;
-    private double                                 layoutWidth = 0.0;
-    private Style                                 model;
-    private final SimpleObjectProperty<SchemaNode> root        = new SimpleObjectProperty<>();
-    private final String                           stylesheet;
+    private LayoutCell<? extends Region>                  control;
+    private final FocusController<AutoLayout>             controller;
+    private SimpleObjectProperty<JsonNode>                data         = new SimpleObjectProperty<>();
+    private final Map<LayoutDecisionKey, LayoutResult>    decisionCache = new HashMap<>();
+    private SchemaNodeLayout                              layout;
+    private MeasureResult                                 measureResult;
+    private double                                        layoutWidth  = 0.0;
+    private Style                                        model;
+    private final SimpleObjectProperty<SchemaNode>        root         = new SimpleObjectProperty<>();
+    private final String                                  stylesheet;
+
+    // Search
+    private SearchBar                                     searchBar;
+    private LayoutSearch                                  layoutSearch;
+    private int                                           searchCursor = -1;
 
     public AutoLayout() {
         this(null);
@@ -77,6 +87,11 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         getStyleClass().add(AUTO_LAYOUT);
         this.model = model;
         this.root.set(root);
+        this.root.addListener((o, p, c) -> {
+            layout = null;
+            measureResult = null;
+            decisionCache.clear();
+        });
         data.addListener((o, p, c) -> setContent());
         controller = new FocusController<>(this);
         getStylesheets().addListener((ListChangeListener<String>) c -> {
@@ -85,16 +100,19 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
             model.setStyleSheets(newList, this);
             layout = null;
             measureResult = null;
+            decisionCache.clear();
             if (getData() != null) {
                 autoLayout();
             }
         });
         getStylesheets().add(getClass().getResource(DEFAULT_CSS)
                                        .toExternalForm());
+        installSearchKeyBindings();
     }
 
     public void autoLayout() {
         layoutWidth = 0.0;
+        decisionCache.clear();
         Platform.runLater(() -> autoLayout(getData(), getWidth()));
     }
 
@@ -188,6 +206,143 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         data.set(item);
         getNode().pseudoClassStateChanged(PSEUDO_CLASS_FILLED, item != null);
         getNode().pseudoClassStateChanged(PSEUDO_CLASS_EMPTY, item == null);
+    }
+
+    // -----------------------------------------------------------------------
+    // Search bar
+    // -----------------------------------------------------------------------
+
+    /**
+     * Shows the search bar at the bottom of the AutoLayout pane and requests
+     * focus on the query field.
+     */
+    public void showSearchBar() {
+        if (searchBar == null) {
+            searchBar = new SearchBar();
+            searchBar.setOnFindNext(this::doFindNext);
+            searchBar.setOnFindPrevious(this::doFindPrevious);
+            searchBar.getSearchField().textProperty().addListener((obs, old, nv) -> rebuildSearch(nv));
+        }
+        if (!getChildren().contains(searchBar)) {
+            setBottomAnchor(searchBar, 0d);
+            setLeftAnchor(searchBar, 0d);
+            setRightAnchor(searchBar, 0d);
+            getChildren().add(searchBar);
+        }
+        searchBar.setVisible(true);
+        searchBar.getSearchField().requestFocus();
+    }
+
+    /**
+     * Hides the search bar and returns focus to the main content pane.
+     */
+    public void hideSearchBar() {
+        if (searchBar != null) {
+            getChildren().remove(searchBar);
+            searchBar.setVisible(false);
+        }
+        layoutSearch = null;
+        searchCursor = -1;
+        requestFocus();
+    }
+
+    /** Returns the SearchBar, or {@code null} if it has never been shown. */
+    public SearchBar getSearchBar() {
+        return searchBar;
+    }
+
+    // -----------------------------------------------------------------------
+    // Private search helpers
+    // -----------------------------------------------------------------------
+
+    private void installSearchKeyBindings() {
+        addEventFilter(KeyEvent.KEY_PRESSED, this::handleSearchKeyPressed);
+    }
+
+    private void handleSearchKeyPressed(KeyEvent evt) {
+        boolean shortcutDown = evt.isShortcutDown();
+        KeyCode code = evt.getCode();
+
+        if (shortcutDown && code == KeyCode.F) {
+            showSearchBar();
+            evt.consume();
+            return;
+        }
+
+        if (searchBar != null && searchBar.isVisible()) {
+            if (code == KeyCode.F3 && !evt.isShiftDown()) {
+                doFindNext();
+                evt.consume();
+                return;
+            }
+            if (code == KeyCode.F3 && evt.isShiftDown()) {
+                doFindPrevious();
+                evt.consume();
+                return;
+            }
+            if (code == KeyCode.ESCAPE) {
+                hideSearchBar();
+                evt.consume();
+            }
+        }
+    }
+
+    private void rebuildSearch(String query) {
+        SchemaNode schemaRoot = root.get();
+        JsonNode currentData  = data.get();
+        if (schemaRoot == null || currentData == null) {
+            layoutSearch = null;
+            searchCursor = -1;
+            updateMatchDisplay(0, 0);
+            return;
+        }
+        layoutSearch = new LayoutSearch(schemaRoot, currentData,
+                                        getOutermostVirtualFlow().orElse(null),
+                                        null);
+        layoutSearch.setQuery(query);
+        searchCursor = -1;
+        updateMatchDisplay(0, layoutSearch.countMatches());
+    }
+
+    private void doFindNext() {
+        if (searchBar == null) return;
+        ensureSearch();
+        if (layoutSearch == null) return;
+        layoutSearch.findNext().ifPresentOrElse(
+            r -> {
+                searchCursor++;
+                if (searchCursor >= layoutSearch.countMatches()) searchCursor = 0;
+                updateMatchDisplay(searchCursor + 1, layoutSearch.countMatches());
+            },
+            () -> updateMatchDisplay(0, 0)
+        );
+    }
+
+    private void doFindPrevious() {
+        if (searchBar == null) return;
+        ensureSearch();
+        if (layoutSearch == null) return;
+        layoutSearch.findPrevious().ifPresentOrElse(
+            r -> {
+                searchCursor--;
+                int total = layoutSearch.countMatches();
+                if (searchCursor < 0) searchCursor = total - 1;
+                updateMatchDisplay(searchCursor + 1, total);
+            },
+            () -> updateMatchDisplay(0, 0)
+        );
+    }
+
+    private void ensureSearch() {
+        if (layoutSearch == null && searchBar != null) {
+            rebuildSearch(searchBar.getSearchField().getText());
+        }
+    }
+
+    private void updateMatchDisplay(int current, int total) {
+        if (searchBar != null) {
+            searchBar.setMatchInfo(current, total);
+        }
     }
 
     private void autoLayout(JsonNode zeeData, double width) {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutDecisionKey.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutDecisionKey.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+/**
+ * Cache key for the layout decision cache in {@link AutoLayout}.
+ * Bucketing width to the nearest 10px prevents thrashing on sub-pixel resize
+ * events while still producing distinct keys across meaningful width changes.
+ *
+ * <p>The record's generated {@code equals} and {@code hashCode} make it safe
+ * to use directly as a {@link java.util.HashMap} key.
+ */
+public record LayoutDecisionKey(SchemaPath path, int widthBucket, int dataCardinality) {
+
+    /**
+     * Creates a key from a schema path, a raw pixel width, and an item count.
+     * Width is bucketed by truncating {@code width / 10} to an integer.
+     */
+    public static LayoutDecisionKey of(SchemaPath path, double width, int itemCount) {
+        return new LayoutDecisionKey(path, (int) (width / 10), itemCount);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutSearch.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutSearch.java
@@ -4,6 +4,8 @@ package com.chiralbehaviors.layout;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.chiralbehaviors.layout.cell.LayoutCell;
 import com.chiralbehaviors.layout.cell.control.FocusController;
@@ -13,6 +15,8 @@ import com.chiralbehaviors.layout.schema.Relation;
 import com.chiralbehaviors.layout.schema.SchemaNode;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import javafx.application.Platform;
 
 /**
  * Text search over the flat array of rows produced by a schema + data pair.
@@ -34,10 +38,29 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
  */
 public class LayoutSearch {
 
-    private final SchemaNode                  root;
-    private final JsonNode                    data;
-    private final VirtualFlow<LayoutCell<?>>  virtualFlow;
+    private final SchemaNode                     root;
+    private final JsonNode                       data;
+    private final VirtualFlow<LayoutCell<?>>     virtualFlow;
     private final FocusController<LayoutCell<?>> focusController;
+
+    /**
+     * Resolves the VirtualFlow at a given nesting depth from the scene graph.
+     * Depth 0 is the outermost flow. May return {@code null} if the depth
+     * is not present in the current layout.
+     */
+    private final Function<Integer, VirtualFlow<?>> flowResolver;
+
+    /**
+     * Schedules a task for the next JavaFX pulse. Defaults to
+     * {@link Platform#runLater}; injectable for unit tests.
+     */
+    private final Consumer<Runnable> runLater;
+
+    /** Set to {@code true} by {@link #cancelNavigation()} to stop the chain. */
+    private volatile boolean navigationCancelled = false;
+
+    /** Set to {@code true} while a navigation chain is in progress. */
+    private volatile boolean navigationInProgress = false;
 
     private String  query;
     private boolean caseSensitive = false;
@@ -54,7 +77,12 @@ public class LayoutSearch {
      * {@link #navigateToResult(SearchResult)} is a no-op.
      */
     public LayoutSearch(SchemaNode root, JsonNode data) {
-        this(root, data, null, null);
+        this.root = root;
+        this.data = data;
+        this.virtualFlow = null;
+        this.focusController = null;
+        this.flowResolver = null;
+        this.runLater = Platform::runLater;
     }
 
     /**
@@ -73,6 +101,46 @@ public class LayoutSearch {
         this.data = data;
         this.virtualFlow = (VirtualFlow<LayoutCell<?>>) virtualFlow;
         this.focusController = (FocusController<LayoutCell<?>>) focusController;
+        this.flowResolver = null;
+        this.runLater = Platform::runLater;
+    }
+
+    /**
+     * Creates a search with nested-navigation capability backed by an
+     * {@link AutoLayout} whose scene graph is walked to resolve VirtualFlows
+     * at each nesting depth.
+     *
+     * @param root       schema root
+     * @param data       array data to search
+     * @param autoLayout the AutoLayout whose control tree supplies the flows
+     */
+    public LayoutSearch(SchemaNode root, JsonNode data, AutoLayout autoLayout) {
+        this.root = root;
+        this.data = data;
+        this.virtualFlow = null;
+        this.focusController = null;
+        this.flowResolver = depth -> findFlowAtDepth(autoLayout, depth.intValue());
+        this.runLater = Platform::runLater;
+    }
+
+    /**
+     * Package-private constructor for unit tests: accepts an injectable flow
+     * resolver and a synchronous substitute for {@link Platform#runLater}.
+     *
+     * @param root         schema root
+     * @param data         array data
+     * @param flowResolver maps nesting depth → VirtualFlow (may return null)
+     * @param runLater     substitute for Platform.runLater
+     */
+    LayoutSearch(SchemaNode root, JsonNode data,
+                 Function<Integer, VirtualFlow<?>> flowResolver,
+                 Consumer<Runnable> runLater) {
+        this.root = root;
+        this.data = data;
+        this.virtualFlow = null;
+        this.focusController = null;
+        this.flowResolver = flowResolver;
+        this.runLater = runLater;
     }
 
     // -------------------------------------------------------------------------
@@ -193,6 +261,126 @@ public class LayoutSearch {
         if (focusController != null) {
             focusController.navigateTo(virtualFlow, rowIndex);
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Nested-flow chain navigation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns {@code true} while a {@link #navigateToMatch} chain is in
+     * progress (i.e., pending runLater hops remain).
+     */
+    public boolean isNavigationInProgress() {
+        return navigationInProgress;
+    }
+
+    /**
+     * Cancels any in-progress navigation chain. The next pending runLater hop
+     * will see the flag and abort without scheduling further hops.
+     */
+    public void cancelNavigation() {
+        navigationCancelled = true;
+    }
+
+    /**
+     * Begins an async chain-navigation to the position described by
+     * {@code path}. Each step in the path maps to one nesting depth: depth 0
+     * is the outermost VirtualFlow, depth 1 is the next VirtualFlow inside a
+     * rendered cell, and so on.
+     *
+     * <p>Each hop calls {@link VirtualFlow#show(int)} immediately (to scroll
+     * the current depth into view) and then schedules the next hop via
+     * {@code Platform.runLater} so that the JavaFX pulse has a chance to
+     * render the newly-scrolled cell before the inner flow is located.
+     *
+     * <p>Guards:
+     * <ul>
+     *   <li>If a navigation chain is already in progress, this call is
+     *       silently ignored — call {@link #cancelNavigation()} first.</li>
+     *   <li>If {@link #cancelNavigation()} is called between hops the chain
+     *       terminates at the next scheduled hop.</li>
+     *   <li>If the flow resolver returns {@code null} at any depth the chain
+     *       terminates gracefully.</li>
+     * </ul>
+     *
+     * @param path the navigation path; must not be {@code null}
+     */
+    public void navigateToMatch(NavigationPath path) {
+        if (navigationInProgress) {
+            return;
+        }
+        navigationCancelled = false;
+        navigationInProgress = true;
+        navigateStep(path, 0);
+    }
+
+    private void navigateStep(NavigationPath path, int depth) {
+        if (depth >= path.steps().size() || navigationCancelled) {
+            navigationInProgress = false;
+            return;
+        }
+        var step = path.steps().get(depth);
+        // Resolve VirtualFlow fresh from the scene graph — never capture across
+        // runLater boundaries so stale refs from prior layouts are not used.
+        VirtualFlow<?> vf = resolveFlowForDepth(depth);
+        if (vf == null) {
+            navigationInProgress = false;
+            return;
+        }
+        vf.show(step.rowIndex());
+        runLater.accept(() -> navigateStep(path, depth + 1));
+    }
+
+    /**
+     * Returns the VirtualFlow at the given nesting depth by consulting the
+     * injected {@code flowResolver}, or falls back to the single outermost
+     * flow stored at construction time when depth is 0 and no resolver is set.
+     *
+     * @param depth nesting depth (0 = outermost)
+     * @return the resolved flow, or {@code null} if not available
+     */
+    @SuppressWarnings("unchecked")
+    private VirtualFlow<?> resolveFlowForDepth(int depth) {
+        if (flowResolver != null) {
+            return flowResolver.apply(depth);
+        }
+        // Fallback: only depth 0 is supported via the single stored flow
+        return depth == 0 ? virtualFlow : null;
+    }
+
+    /**
+     * Walks the scene graph rooted at {@code autoLayout} and returns the
+     * VirtualFlow at nesting depth {@code depth}, where depth 0 is the
+     * outermost flow and each increment descends one VirtualFlow level deeper.
+     */
+    private static VirtualFlow<?> findFlowAtDepth(AutoLayout autoLayout,
+                                                   int depth) {
+        if (autoLayout == null) {
+            return null;
+        }
+        return findFlowAtDepth(autoLayout, depth, new int[] { 0 });
+    }
+
+    private static VirtualFlow<?> findFlowAtDepth(javafx.scene.Node node,
+                                                   int targetDepth,
+                                                   int[] currentDepth) {
+        if (node instanceof VirtualFlow<?> vf) {
+            if (currentDepth[0] == targetDepth) {
+                return vf;
+            }
+            currentDepth[0]++;
+        }
+        if (node instanceof javafx.scene.Parent parent) {
+            for (javafx.scene.Node child : parent.getChildrenUnmodifiable()) {
+                VirtualFlow<?> found = findFlowAtDepth(child, targetDepth,
+                                                       currentDepth);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
     }
 
     // -------------------------------------------------------------------------

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SearchBar.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SearchBar.java
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.net.URL;
+
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+
+/**
+ * A compact search bar overlay composed of a query {@link TextField}, a match
+ * count {@link Label}, and previous/next {@link Button}s.
+ *
+ * <p>Callers wire actions via {@link #setOnFindPrevious(Runnable)} and
+ * {@link #setOnFindNext(Runnable)}, and update the display via
+ * {@link #setMatchInfo(int, int)}.
+ *
+ * <p>Styled by the co-located {@code search-bar.css}; the root node carries
+ * the CSS style class {@code search-bar}.
+ */
+public class SearchBar extends HBox {
+
+    private static final String STYLE_SHEET  = "search-bar.css";
+    private static final String STYLE_CLASS  = "search-bar";
+
+    private final TextField searchField;
+    private final Label     matchCount;
+    private final Button    prevButton;
+    private final Button    nextButton;
+
+    private Runnable onFindNext;
+    private Runnable onFindPrevious;
+
+    public SearchBar() {
+        getStyleClass().add(STYLE_CLASS);
+        URL cssUrl = getClass().getResource(STYLE_SHEET);
+        if (cssUrl != null) {
+            getStylesheets().add(cssUrl.toExternalForm());
+        }
+
+        searchField = new TextField();
+        searchField.setPromptText("Search…");
+        HBox.setHgrow(searchField, Priority.ALWAYS);
+
+        matchCount = new Label("No matches");
+        matchCount.getStyleClass().add("search-match-count");
+        matchCount.setMinWidth(80);
+        matchCount.setAlignment(Pos.CENTER);
+
+        prevButton = new Button("<");
+        prevButton.getStyleClass().add("search-prev");
+        prevButton.setFocusTraversable(false);
+        prevButton.setOnAction(e -> {
+            if (onFindPrevious != null) {
+                onFindPrevious.run();
+            }
+        });
+
+        nextButton = new Button(">");
+        nextButton.getStyleClass().add("search-next");
+        nextButton.setFocusTraversable(false);
+        nextButton.setOnAction(e -> {
+            if (onFindNext != null) {
+                onFindNext.run();
+            }
+        });
+
+        // Enter in the text field triggers findNext (consumed before TRAVERSAL_INPUT_MAP).
+        searchField.setOnAction(e -> {
+            if (onFindNext != null) {
+                onFindNext.run();
+            }
+        });
+
+        setAlignment(Pos.CENTER_LEFT);
+        setSpacing(4);
+        getChildren().addAll(searchField, matchCount, prevButton, nextButton);
+    }
+
+    /** Returns the query {@link TextField}. */
+    public TextField getSearchField() {
+        return searchField;
+    }
+
+    /**
+     * Updates the match count display.
+     *
+     * @param current 1-based index of the current match (0 means none selected)
+     * @param total   total number of matches
+     */
+    public void setMatchInfo(int current, int total) {
+        if (total == 0 || current == 0) {
+            matchCount.setText("No matches");
+        } else {
+            matchCount.setText(current + " of " + total);
+        }
+    }
+
+    /**
+     * Sets the action invoked when the user presses the next button or Enter
+     * in the search field.
+     *
+     * @param action the runnable to call, or {@code null} to clear
+     */
+    public void setOnFindNext(Runnable action) {
+        this.onFindNext = action;
+    }
+
+    /**
+     * Sets the action invoked when the user presses the previous button.
+     *
+     * @param action the runnable to call, or {@code null} to clear
+     */
+    public void setOnFindPrevious(Runnable action) {
+        this.onFindPrevious = action;
+    }
+}

--- a/kramer/src/main/resources/com/chiralbehaviors/layout/search-bar.css
+++ b/kramer/src/main/resources/com/chiralbehaviors/layout/search-bar.css
@@ -1,0 +1,25 @@
+.search-bar {
+    -fx-background-color: derive(-fx-control-inner-background, -5%);
+    -fx-border-color: derive(-fx-text-box-border, -10%);
+    -fx-border-width: 1 0 0 0;
+    -fx-padding: 4 6 4 6;
+    -fx-spacing: 4;
+}
+
+.search-bar .text-field {
+    -fx-pref-height: 22;
+}
+
+.search-match-count {
+    -fx-text-fill: derive(-fx-text-box-border, -30%);
+    -fx-font-size: 11px;
+    -fx-min-width: 80;
+    -fx-alignment: center;
+}
+
+.search-prev,
+.search-next {
+    -fx-pref-width: 28;
+    -fx-pref-height: 22;
+    -fx-padding: 0 4 0 4;
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionCacheTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionCacheTest.java
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Kramer-6g1: LayoutDecisionKey record and cache infrastructure.
+ */
+class LayoutDecisionCacheTest {
+
+    // ---- LayoutDecisionKey equality ----
+
+    @Test
+    void samePathBucketCardinalityAreEqual() {
+        var path = new SchemaPath("root").child("items");
+        var k1 = LayoutDecisionKey.of(path, 250.0, 5);
+        var k2 = LayoutDecisionKey.of(path, 255.0, 5); // same bucket (250/10=25)
+        assertEquals(k1, k2, "Keys with the same width bucket must be equal");
+        assertEquals(k1.hashCode(), k2.hashCode());
+    }
+
+    @Test
+    void differentWidthBucketProducesDifferentKey() {
+        var path = new SchemaPath("root");
+        var k1 = LayoutDecisionKey.of(path, 100.0, 3); // bucket 10
+        var k2 = LayoutDecisionKey.of(path, 110.0, 3); // bucket 11
+        assertNotEquals(k1, k2, "Different width buckets must produce different keys");
+    }
+
+    @Test
+    void differentPathProducesDifferentKey() {
+        var path1 = new SchemaPath("root").child("a");
+        var path2 = new SchemaPath("root").child("b");
+        var k1 = LayoutDecisionKey.of(path1, 200.0, 4);
+        var k2 = LayoutDecisionKey.of(path2, 200.0, 4);
+        assertNotEquals(k1, k2);
+    }
+
+    @Test
+    void differentCardinalityProducesDifferentKey() {
+        var path = new SchemaPath("root");
+        var k1 = LayoutDecisionKey.of(path, 200.0, 4);
+        var k2 = LayoutDecisionKey.of(path, 200.0, 5);
+        assertNotEquals(k1, k2);
+    }
+
+    @Test
+    void keyRecordAccessors() {
+        var path = new SchemaPath("catalog");
+        var key = LayoutDecisionKey.of(path, 350.0, 10);
+        assertEquals(path, key.path());
+        assertEquals((int) (350.0 / 10), key.widthBucket());
+        assertEquals(10, key.dataCardinality());
+    }
+
+    // ---- Cache store/retrieve ----
+
+    @Test
+    void cacheStoresAndRetrievesLayoutResult() {
+        Map<LayoutDecisionKey, LayoutResult> cache = new HashMap<>();
+
+        var path = new SchemaPath("root");
+        var key = LayoutDecisionKey.of(path, 400.0, 7);
+        var result = new LayoutResult(true, false, 120.0, 0.0, 100.0, List.of());
+
+        cache.put(key, result);
+
+        var retrieved = cache.get(LayoutDecisionKey.of(path, 405.0, 7)); // same bucket
+        assertNotNull(retrieved);
+        assertSame(result, retrieved);
+    }
+
+    @Test
+    void cacheMissReturnsNull() {
+        Map<LayoutDecisionKey, LayoutResult> cache = new HashMap<>();
+
+        var path = new SchemaPath("root");
+        var key = LayoutDecisionKey.of(path, 400.0, 7);
+
+        assertNull(cache.get(key), "Empty cache must return null");
+    }
+
+    @Test
+    void cacheClearInvalidatesAllEntries() {
+        Map<LayoutDecisionKey, LayoutResult> cache = new HashMap<>();
+
+        var path = new SchemaPath("root");
+        cache.put(LayoutDecisionKey.of(path, 100.0, 2),
+                  new LayoutResult(false, false, 50.0, 0.0, 40.0, List.of()));
+        cache.put(LayoutDecisionKey.of(path, 200.0, 3),
+                  new LayoutResult(true, false, 80.0, 0.0, 70.0, List.of()));
+        assertEquals(2, cache.size());
+
+        // Simulates stylesheet change or autoLayout() reset
+        cache.clear();
+
+        assertTrue(cache.isEmpty(), "Cache must be empty after clear (stylesheet invalidation)");
+    }
+
+    @Test
+    void cacheInvalidatedOnCardinalityChange() {
+        Map<LayoutDecisionKey, LayoutResult> cache = new HashMap<>();
+
+        var path = new SchemaPath("root");
+        var width = 300.0;
+        int oldCardinality = 5;
+        int newCardinality = 10;
+
+        var oldKey = LayoutDecisionKey.of(path, width, oldCardinality);
+        cache.put(oldKey, new LayoutResult(false, false, 60.0, 0.0, 50.0, List.of()));
+
+        // When data changes cardinality the caller must re-measure; old key is stale.
+        var newKey = LayoutDecisionKey.of(path, width, newCardinality);
+        assertNull(cache.get(newKey),
+                   "A key with different cardinality must not hit the old cache entry");
+    }
+
+    // ---- widthBucket boundary conditions ----
+
+    @Test
+    void widthBucketTruncates() {
+        var path = new SchemaPath("x");
+        // 99.9 / 10 = 9.99 → (int) = 9
+        // 100.0 / 10 = 10.0 → (int) = 10
+        var k1 = LayoutDecisionKey.of(path, 99.9, 1);
+        var k2 = LayoutDecisionKey.of(path, 100.0, 1);
+        assertNotEquals(k1, k2, "Boundary between buckets 9 and 10 must be distinct");
+    }
+
+    @Test
+    void usableAsMapKey() {
+        // Verify the record is a valid map key (equals+hashCode contract)
+        var path = new SchemaPath("root");
+        Map<LayoutDecisionKey, String> map = new HashMap<>();
+        var k = LayoutDecisionKey.of(path, 500.0, 3);
+        map.put(k, "value");
+        assertEquals("value", map.get(LayoutDecisionKey.of(path, 509.9, 3)));
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/NestedNavigationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/NestedNavigationTest.java
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.cell.LayoutCell;
+import com.chiralbehaviors.layout.flowless.VirtualFlow;
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for nested VirtualFlow chain navigation in LayoutSearch.
+ *
+ * <p>These tests exercise the async Platform.runLater chain without a live
+ * JavaFX scene by supplying a synchronous runLater substitute and an
+ * injectable flow resolver.
+ */
+class NestedNavigationTest {
+
+    /** Synchronous substitute for Platform.runLater in tests. */
+    private final List<Runnable> pendingRunnables = new ArrayList<>();
+
+    private Relation                                     schema;
+    private com.fasterxml.jackson.databind.node.ArrayNode data;
+
+    @BeforeEach
+    void setUp() {
+        pendingRunnables.clear();
+        schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+
+        data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 5; i++) {
+            var row = JsonNodeFactory.instance.objectNode();
+            row.put("name", "Item" + i);
+            data.add(row);
+        }
+    }
+
+    /** Drains all pending runnables synchronously (simulates JavaFX pulse pump). */
+    private void drainAll() {
+        while (!pendingRunnables.isEmpty()) {
+            List<Runnable> batch = new ArrayList<>(pendingRunnables);
+            pendingRunnables.clear();
+            batch.forEach(Runnable::run);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // navigationCancelled flag prevents further hops
+    // -----------------------------------------------------------------------
+
+    @Test
+    void cancellationPreventsHops() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf0 = mock(VirtualFlow.class);
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf1 = mock(VirtualFlow.class);
+
+        Function<Integer, VirtualFlow<?>> resolver = depth -> switch (depth) {
+            case 0 -> vf0;
+            case 1 -> vf1;
+            default -> null;
+        };
+
+        var path = buildPath(0, 2);
+        var search = new LayoutSearch(schema, data, resolver, pendingRunnables::add);
+        search.navigateToMatch(path);
+
+        // After first hop vf0.show(0) is called and a runLater is queued
+        verify(vf0).show(0);
+        assertEquals(1, pendingRunnables.size());
+
+        // Cancel before draining — second hop must not execute
+        search.cancelNavigation();
+        drainAll();
+
+        verifyNoInteractions(vf1);
+        assertFalse(search.isNavigationInProgress());
+    }
+
+    // -----------------------------------------------------------------------
+    // navigationInProgress guard prevents overlapping chains
+    // -----------------------------------------------------------------------
+
+    @Test
+    void inProgressGuardPreventsOverlap() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf0 = mock(VirtualFlow.class);
+
+        AtomicInteger showCount = new AtomicInteger();
+        doAnswer(inv -> { showCount.incrementAndGet(); return null; }).when(vf0).show(anyInt());
+
+        Function<Integer, VirtualFlow<?>> resolver = depth -> depth == 0 ? vf0 : null;
+
+        var path = buildPath(0);   // single step
+        var search = new LayoutSearch(schema, data, resolver, pendingRunnables::add);
+
+        search.navigateToMatch(path);
+        assertTrue(search.isNavigationInProgress());
+
+        // Second call while still in progress must be a no-op
+        search.navigateToMatch(path);
+        drainAll();
+
+        // vf0.show() called exactly once from the first chain
+        assertEquals(1, showCount.get());
+    }
+
+    // -----------------------------------------------------------------------
+    // null VirtualFlow at depth aborts chain gracefully
+    // -----------------------------------------------------------------------
+
+    @Test
+    void nullFlowAtDepthAbortsGracefully() {
+        // Resolver always returns null — should not throw
+        Function<Integer, VirtualFlow<?>> resolver = depth -> null;
+
+        var path = buildPath(3);
+        var search = new LayoutSearch(schema, data, resolver, pendingRunnables::add);
+
+        assertDoesNotThrow(() -> search.navigateToMatch(path));
+        drainAll();
+
+        assertFalse(search.isNavigationInProgress());
+    }
+
+    @Test
+    void nullFlowAtSecondDepthAbortsAfterFirstHop() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf0 = mock(VirtualFlow.class);
+
+        // depth 0 ok, depth 1 returns null
+        Function<Integer, VirtualFlow<?>> resolver = depth -> depth == 0 ? vf0 : null;
+
+        var path = buildPath(0, 2);  // two steps
+        var search = new LayoutSearch(schema, data, resolver, pendingRunnables::add);
+
+        search.navigateToMatch(path);
+        verify(vf0).show(0);
+        assertEquals(1, pendingRunnables.size());
+
+        // Drain — second step should abort because vf1 is null
+        drainAll();
+
+        assertFalse(search.isNavigationInProgress());
+        verifyNoMoreInteractions(vf0);
+    }
+
+    // -----------------------------------------------------------------------
+    // NavigationPath with multiple steps chains correctly
+    // -----------------------------------------------------------------------
+
+    @Test
+    void multiStepPathChainsCorrectly() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf0 = mock(VirtualFlow.class);
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf1 = mock(VirtualFlow.class);
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf2 = mock(VirtualFlow.class);
+
+        Function<Integer, VirtualFlow<?>> resolver = depth -> switch (depth) {
+            case 0 -> vf0;
+            case 1 -> vf1;
+            case 2 -> vf2;
+            default -> null;
+        };
+
+        // Three steps: row 1, row 3, row 0
+        var path = buildPath(1, 3, 0);
+        var search = new LayoutSearch(schema, data, resolver, pendingRunnables::add);
+
+        // Step 0: immediate
+        search.navigateToMatch(path);
+        verify(vf0).show(1);
+        assertEquals(1, pendingRunnables.size());
+
+        // Step 1: first pulse
+        List<Runnable> pulse1 = new ArrayList<>(pendingRunnables);
+        pendingRunnables.clear();
+        pulse1.forEach(Runnable::run);
+        verify(vf1).show(3);
+        assertEquals(1, pendingRunnables.size());
+
+        // Step 2: second pulse
+        drainAll();
+        verify(vf2).show(0);
+
+        assertFalse(search.isNavigationInProgress());
+    }
+
+    @Test
+    void singleStepPathCompletesWithoutRunLater() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf0 = mock(VirtualFlow.class);
+
+        Function<Integer, VirtualFlow<?>> resolver = depth -> depth == 0 ? vf0 : null;
+
+        var path = buildPath(2);  // single step, rowIndex=2
+        var search = new LayoutSearch(schema, data, resolver, pendingRunnables::add);
+
+        search.navigateToMatch(path);
+
+        verify(vf0).show(2);
+        // No more hops — navigationInProgress should clear without draining
+        // (the runLater is fired but clears the flag)
+        drainAll();
+        assertFalse(search.isNavigationInProgress());
+        assertTrue(pendingRunnables.isEmpty());
+    }
+
+    @Test
+    void cancelNavigationResetsCancelledFlagOnNextNavigate() {
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf0 = mock(VirtualFlow.class);
+        @SuppressWarnings("unchecked")
+        VirtualFlow<LayoutCell<?>> vf1 = mock(VirtualFlow.class);
+
+        Function<Integer, VirtualFlow<?>> resolver = depth -> switch (depth) {
+            case 0 -> vf0;
+            case 1 -> vf1;
+            default -> null;
+        };
+
+        var path = buildPath(0, 1);
+        var search = new LayoutSearch(schema, data, resolver, pendingRunnables::add);
+
+        // First chain, then cancel
+        search.navigateToMatch(path);
+        search.cancelNavigation();
+        drainAll();
+        assertFalse(search.isNavigationInProgress());
+
+        // Second chain must run fully despite prior cancellation
+        search.navigateToMatch(path);
+        verify(vf0, times(2)).show(0);
+
+        drainAll();
+        verify(vf1).show(1);
+        assertFalse(search.isNavigationInProgress());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: build a NavigationPath from row indices (one step per index)
+    // -----------------------------------------------------------------------
+
+    private NavigationPath buildPath(int... rowIndices) {
+        var fieldPath = new SchemaPath("items").child("name");
+        List<NavigationPath.NavigationStep> steps = new ArrayList<>();
+        for (int idx : rowIndices) {
+            steps.add(new NavigationPath.NavigationStep(fieldPath, idx));
+        }
+        return new NavigationPath(steps);
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SearchBarTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SearchBarTest.java
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextField;
+import javafx.stage.Stage;
+
+/**
+ * Tests for SearchBar component.
+ *
+ * Runs under TestFX with Monocle headless toolkit so JavaFX nodes
+ * can be instantiated and inspected without a display.
+ */
+class SearchBarTest extends ApplicationTest {
+
+    private SearchBar searchBar;
+
+    @Override
+    public void start(Stage stage) {
+        searchBar = new SearchBar();
+    }
+
+    @Test
+    void constructionCreatesTextField() {
+        assertNotNull(searchBar.getSearchField(),
+                      "getSearchField() must return a non-null TextField");
+        assertInstanceOf(TextField.class, searchBar.getSearchField());
+    }
+
+    @Test
+    void constructionCreatesMatchCountLabel() {
+        // find the Label child in the HBox
+        long labelCount = searchBar.getChildren().stream()
+                                   .filter(n -> n instanceof Label)
+                                   .count();
+        assertTrue(labelCount >= 1, "SearchBar must contain at least one Label for match count");
+    }
+
+    @Test
+    void constructionCreatesNextAndPrevButtons() {
+        long buttonCount = searchBar.getChildren().stream()
+                                    .filter(n -> n instanceof Button)
+                                    .count();
+        assertEquals(2, buttonCount, "SearchBar must contain exactly two Buttons (prev and next)");
+    }
+
+    @Test
+    void setMatchInfoDisplaysCurrentOfTotal() {
+        searchBar.setMatchInfo(3, 17);
+        Label matchLabel = findMatchCountLabel();
+        assertEquals("3 of 17", matchLabel.getText());
+    }
+
+    @Test
+    void setMatchInfoZeroDisplaysNoMatches() {
+        searchBar.setMatchInfo(0, 0);
+        Label matchLabel = findMatchCountLabel();
+        assertEquals("No matches", matchLabel.getText());
+    }
+
+    @Test
+    void setMatchInfoZeroTotalDisplaysNoMatches() {
+        searchBar.setMatchInfo(0, 5);
+        Label matchLabel = findMatchCountLabel();
+        // 0 current with non-zero total still means "No matches" (nothing found yet)
+        assertEquals("No matches", matchLabel.getText());
+    }
+
+    @Test
+    void setMatchInfoOneOfOneDisplaysCorrectly() {
+        searchBar.setMatchInfo(1, 1);
+        Label matchLabel = findMatchCountLabel();
+        assertEquals("1 of 1", matchLabel.getText());
+    }
+
+    @Test
+    void searchFieldIsIncludedInChildren() {
+        assertTrue(searchBar.getChildren().contains(searchBar.getSearchField()),
+                   "SearchField must be a direct child of the SearchBar HBox");
+    }
+
+    @Test
+    void setOnFindNextInvokesRunnable() {
+        boolean[] called = { false };
+        searchBar.setOnFindNext(() -> called[0] = true);
+
+        // Fire the next button
+        Button nextButton = findNextButton();
+        nextButton.fire();
+
+        assertTrue(called[0], "setOnFindNext runnable must be called when next button fires");
+    }
+
+    @Test
+    void setOnFindPreviousInvokesRunnable() {
+        boolean[] called = { false };
+        searchBar.setOnFindPrevious(() -> called[0] = true);
+
+        Button prevButton = findPrevButton();
+        prevButton.fire();
+
+        assertTrue(called[0], "setOnFindPrevious runnable must be called when prev button fires");
+    }
+
+    @Test
+    void findNextHandlerCanBeReplacedWithNull() {
+        searchBar.setOnFindNext(() -> { /* noop */ });
+        assertDoesNotThrow(() -> searchBar.setOnFindNext(null));
+
+        Button nextButton = findNextButton();
+        assertDoesNotThrow(nextButton::fire, "Null find-next handler must not throw on button fire");
+    }
+
+    @Test
+    void findPreviousHandlerCanBeReplacedWithNull() {
+        searchBar.setOnFindPrevious(() -> { /* noop */ });
+        assertDoesNotThrow(() -> searchBar.setOnFindPrevious(null));
+
+        Button prevButton = findPrevButton();
+        assertDoesNotThrow(prevButton::fire, "Null find-prev handler must not throw on button fire");
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private Label findMatchCountLabel() {
+        return searchBar.getChildren().stream()
+                        .filter(n -> n instanceof Label)
+                        .map(n -> (Label) n)
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("No Label found in SearchBar"));
+    }
+
+    /** Returns the button whose text starts with ">" or is identified as the next button. */
+    private Button findNextButton() {
+        var buttons = searchBar.getChildren().stream()
+                               .filter(n -> n instanceof Button)
+                               .map(n -> (Button) n)
+                               .toList();
+        assertEquals(2, buttons.size(), "Expected exactly 2 buttons");
+        // By convention next is the last button
+        return buttons.get(1);
+    }
+
+    private Button findPrevButton() {
+        var buttons = searchBar.getChildren().stream()
+                               .filter(n -> n instanceof Button)
+                               .map(n -> (Button) n)
+                               .toList();
+        assertEquals(2, buttons.size(), "Expected exactly 2 buttons");
+        // By convention prev is the first button
+        return buttons.get(0);
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SortIntegrationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SortIntegrationTest.java
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * End-to-end integration tests for stable sort through the full measure
+ * pipeline with realistic multi-field JSON data (id, name, value).
+ *
+ * Complements the unit-level RelationLayoutSortTest by exercising the
+ * complete measure() → extractFrom() path with richer fixture data.
+ */
+class SortIntegrationTest {
+
+    private static final JsonNodeFactory NF = JsonNodeFactory.instance;
+
+    // Schema: Relation("records") with children id (int), name (string), value (int)
+    private Relation       schema;
+    private RelationStyle  relStyle;
+    private Style          model;
+
+    @BeforeEach
+    void setUp() {
+        schema = new Relation("records");
+        schema.addChild(new Primitive("id"));
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("value"));
+
+        relStyle = TestLayouts.mockRelationStyle();
+
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+
+        model = mock(Style.class);
+        for (SchemaNode child : schema.getChildren()) {
+            if (child instanceof Primitive p) {
+                PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+                when(model.layout(p)).thenReturn(pl);
+            }
+        }
+        // Delegate any SchemaNode dispatch back to typed overloads
+        when(model.layout(any(SchemaNode.class))).thenAnswer(inv -> {
+            SchemaNode n = inv.getArgument(0);
+            if (n instanceof Primitive p) return model.layout(p);
+            return model.layout((Relation) n);
+        });
+    }
+
+    /**
+     * Build a row with integer id, string name, integer value.
+     */
+    private ObjectNode row(int id, String name, int value) {
+        ObjectNode obj = NF.objectNode();
+        obj.put("id", id);
+        obj.put("name", name);
+        obj.put("value", value);
+        return obj;
+    }
+
+    /**
+     * Run measure() then extractFrom() and return the extracted array.
+     */
+    private JsonNode measureAndExtract(RelationLayout layout, ArrayNode data) {
+        layout.measure(data, n -> n, model);
+        ObjectNode parent = NF.objectNode();
+        parent.set("records", data);
+        return layout.extractFrom(parent);
+    }
+
+    /**
+     * Collect field values from an extracted array in order.
+     */
+    private <T> List<T> collect(JsonNode extracted, String field,
+                                java.util.function.Function<JsonNode, T> mapper) {
+        List<T> result = new ArrayList<>();
+        extracted.forEach(row -> result.add(mapper.apply(row.get(field))));
+        return result;
+    }
+
+    // -----------------------------------------------------------------------
+    // autoSort=false preserves original JSON order
+    // -----------------------------------------------------------------------
+
+    @Test
+    void noSortPreservesOriginalOrder() {
+        // Default: autoSort=false, no sortFields
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = NF.arrayNode();
+        data.add(row(10, "Zebra",  99));
+        data.add(row(2,  "Alpha",  5));
+        data.add(row(100,"Mango",  42));
+        data.add(row(1,  "Berry",  77));
+
+        JsonNode extracted = measureAndExtract(layout, data);
+
+        List<Integer> ids = collect(extracted, "id", JsonNode::intValue);
+        assertEquals(List.of(10, 2, 100, 1), ids,
+                     "autoSort=false must preserve original insertion order");
+    }
+
+    // -----------------------------------------------------------------------
+    // Numeric sort field: 10 comes before 100 (numeric, not lexicographic)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void numericIdSortsNumerically() {
+        schema.setSortFields(List.of("id"));
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        // Lexicographic order would be: 1, 10, 100, 2
+        // Numeric order must be:        1, 2, 10, 100
+        ArrayNode data = NF.arrayNode();
+        data.add(row(10,  "Ten",     10));
+        data.add(row(100, "Hundred", 100));
+        data.add(row(2,   "Two",     2));
+        data.add(row(1,   "One",     1));
+
+        JsonNode extracted = measureAndExtract(layout, data);
+
+        List<Integer> ids = collect(extracted, "id", JsonNode::intValue);
+        assertEquals(List.of(1, 2, 10, 100), ids,
+                     "Numeric id field must sort numerically (1 < 2 < 10 < 100), not lexicographically");
+    }
+
+    // -----------------------------------------------------------------------
+    // String sort field: lexicographic on name
+    // -----------------------------------------------------------------------
+
+    @Test
+    void stringSortFieldSortsLexicographically() {
+        schema.setSortFields(List.of("name"));
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = NF.arrayNode();
+        data.add(row(3,  "Zebra",   30));
+        data.add(row(1,  "Apple",   10));
+        data.add(row(2,  "Mango",   20));
+
+        JsonNode extracted = measureAndExtract(layout, data);
+
+        List<String> names = collect(extracted, "name", JsonNode::asText);
+        assertEquals(List.of("Apple", "Mango", "Zebra"), names,
+                     "String sort field must produce lexicographic order");
+    }
+
+    // -----------------------------------------------------------------------
+    // Null and missing sort fields sort last without NPE
+    // -----------------------------------------------------------------------
+
+    @Test
+    void nullAndMissingValuesInSortFieldSortLast() {
+        schema.setSortFields(List.of("value"));
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = NF.arrayNode();
+        // Row with value present
+        ObjectNode r1 = NF.objectNode();
+        r1.put("id", 1); r1.put("name", "HasValue"); r1.put("value", 5);
+        data.add(r1);
+        // Row with explicit null value
+        ObjectNode r2 = NF.objectNode();
+        r2.put("id", 2); r2.put("name", "NullValue"); r2.putNull("value");
+        data.add(r2);
+        // Row with value field entirely missing
+        ObjectNode r3 = NF.objectNode();
+        r3.put("id", 3); r3.put("name", "MissingValue");
+        data.add(r3);
+        // Row with another present value
+        ObjectNode r4 = NF.objectNode();
+        r4.put("id", 4); r4.put("name", "AlsoHasValue"); r4.put("value", 1);
+        data.add(r4);
+
+        JsonNode extracted = assertDoesNotThrow(
+            () -> measureAndExtract(layout, data),
+            "Null/missing sort values must not throw NPE"
+        );
+
+        List<String> names = collect(extracted, "name", JsonNode::asText);
+        // Rows with values come first (sorted numerically: 1, 5)
+        assertTrue(names.indexOf("AlsoHasValue") < names.indexOf("NullValue"),
+                   "row with value=1 must precede row with null value");
+        assertTrue(names.indexOf("HasValue") < names.indexOf("NullValue"),
+                   "row with value=5 must precede row with null value");
+        // Null/missing must sort last
+        assertTrue(names.indexOf("NullValue")    >= 2, "null value must sort last");
+        assertTrue(names.indexOf("MissingValue") >= 2, "missing value must sort last");
+    }
+
+    // -----------------------------------------------------------------------
+    // autoSort=true with "id" child uses id as sort key
+    // -----------------------------------------------------------------------
+
+    @Test
+    void autoSortWithIdFieldUsesIdAsSortKey() {
+        schema.setAutoSort(true);
+        // sortFields is empty — autoSort heuristic should pick "id"
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = NF.arrayNode();
+        data.add(row(30, "Charlie", 3));
+        data.add(row(10, "Alice",   1));
+        data.add(row(20, "Bob",     2));
+
+        JsonNode extracted = measureAndExtract(layout, data);
+
+        List<Integer> ids = collect(extracted, "id", JsonNode::intValue);
+        assertEquals(List.of(10, 20, 30), ids,
+                     "autoSort=true with 'id' child must sort by id");
+    }
+
+    // -----------------------------------------------------------------------
+    // Sort is stable: equal keys preserve relative insertion order
+    // -----------------------------------------------------------------------
+
+    @Test
+    void sortIsStableOnEqualKeys() {
+        schema.setSortFields(List.of("value"));
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        // Rows with the same value=10 — stable sort must keep insertion order
+        ArrayNode data = NF.arrayNode();
+        data.add(row(1, "First",  10));
+        data.add(row(2, "Second", 99));
+        data.add(row(3, "Third",  10));
+
+        JsonNode extracted = measureAndExtract(layout, data);
+
+        List<String> names = collect(extracted, "name", JsonNode::asText);
+        // value=10 rows appear first (both tie), then value=99
+        int firstIdx  = names.indexOf("First");
+        int thirdIdx  = names.indexOf("Third");
+        int secondIdx = names.indexOf("Second");
+        assertTrue(firstIdx  < secondIdx, "'First'  (value=10) must precede 'Second' (value=99)");
+        assertTrue(thirdIdx  < secondIdx, "'Third'  (value=10) must precede 'Second' (value=99)");
+        // Stable: First was inserted before Third, so must remain before Third
+        assertTrue(firstIdx  < thirdIdx,  "Stable sort: 'First' must precede 'Third' (equal keys, insertion order)");
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiple sort fields: primary + secondary sort
+    // -----------------------------------------------------------------------
+
+    @Test
+    void multipleExplicitSortFields() {
+        // Sort by value ascending, then name ascending for ties
+        schema.setSortFields(List.of("value", "name"));
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+
+        ArrayNode data = NF.arrayNode();
+        data.add(row(1, "Zebra",   10));
+        data.add(row(2, "Apple",   10));   // same value as Zebra — name tiebreak
+        data.add(row(3, "Mango",   5));
+
+        JsonNode extracted = measureAndExtract(layout, data);
+
+        List<String> names = collect(extracted, "name", JsonNode::asText);
+        // value=5 first, then value=10 ties broken by name: Apple < Zebra
+        assertEquals(List.of("Mango", "Apple", "Zebra"), names,
+                     "Multi-field sort: value asc then name asc for ties");
+    }
+}


### PR DESCRIPTION
## Summary
4 beads across 3 RDRs:

- **RDR-014** (Kramer-ir7): Sort integration test fixture — 7 end-to-end tests (numeric, lexicographic, null-last, autoSort heuristic, multi-field, stability)
- **RDR-016** (Kramer-6g1): `LayoutDecisionKey` record + `decisionCache` on `AutoLayout`. Root property listener nulls layout/measureResult on schema change. Cache cleared on stylesheet/data/root changes.
- **RDR-017** (Kramer-ogr): `SearchBar` UI — HBox with TextField, match count label, prev/next buttons. Keyboard bindings: Ctrl+F, F3, Shift+F3, Escape. Co-located `search-bar.css`.
- **RDR-017** (Kramer-2ff): Nested VirtualFlow chain navigation — async `Platform.runLater()` per depth, fresh VF resolution per hop, cancellation flag, in-progress overlap guard.

## Test plan
- [x] 301 tests pass (37 new)
- [x] Sort integration: 7 tests
- [x] SearchBar: 12 tests (construction, match info, callbacks, null safety)
- [x] Layout cache: 11 tests (key equality, buckets, store/retrieve, invalidation)
- [x] Nested nav: 7 tests (cancellation, overlap guard, null flow, multi-step)

Ref: Kramer-ir7, Kramer-ogr, Kramer-6g1, Kramer-2ff