### PR TITLE
Wave 1 Batch 5: hideIfEmpty filter + convergence detection

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -53,6 +53,12 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     private boolean                useVerticalHeader         = false;
     private MeasureResult          measureResult;
 
+    // Convergence detection state (Kramer-16k)
+    private MeasureResult          frozenResult;
+    private long                   frozenStylesheetVersion   = -1;
+    private double                 lastP90Width              = Double.NaN;
+    private int                    consecutiveStableCount    = 0;
+
     public PrimitiveLayout(Primitive p, PrimitiveStyle style) {
         super(p, style.getLabelStyle());
         this.style = style;
@@ -161,6 +167,19 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     @Override
     public double measure(JsonNode data, Function<JsonNode, JsonNode> extractor,
                           Style model) {
+        // Convergence short-circuit: return frozen result if stylesheet unchanged.
+        if (frozenResult != null && model != null) {
+            LayoutStylesheet stylesheet = model.getStylesheet();
+            if (stylesheet != null && frozenStylesheetVersion == stylesheet.getVersion()) {
+                return frozenResult.columnWidth();
+            }
+            // Stylesheet version changed — invalidate frozen state.
+            frozenResult = null;
+            frozenStylesheetVersion = -1;
+            lastP90Width = Double.NaN;
+            consecutiveStableCount = 0;
+        }
+
         clear();
         labelWidth = labelWidth(node.getLabel());
         double summedDataWidth = 0;
@@ -206,14 +225,42 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             isVariableLength = true; // safe fallback for empty data
         }
 
-        // Compute percentile stats when sample count is sufficient (Phase 1: minSamples=30).
+        // Compute percentile stats when sample count is sufficient.
+        // Read minSamples from stylesheet if available; fall back to compile-time default.
+        int minSamples = MIN_SAMPLES;
+        double epsilon = 1.0;
+        int k = 3;
+        LayoutStylesheet stylesheet = (model != null) ? model.getStylesheet() : null;
+        SchemaPath path = getSchemaPath();
+        if (stylesheet != null && path != null) {
+            minSamples = stylesheet.getInt(path, "stat-min-samples", MIN_SAMPLES);
+            epsilon    = stylesheet.getDouble(path, "stat-convergence-epsilon", 1.0);
+            k          = stylesheet.getInt(path, "stat-convergence-k", 3);
+        }
+
         ContentWidthStats contentStats = null;
         int sampleCount = allWidths.size();
-        if (sampleCount >= MIN_SAMPLES) {
+        if (sampleCount >= minSamples) {
             Collections.sort(allWidths);
             double p50 = allWidths.get(sampleCount / 2);
             double p90 = allWidths.get(sampleCount * 9 / 10);
-            contentStats = new ContentWidthStats(p50, p90, sampleCount, false);
+
+            // Convergence detection: track consecutive calls where p90 is stable.
+            // The first qualifying call (lastP90Width == NaN) starts the stable run at 1.
+            boolean converged = false;
+            if (Double.isNaN(lastP90Width)) {
+                consecutiveStableCount = 1;
+            } else if (Math.abs(p90 - lastP90Width) < epsilon) {
+                consecutiveStableCount++;
+            } else {
+                consecutiveStableCount = 1;
+            }
+            lastP90Width = p90;
+
+            if (consecutiveStableCount >= k) {
+                converged = true;
+            }
+            contentStats = new ContentWidthStats(p50, p90, sampleCount, converged);
         }
 
         // RF-3: p90 replaces averageWidth ONLY in isVariableLength==true branch,
@@ -233,6 +280,12 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             averageCardinality, isVariableLength,
             0, 0, null, List.of(), contentStats
         );
+
+        // Freeze result when convergence is achieved.
+        if (contentStats != null && contentStats.converged()) {
+            frozenResult = measureResult;
+            frozenStylesheetVersion = (stylesheet != null) ? stylesheet.getVersion() : -1;
+        }
 
         return columnWidth;
     }
