### PR TITLE
Wave 1 Batch 4: hideIfEmpty + LayoutStylesheet pipeline wiring

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/schema/Relation.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/schema/Relation.java
@@ -26,11 +26,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  */
 public non-sealed class Relation extends SchemaNode {
-    private boolean                autoFold   = true;
-    private boolean                autoSort   = false;
-    private final List<SchemaNode> children   = new ArrayList<>();
+    private boolean                autoFold     = true;
+    private boolean                autoSort     = false;
+    private final List<SchemaNode> children     = new ArrayList<>();
     private Relation               fold;
-    private List<String>           sortFields = List.of();
+    private Boolean                hideIfEmpty  = null;
+    private List<String>           sortFields   = List.of();
 
     public Relation(String label) {
         super(label);
@@ -82,6 +83,14 @@ public non-sealed class Relation extends SchemaNode {
         this.fold = (fold && children.size() == 1
                      && children.get(0) instanceof Relation r) ? r
                                                                : null;
+    }
+
+    public Boolean getHideIfEmpty() {
+        return hideIfEmpty;
+    }
+
+    public void setHideIfEmpty(Boolean hide) {
+        this.hideIfEmpty = hide;
     }
 
     public List<String> getSortFields() {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/Style.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/Style.java
@@ -22,7 +22,9 @@ import java.util.List;
 
 import javafx.application.Platform;
 
+import com.chiralbehaviors.layout.DefaultLayoutStylesheet;
 import com.chiralbehaviors.layout.LayoutLabel;
+import com.chiralbehaviors.layout.LayoutStylesheet;
 import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.PrimitiveLayout;
 import com.chiralbehaviors.layout.RelationLayout;
@@ -130,6 +132,7 @@ public class Style {
 
     private final LayoutObserver              observer;
     private Object                            owner;
+    private LayoutStylesheet                  stylesheet;
 
     private final List<String>                styleSheets          = new ArrayList<>();
     private final IdentityHashMap<Primitive, PrimitiveStyle>  primitiveStyleCache  = new IdentityHashMap<>();
@@ -143,6 +146,28 @@ public class Style {
 
     public Style(LayoutObserver observer) {
         this.observer = observer;
+        this.stylesheet = new DefaultLayoutStylesheet(this);
+    }
+
+    public Style(LayoutObserver observer, LayoutStylesheet stylesheet) {
+        this.observer = observer;
+        this.stylesheet = stylesheet;
+    }
+
+    public Style(LayoutStylesheet stylesheet) {
+        this(new LayoutObserver() {
+        }, stylesheet);
+    }
+
+    public LayoutStylesheet getStylesheet() {
+        return stylesheet;
+    }
+
+    public void setStylesheet(LayoutStylesheet stylesheet) {
+        if (stylesheet == null) {
+            throw new NullPointerException("stylesheet must not be null");
+        }
+        this.stylesheet = stylesheet;
     }
 
     public <T extends LayoutCell<?>> void apply(T cell, Primitive p) {

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutStylesheetWiringTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutStylesheetWiringTest.java
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.style.Style;
+
+/**
+ * Tests for Kramer-517: LayoutStylesheet wired into Style (the measure/layout/compress pipeline).
+ */
+class LayoutStylesheetWiringTest {
+
+    @Test
+    void defaultConstructorCreatesDefaultStylesheet() {
+        Style style = new Style();
+        assertNotNull(style.getStylesheet(),
+                      "Default constructor must set a non-null LayoutStylesheet");
+    }
+
+    @Test
+    void defaultStylesheetIsDefaultLayoutStylesheet() {
+        Style style = new Style();
+        assertInstanceOf(DefaultLayoutStylesheet.class, style.getStylesheet(),
+                         "Default constructor must create a DefaultLayoutStylesheet");
+    }
+
+    @Test
+    void observerConstructorCreatesDefaultStylesheet() {
+        Style.LayoutObserver observer = new Style.LayoutObserver() {};
+        Style style = new Style(observer);
+        assertNotNull(style.getStylesheet(),
+                      "Observer constructor must set a non-null LayoutStylesheet");
+        assertInstanceOf(DefaultLayoutStylesheet.class, style.getStylesheet(),
+                         "Observer constructor must create a DefaultLayoutStylesheet");
+    }
+
+    @Test
+    void explicitStylesheetConstructorStoresIt() {
+        Style.LayoutObserver observer = new Style.LayoutObserver() {};
+        LayoutStylesheet explicit = mock(LayoutStylesheet.class);
+        Style style = new Style(observer, explicit);
+        assertSame(explicit, style.getStylesheet(),
+                   "Explicit stylesheet constructor must store the provided instance");
+    }
+
+    @Test
+    void explicitStylesheetConstructorDefaultObserver() {
+        LayoutStylesheet explicit = mock(LayoutStylesheet.class);
+        Style style = new Style(explicit);
+        assertSame(explicit, style.getStylesheet(),
+                   "Style(LayoutStylesheet) must store the provided stylesheet");
+    }
+
+    @Test
+    void defaultStylesheetVersionStartsAtZero() {
+        Style style = new Style();
+        assertEquals(0L, style.getStylesheet().getVersion(),
+                     "Default stylesheet version must start at 0");
+    }
+
+    @Test
+    void primitiveLayoutCanAccessStylesheetViaModel() {
+        Style style = new Style();
+        LayoutStylesheet sheet = style.getStylesheet();
+        assertNotNull(sheet, "PrimitiveLayout can reach stylesheet via style.getStylesheet()");
+    }
+
+    @Test
+    void relationLayoutCanAccessStylesheetViaModel() {
+        Style style = new Style();
+        LayoutStylesheet sheet = style.getStylesheet();
+        assertNotNull(sheet, "RelationLayout can reach stylesheet via style.getStylesheet()");
+    }
+
+    @Test
+    void setStylesheetReplacesExistingSheet() {
+        Style style = new Style();
+        LayoutStylesheet replacement = mock(LayoutStylesheet.class);
+        style.setStylesheet(replacement);
+        assertSame(replacement, style.getStylesheet(),
+                   "setStylesheet must replace the current stylesheet");
+    }
+
+    @Test
+    void setStylesheetNullThrows() {
+        Style style = new Style();
+        assertThrows(NullPointerException.class, () -> style.setStylesheet(null),
+                     "setStylesheet(null) must throw NullPointerException");
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RelationHideIfEmptyPropertyTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RelationHideIfEmptyPropertyTest.java
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Relation;
+
+/**
+ * Tests for Relation.hideIfEmpty property.
+ */
+class RelationHideIfEmptyPropertyTest {
+
+    @Test
+    void hideIfEmptyDefaultsToNull() {
+        var r = new Relation("items");
+        assertNull(r.getHideIfEmpty());
+    }
+
+    @Test
+    void setHideIfEmptyTrueRoundtrip() {
+        var r = new Relation("items");
+        r.setHideIfEmpty(true);
+        assertEquals(Boolean.TRUE, r.getHideIfEmpty());
+    }
+
+    @Test
+    void setHideIfEmptyFalseExplicitlyDisables() {
+        var r = new Relation("items");
+        r.setHideIfEmpty(false);
+        assertEquals(Boolean.FALSE, r.getHideIfEmpty());
+    }
+
+    @Test
+    void setHideIfEmptyNullResetsToDelegate() {
+        var r = new Relation("items");
+        r.setHideIfEmpty(true);
+        r.setHideIfEmpty(null);
+        assertNull(r.getHideIfEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-014** (Kramer-rtl): `hideIfEmpty` nullable `Boolean` property on `Relation` (null = delegate to stylesheet)
- **Cross-cutting** (Kramer-517): `LayoutStylesheet` wired into `Style`. All layout code can now access per-path properties via `model.getStylesheet()`. Unblocks RDR-013 Phase 2, RDR-014 stylesheet lookup, RDR-015, RDR-018.

## Test plan
- [x] 315 tests pass (14 new)
- [x] hideIfEmpty: 4 tests (default null, set true, set false, reset to null)
- [x] LayoutStylesheet wiring: 10 tests (all constructors, getter, setter, null guard, pipeline accessibility)

Ref: Kramer-rtl, Kramer-517