@@ -295,6 +348,11 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     public MeasureResult getMeasureResult() {
         return measureResult;
+    }
+
+    /** Returns true when a frozen (converged) result is cached and valid. */
+    public boolean isConverged() {
+        return frozenResult != null;
     }
 
     public LayoutResult computeLayout(double width) {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -22,7 +22,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.cell.LayoutCell;
@@ -133,6 +135,37 @@ public final class RelationLayout extends SchemaNodeLayout {
         return array;
     }
 
+    /**
+     * Returns true if the item has at least one child Relation field that is a
+     * non-empty array, or if the relation has no Relation children at all.
+     */
+    static boolean hasNonEmptyChildren(JsonNode item, Relation relation) {
+        boolean hasRelationChild = false;
+        for (SchemaNode child : relation.getChildren()) {
+            if (child.isRelation()) {
+                hasRelationChild = true;
+                JsonNode childData = item.get(child.getField());
+                if (childData != null && childData.isArray() && childData.size() > 0) {
+                    return true;
+                }
+            }
+        }
+        // If no Relation children exist, the row is always kept
+        return !hasRelationChild;
+    }
+
+    /**
+     * Filter an ArrayNode, keeping only items that pass the given predicate.
+     * Returns a new ArrayNode containing the survivors.
+     */
+    static ArrayNode filterArrayNode(JsonNode datum, Predicate<JsonNode> pred) {
+        ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        StreamSupport.stream(datum.spliterator(), false)
+                     .filter(pred)
+                     .forEach(result::add);
+        return result;
+    }
+
     protected int                          averageChildCardinality;
     protected double                       cellHeight       = -1;
     protected final List<SchemaNodeLayout> children         = new ArrayList<>();
@@ -147,6 +180,8 @@ public final class RelationLayout extends SchemaNodeLayout {
     private MeasureResult                  measureResult;
     /** Comparator derived from sortFields / autoSort; null when no sort is needed. */
     private Comparator<JsonNode>           sortComparator;
+    /** Filter predicate for hide-if-empty; null when filtering is disabled. */
+    private Predicate<JsonNode>            hideIfEmptyFilter;
 
     public RelationLayout(Relation r, RelationStyle style) {
         super(r, style.getLabelStyle());
@@ -360,6 +395,9 @@ public final class RelationLayout extends SchemaNodeLayout {
         if (sortComparator != null && result instanceof ArrayNode arr) {
             sortArrayNode(arr, sortComparator);
         }
+        if (hideIfEmptyFilter != null && result instanceof ArrayNode arr) {
+            result = filterArrayNode(arr, hideIfEmptyFilter);
+        }
         return result;
     }
 
@@ -490,6 +528,17 @@ public final class RelationLayout extends SchemaNodeLayout {
         // reflects data order consistent with the build phase.
         if (sortComparator != null && datum instanceof ArrayNode datumArray) {
             sortArrayNode(datumArray, sortComparator);
+        }
+        // Resolve hide-if-empty filter: only active when hideIfEmpty=true and
+        // autoFoldable is null (filtering is incompatible with autoFold).
+        Boolean hideOverride = getNode().getHideIfEmpty();
+        boolean shouldFilter = Boolean.TRUE.equals(hideOverride)
+                               && getNode().getAutoFoldable() == null;
+        if (shouldFilter) {
+            hideIfEmptyFilter = item -> hasNonEmptyChildren(item, getNode());
+            datum = filterArrayNode(datum, hideIfEmptyFilter);
+        } else {
+            hideIfEmptyFilter = null;
         }
         double sum = 0;
         columnWidth = 0;

--- a/kramer/src/test/java/com/chiralbehaviors/layout/HideIfEmptyFilterTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/HideIfEmptyFilterTest.java
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Tests for Kramer-xa0: hide-if-empty filter in RelationLayout.measure()
+ * and extractFrom().
+ */
+class HideIfEmptyFilterTest {
+
+    // -----------------------------------------------------------------------
+    // Schema builder helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a parent Relation with one Primitive child ("name") and one
+     * Relation child ("tags") whose items are the rows to be filtered.
+     * The parent's field is "rows".
+     */
+    private Relation buildParentSchema(String parentField) {
+        Relation parent = new Relation(parentField);
+        parent.addChild(new Primitive("name"));
+        Relation tags = new Relation("tags");
+        tags.addChild(new Primitive("tag"));
+        parent.addChild(tags);
+        return parent;
+    }
+
+    /** Build an ObjectNode row: name=<name>, tags=[<tagValues>...] */
+    private ObjectNode buildRow(String name, String... tagValues) {
+        ObjectNode row = JsonNodeFactory.instance.objectNode();
+        row.put("name", name);
+        ArrayNode tags = JsonNodeFactory.instance.arrayNode();
+        for (String t : tagValues) {
+            ObjectNode tagObj = JsonNodeFactory.instance.objectNode();
+            tagObj.put("tag", t);
+            tags.add(tagObj);
+        }
+        row.set("tags", tags);
+        return row;
+    }
+
+    /** Wrap rows in an ArrayNode. */
+    private ArrayNode buildData(ObjectNode... rows) {
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (ObjectNode r : rows) {
+            data.add(r);
+        }
+        return data;
+    }
+
+    /**
+     * Build a Style mock that handles both Primitive and Relation children
+     * of the given parent schema.
+     */
+    private Style mockModel(Relation parent) {
+        Style model = mock(Style.class);
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+
+        // Use thenAnswer for the general case — create fresh layouts to avoid recursion
+        when(model.layout(any(SchemaNode.class))).thenAnswer(inv -> {
+            SchemaNode n = inv.getArgument(0);
+            if (n instanceof Primitive p) return new PrimitiveLayout(p, primStyle);
+            if (n instanceof Relation r) return new RelationLayout(r, relStyle);
+            return null;
+        });
+        return model;
+    }
+
+    private RelationLayout buildLayout(Relation schema) {
+        RelationStyle style = TestLayouts.mockRelationStyle();
+        return new RelationLayout(schema, style);
+    }
+
+    /**
+     * Run measure and return list of "name" field values from extracted rows.
+     */
+    private List<String> namesAfterMeasure(RelationLayout layout,
+                                            ArrayNode data,
+                                            Style model) {
+        layout.measure(data, n -> n, model);
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set(layout.getNode().getField(), data);
+        JsonNode extracted = layout.extractFrom(parent);
+        List<String> names = new ArrayList<>();
+        extracted.forEach(row -> {
+            JsonNode nameNode = row.get("name");
+            names.add(nameNode != null ? nameNode.asText() : "<null>");
+        });
+        return names;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: hideIfEmpty=null (default) preserves all rows including empty
+    // -----------------------------------------------------------------------
+
+    @Test
+    void hideIfEmptyNullPreservesAllRows() {
+        Relation schema = buildParentSchema("rows");
+        // hideIfEmpty defaults to null — no filtering
+        assertNull(schema.getHideIfEmpty());
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        // 2 of 3 rows have non-empty tags (avg cardinality rounds to >= 1)
+        ArrayNode data = buildData(
+            buildRow("Alpha", "x", "y"),   // has tags
+            buildRow("Beta"),               // empty tags array — must still be kept
+            buildRow("Gamma", "z", "w")    // has tags
+        );
+
+        List<String> names = namesAfterMeasure(layout, data, model);
+        assertEquals(List.of("Alpha", "Beta", "Gamma"), names,
+                     "hideIfEmpty=null must preserve all rows, including those with empty children");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: hideIfEmpty=false explicitly keeps all rows
+    // -----------------------------------------------------------------------
+
+    @Test
+    void hideIfEmptyFalseKeepsAllRows() {
+        Relation schema = buildParentSchema("rows");
+        schema.setHideIfEmpty(false);
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        // Ensure enough non-empty rows so avg cardinality rounds to >= 1
+        ArrayNode data = buildData(
+            buildRow("Alpha", "x", "y"),    // has tags
+            buildRow("Beta", "z"),          // has tags
+            buildRow("Gamma")               // empty tags — must still be kept
+        );
+
+        List<String> names = namesAfterMeasure(layout, data, model);
+        assertEquals(List.of("Alpha", "Beta", "Gamma"), names,
+                     "hideIfEmpty=false must keep all rows");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: hideIfEmpty=true removes rows where all child Relations are empty
+    // -----------------------------------------------------------------------
+
+    @Test
+    void hideIfEmptyTrueRemovesRowsWithAllEmptyChildRelations() {
+        Relation schema = buildParentSchema("rows");
+        schema.setHideIfEmpty(true);
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = buildData(
+            buildRow("Alpha", "x", "y"),   // has tags — keep
+            buildRow("Beta"),               // empty tags — remove
+            buildRow("Gamma", "z")          // has tags — keep
+        );
+
+        List<String> names = namesAfterMeasure(layout, data, model);
+        assertEquals(List.of("Alpha", "Gamma"), names,
+                     "hideIfEmpty=true must remove rows with empty child Relations");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: hideIfEmpty=true keeps rows with at least one non-empty child Relation
+    // -----------------------------------------------------------------------
+
+    @Test
+    void hideIfEmptyTrueKeepsRowsWithAtLeastOneNonEmptyChildRelation() {
+        Relation schema = buildParentSchema("rows");
+        schema.setHideIfEmpty(true);
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = buildData(
+            buildRow("OnlyNonEmpty", "tag1"),  // non-empty — keep
+            buildRow("AlsoNonEmpty", "a", "b") // non-empty — keep
+        );
+
+        List<String> names = namesAfterMeasure(layout, data, model);
+        assertEquals(List.of("OnlyNonEmpty", "AlsoNonEmpty"), names,
+                     "hideIfEmpty=true must keep rows with at least one non-empty child Relation");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: hideIfEmpty=true with autoFoldable != null is skipped (guard)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void hideIfEmptyTrueWithAutoFoldableIsSkipped() {
+        // Build a schema where autoFoldable returns non-null:
+        // A single Relation child triggers autoFold by default.
+        Relation inner = new Relation("items");
+        inner.addChild(new Primitive("value"));
+
+        Relation schema = new Relation("rows");
+        schema.addChild(inner);       // single Relation child → autoFold
+        schema.setHideIfEmpty(true);  // set filter, but guard should skip it
+
+        // autoFoldable should be non-null
+        assertNotNull(schema.getAutoFoldable(), "autoFoldable must be non-null for this guard test");
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        Style model = mock(Style.class);
+        when(model.layout(any(SchemaNode.class))).thenAnswer(inv -> {
+            Object n = inv.getArgument(0);
+            if (n instanceof Relation r) return new RelationLayout(r, relStyle);
+            return new PrimitiveLayout((Primitive) n, primStyle);
+        });
+
+        RelationLayout layout = buildLayout(schema);
+
+        // Three rows: two with items, one without
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ObjectNode r1 = JsonNodeFactory.instance.objectNode();
+        ArrayNode items1 = JsonNodeFactory.instance.arrayNode();
+        ObjectNode v1 = JsonNodeFactory.instance.objectNode();
+        v1.put("value", "a");
+        items1.add(v1);
+        r1.set("items", items1);
+        data.add(r1);
+
+        ObjectNode r2 = JsonNodeFactory.instance.objectNode();
+        r2.set("items", JsonNodeFactory.instance.arrayNode()); // empty
+        data.add(r2);
+
+        ObjectNode r3 = JsonNodeFactory.instance.objectNode();
+        ArrayNode items3 = JsonNodeFactory.instance.arrayNode();
+        ObjectNode v3 = JsonNodeFactory.instance.objectNode();
+        v3.put("value", "b");
+        items3.add(v3);
+        r3.set("items", items3);
+        data.add(r3);
+
+        // measure should not throw; autoFold guard skips filtering
+        assertDoesNotThrow(() -> layout.measure(data, n -> n, model),
+                           "measure() with autoFoldable guard must not throw");
+
+        // maxCardinality reflects all rows (no filtering applied)
+        // We verify by checking maxCardinality via MeasureResult
+        MeasureResult mr = layout.getMeasureResult();
+        assertNotNull(mr);
+        // autoFold flattens across the fold child; we just verify no NPE and
+        // that the guard did not silently corrupt state
+        assertTrue(mr.maxCardinality() >= 0,
+                   "maxCardinality must be non-negative after guarded measure()");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: hideIfEmpty=true with ALL rows filtered produces maxCardinality=0
+    // -----------------------------------------------------------------------
+
+    @Test
+    void hideIfEmptyTrueAllRowsFilteredProducesZeroCardinality() {
+        Relation schema = buildParentSchema("rows");
+        schema.setHideIfEmpty(true);
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        // All rows have empty tags
+        ArrayNode data = buildData(
+            buildRow("Alpha"),
+            buildRow("Beta"),
+            buildRow("Gamma")
+        );
+
+        layout.measure(data, n -> n, model);
+
+        MeasureResult mr = layout.getMeasureResult();
+        assertNotNull(mr);
+        assertEquals(0, mr.maxCardinality(),
+                     "All rows filtered out must produce maxCardinality=0");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: extractFrom() applies same filter as measure() for build-phase consistency
+    // -----------------------------------------------------------------------
+
+    @Test
+    void extractFromAppliesSameFilterAsMeasure() {
+        Relation schema = buildParentSchema("rows");
+        schema.setHideIfEmpty(true);
+
+        RelationLayout layout = buildLayout(schema);
+        Style model = mockModel(schema);
+
+        ArrayNode data = buildData(
+            buildRow("Keep1", "t1"),
+            buildRow("Drop1"),
+            buildRow("Keep2", "t2"),
+            buildRow("Drop2")
+        );
+
+        // measure establishes the filter predicate
+        layout.measure(data, n -> n, model);
+
+        // extractFrom() must apply the same filter
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set("rows", data);
+        JsonNode extracted = layout.extractFrom(parent);
+
+        List<String> names = new ArrayList<>();
+        extracted.forEach(row -> names.add(row.get("name").asText()));
+
+        assertEquals(List.of("Keep1", "Keep2"), names,
+                     "extractFrom() must apply the same hide-if-empty filter as measure()");
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveConvergenceTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveConvergenceTest.java
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for Kramer-16k: convergence detection in PrimitiveLayout.
+ *
+ * When p90Width is stable (delta < epsilon) for k consecutive measure() calls
+ * and sampleCount >= minSamples, the MeasureResult is frozen and subsequent
+ * calls return the cached column width without re-measuring.
+ */
+class PrimitiveConvergenceTest {
+
+    private static final int    DEFAULT_MIN_SAMPLES = 30;
+    private static final double DEFAULT_EPSILON     = 1.0;
+    private static final int    DEFAULT_K           = 3;
+
+    // --- helpers ---
+
+    /**
+     * Build a variable-length dataset of {@code count} elements: 90% short (1 char),
+     * 10% long (20 chars). charWidth=1.0, so widths equal char counts.
+     */
+    private static ArrayNode buildVariableDataset(int count) {
+        ArrayNode arr = JsonNodeFactory.instance.arrayNode();
+        int longCount = Math.max(1, count / 10);
+        int shortCount = count - longCount;
+        for (int i = 0; i < shortCount; i++) {
+            arr.add("x");           // width 1.0
+        }
+        for (int i = 0; i < longCount; i++) {
+            arr.add("x".repeat(20)); // width 20.0
+        }
+        return arr;
+    }
+
+    /**
+     * Create a Style mock whose getStylesheet() returns a DefaultLayoutStylesheet
+     * with default values (no overrides).
+     */
+    private static Style modelWithDefaultStylesheet() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+        return model;
+    }
+
+    /**
+     * Create a Style mock whose getStylesheet() returns the given stylesheet.
+     */
+    private static Style modelWith(LayoutStylesheet sheet) {
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+        return model;
+    }
+
+    // --- Test 1: convergence NOT triggered below minSamples ---
+
+    @Test
+    void noConvergenceBelowMinSamples() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        layout.setSchemaPath(new SchemaPath("text"));
+        Style model = modelWithDefaultStylesheet();
+
+        // 5 elements — far below minSamples=30
+        ArrayNode small = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 5; i++) {
+            small.add("x");
+        }
+
+        // Call measure() many times — should never converge
+        for (int i = 0; i < DEFAULT_K + 2; i++) {
+            layout.measure(small, n -> n, model);
+        }
+
+        // contentStats is null for sampleCount < 30, so convergence cannot fire
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result);
+        assertNull(result.contentStats(), "contentStats must be null below minSamples");
+        // frozenResult should not be set
+        assertFalse(layout.isConverged(), "Must not converge below minSamples");
+    }
+
+    // --- Test 2: convergence triggered when p90Width stable for k consecutive calls ---
+
+    @Test
+    void convergenceTriggeredAfterKStableCalls() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        layout.setSchemaPath(new SchemaPath("text"));
+        Style model = modelWithDefaultStylesheet();
+
+        // Stable dataset: 35 elements, same composition every call
+        ArrayNode data = buildVariableDataset(35);
+
+        // Call (k-1) times — not yet converged
+        for (int i = 0; i < DEFAULT_K - 1; i++) {
+            layout.measure(data, n -> n, model);
+            assertFalse(layout.isConverged(),
+                "Should not converge after only " + (i + 1) + " stable call(s)");
+        }
+
+        // k-th stable call — now converged
+        layout.measure(data, n -> n, model);
+        assertTrue(layout.isConverged(), "Should converge after k=" + DEFAULT_K + " stable calls");
+    }
+
+    // --- Test 3: converged=true in ContentWidthStats after convergence ---
+
+    @Test
+    void contentStatsConvergedTrueAfterConvergence() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        layout.setSchemaPath(new SchemaPath("text"));
+        Style model = modelWithDefaultStylesheet();
+
+        ArrayNode data = buildVariableDataset(35);
+
+        // Drive to convergence
+        for (int i = 0; i < DEFAULT_K; i++) {
+            layout.measure(data, n -> n, model);
+        }
+
+        assertTrue(layout.isConverged());
+        ContentWidthStats stats = layout.getMeasureResult().contentStats();
+        assertNotNull(stats);
+        assertTrue(stats.converged(), "ContentWidthStats.converged must be true after convergence");
+    }
+
+    // --- Test 4: frozenResult returned on subsequent measure() calls (short-circuit) ---
+
+    @Test
+    void frozenResultReturnedOnSubsequentMeasureCalls() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        layout.setSchemaPath(new SchemaPath("text"));
+        Style model = modelWithDefaultStylesheet();
+
+        ArrayNode data = buildVariableDataset(35);
+
+        // Drive to convergence
+        for (int i = 0; i < DEFAULT_K; i++) {
+            layout.measure(data, n -> n, model);
+        }
+        assertTrue(layout.isConverged());
+        double frozenColumnWidth = layout.columnWidth();
+
+        // After convergence, different data should NOT change the result
+        ArrayNode differentData = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 35; i++) {
+            differentData.add("x".repeat(50)); // much wider
+        }
+
+        double result = layout.measure(differentData, n -> n, model);
+
+        // Must return frozen width, not the width of the new data
+        assertEquals(frozenColumnWidth, result, 1e-6,
+            "measure() must return frozen column width after convergence");
+        assertEquals(frozenColumnWidth, layout.columnWidth(), 1e-6,
+            "columnWidth() must reflect frozen result after convergence");
+    }
+
+    // --- Test 5: frozenResult invalidated when stylesheet version changes ---
+
+    @Test
+    void frozenResultInvalidatedOnStylesheetVersionChange() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        layout.setSchemaPath(new SchemaPath("text"));
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        Style model = modelWith(sheet);
+
+        ArrayNode data = buildVariableDataset(35);
+
+        // Drive to convergence
+        for (int i = 0; i < DEFAULT_K; i++) {
+            layout.measure(data, n -> n, model);
+        }
+        assertTrue(layout.isConverged());
+
+        // Change the stylesheet version
+        sheet.setOverride(new SchemaPath("text"), "stat-min-samples", 30);
+
+        // Now measure with different data should re-run (frozen is stale)
+        // Build wider data so result differs if re-measured
+        ArrayNode wideData = JsonNodeFactory.instance.arrayNode();
+        int longCount = 4;
+        int shortCount = 35 - longCount;
+        for (int i = 0; i < shortCount; i++) {
+            wideData.add("x".repeat(5));
+        }
+        for (int i = 0; i < longCount; i++) {
+            wideData.add("x".repeat(100));
+        }
+
+        layout.measure(wideData, n -> n, model);
+
+        // After version change, convergence state should be reset
+        assertFalse(layout.isConverged(),
+            "Convergence must be invalidated when stylesheet version changes");
+    }
+
+    // --- Test 6: LayoutStylesheet overrides for stat-min-samples honored ---
+
+    @Test
+    void customMinSamplesOverrideHonored() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        SchemaPath path = new SchemaPath("text");
+        layout.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        // Reduce minSamples to 5 so our small dataset qualifies
+        sheet.setOverride(path, "stat-min-samples", 5);
+        // Also set k=2 to speed up convergence
+        sheet.setOverride(path, "stat-convergence-k", 2);
+        Style model = modelWith(sheet);
+
+        // Dataset with 6 elements (>= custom minSamples=5)
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 5; i++) {
+            data.add("x");
+        }
+        data.add("x".repeat(20));
+
+        // With custom minSamples=5 and k=2, should converge in 2 stable calls
+        layout.measure(data, n -> n, model);
+        assertFalse(layout.isConverged(), "Not converged after 1 stable call (k=2)");
+
+        layout.measure(data, n -> n, model);
+        assertTrue(layout.isConverged(),
+            "Should converge after 2 stable calls with custom k=2 and minSamples=5");
+    }
+
+    // --- Test 7: stat-convergence-epsilon override honored ---
+
+    @Test
+    void customEpsilonOverrideHonored() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        SchemaPath path = new SchemaPath("text");
+        layout.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        // Very tight epsilon: requires exact match
+        sheet.setOverride(path, "stat-convergence-epsilon", 0.001);
+        sheet.setOverride(path, "stat-convergence-k", 2);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        Style model = modelWith(sheet);
+
+        // Two slightly different datasets that differ by ~0.5 in p90
+        // With epsilon=0.001 this should NOT converge
+        ArrayNode data1 = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 5; i++) {
+            data1.add("x");
+        }
+        data1.add("x".repeat(10));
+
+        ArrayNode data2 = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 5; i++) {
+            data2.add("x");
+        }
+        data2.add("x".repeat(15)); // different p90
+
+        layout.measure(data1, n -> n, model);
+        layout.measure(data2, n -> n, model);
+
+        assertFalse(layout.isConverged(),
+            "Should NOT converge when p90 delta exceeds tight epsilon=0.001");
+    }
+
+    // --- Test 8: stat-convergence-k override honored ---
+
+    @Test
+    void customKOverrideHonored() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("text"), style);
+        SchemaPath path = new SchemaPath("text");
+        layout.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 5); // require 5 stable calls
+        Style model = modelWith(sheet);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 5; i++) {
+            data.add("x");
+        }
+        data.add("x".repeat(20));
+
+        // 4 stable calls should not converge with k=5
+        for (int i = 0; i < 4; i++) {
+            layout.measure(data, n -> n, model);
+            assertFalse(layout.isConverged(),
+                "Should not converge after " + (i + 1) + " stable calls with k=5");
+        }
+
+        // 5th stable call triggers convergence
+        layout.measure(data, n -> n, model);
+        assertTrue(layout.isConverged(), "Should converge after 5 stable calls with k=5");
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-014** (Kramer-xa0): Hide-if-empty filter — removes parent rows with empty child Relations when `hideIfEmpty=true`. autoFold guard, dual data-path consistency (measure + extractFrom).
- **RDR-013** (Kramer-16k): Convergence detection — tracks p90Width stability, freezes MeasureResult when converged. Reads `stat-min-samples`/`stat-convergence-epsilon`/`stat-convergence-k` from `LayoutStylesheet` per `SchemaPath`. Cache invalidated by stylesheet version change only.

## Test plan
- [x] 330 tests pass (15 new)
- [x] hideIfEmpty: 7 tests (null default, false, true removes empty, keeps non-empty, autoFold guard, all-filtered, extractFrom consistency)
- [x] Convergence: 8 tests (below minSamples, stable after k calls, converged=true, frozen short-circuit, version invalidation, stylesheet overrides)

Ref: Kramer-xa0, Kramer-16k