### PR TITLE
Wave 2 Batch 1: ColumnSetSnapshot + LayoutResult enum migration

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSet.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSet.java
@@ -100,6 +100,17 @@ public class ColumnSet {
         return columns;
     }
 
+    public ColumnSetSnapshot toSnapshot(double height) {
+        var columnSnapshots = columns.stream()
+                                     .map(c -> new ColumnSnapshot(c.getWidth(),
+                                                                   c.getFields()
+                                                                    .stream()
+                                                                    .map(SchemaNodeLayout::getField)
+                                                                    .toList()))
+                                     .toList();
+        return new ColumnSetSnapshot(columnSnapshots, height);
+    }
+
     @Override
     public String toString() {
         return String.format("ColumnSet [%s]", columns);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSetSnapshot.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSetSnapshot.java
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+/**
+ * Immutable snapshot of a ColumnSet's layout decision: the ordered columns
+ * and the resolved cell height.
+ */
+public record ColumnSetSnapshot(List<ColumnSnapshot> columns, double height) {
+    public ColumnSetSnapshot {
+        columns = List.copyOf(columns);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSnapshot.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSnapshot.java
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+/**
+ * Immutable snapshot of a single column's state: its width and the ordered
+ * names of the fields it contains.
+ */
+public record ColumnSnapshot(double width, List<String> fieldNames) {
+    public ColumnSnapshot {
+        fieldNames = List.copyOf(fieldNames);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutResult.java
@@ -11,7 +11,8 @@ import java.util.List;
  * @see SchemaNodeLayout#layout(double)
  */
 public record LayoutResult(
-    boolean useTable,
+    RelationRenderMode relationMode,
+    PrimitiveRenderMode primitiveMode,
     boolean useVerticalHeader,
     double tableColumnWidth,
     double columnHeaderIndentation,
@@ -20,5 +21,10 @@ public record LayoutResult(
 ) {
     public LayoutResult {
         childResults = childResults == null ? List.of() : List.copyOf(childResults);
+    }
+
+    /** Backward-compatible accessor: returns true when relationMode is TABLE. */
+    public boolean useTable() {
+        return relationMode == RelationRenderMode.TABLE;
     }
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -361,11 +361,12 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     public LayoutResult computeLayout(double width) {
         clear();
         return new LayoutResult(
-            false,              // useTable — primitives never use table mode
-            useVerticalHeader,  // preserved from nestTableColumn if set
-            0,                  // tableColumnWidth — not applicable
+            RelationRenderMode.OUTLINE,    // primitives never use table mode
+            PrimitiveRenderMode.TEXT,
+            useVerticalHeader,             // preserved from nestTableColumn if set
+            0,                             // tableColumnWidth — not applicable
             columnHeaderIndentation,
-            width,              // constrainedColumnWidth
+            width,                         // constrainedColumnWidth
             List.of()
         );
     }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveRenderMode.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveRenderMode.java
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+/**
+ * Controls how a Primitive leaf node is rendered.
+ *
+ * <ul>
+ *   <li>TEXT — plain text label (default)</li>
+ *   <li>BAR — horizontal bar chart representation</li>
+ *   <li>BADGE — badge / chip representation</li>
+ * </ul>
+ */
+public enum PrimitiveRenderMode {
+    TEXT, BAR, BADGE
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -456,7 +456,8 @@ public final class RelationLayout extends SchemaNodeLayout {
     public LayoutResult computeLayout(double width) {
         layout(width);
         return new LayoutResult(
-            useTable,
+            useTable ? RelationRenderMode.TABLE : RelationRenderMode.OUTLINE,
+            PrimitiveRenderMode.TEXT,
             false,
             tableColumnWidth,
             columnHeaderIndentation,
@@ -479,7 +480,8 @@ public final class RelationLayout extends SchemaNodeLayout {
      */
     public LayoutResult snapshotLayoutResult() {
         return new LayoutResult(
-            useTable,
+            useTable ? RelationRenderMode.TABLE : RelationRenderMode.OUTLINE,
+            PrimitiveRenderMode.TEXT,
             false,
             tableColumnWidth,
             columnHeaderIndentation,

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationRenderMode.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationRenderMode.java
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+/**
+ * Controls how a Relation node is rendered.
+ *
+ * <ul>
+ *   <li>AUTO — let the layout engine decide (outline or nested-table) based on width</li>
+ *   <li>TABLE — force nested-table rendering</li>
+ *   <li>OUTLINE — force outline rendering</li>
+ *   <li>CROSSTAB — cross-tabulation rendering (reserved for future use)</li>
+ * </ul>
+ */
+public enum RelationRenderMode {
+    AUTO, TABLE, OUTLINE, CROSSTAB
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/ColumnSetSnapshotTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/ColumnSetSnapshotTest.java
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.LabelStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+
+import javafx.geometry.Insets;
+
+class ColumnSetSnapshotTest {
+
+    // --- ColumnSnapshot construction ---
+
+    @Test
+    void columnSnapshotStoresWidthAndFields() {
+        var snap = new ColumnSnapshot(120.0, List.of("name", "age"));
+        assertEquals(120.0, snap.width());
+        assertEquals(List.of("name", "age"), snap.fieldNames());
+    }
+
+    @Test
+    void columnSnapshotIsImmutable() {
+        var mutable = new ArrayList<>(List.of("a", "b"));
+        var snap = new ColumnSnapshot(50.0, mutable);
+        mutable.add("c");
+        assertEquals(List.of("a", "b"), snap.fieldNames(),
+                     "ColumnSnapshot must copy field list on construction");
+        assertThrows(UnsupportedOperationException.class,
+                     () -> snap.fieldNames().add("x"));
+    }
+
+    // --- ColumnSetSnapshot construction ---
+
+    @Test
+    void columnSetSnapshotStoresColumnsAndHeight() {
+        var c1 = new ColumnSnapshot(100.0, List.of("f1"));
+        var c2 = new ColumnSnapshot(100.0, List.of("f2", "f3"));
+        var snap = new ColumnSetSnapshot(List.of(c1, c2), 80.0);
+        assertEquals(2, snap.columns().size());
+        assertEquals(80.0, snap.height());
+    }
+
+    @Test
+    void columnSetSnapshotIsImmutable() {
+        var c1 = new ColumnSnapshot(100.0, List.of("f1"));
+        var mutable = new ArrayList<>(List.of(c1));
+        var snap = new ColumnSetSnapshot(mutable, 40.0);
+        mutable.add(new ColumnSnapshot(50.0, List.of("f2")));
+        assertEquals(1, snap.columns().size(),
+                     "ColumnSetSnapshot must copy column list on construction");
+        assertThrows(UnsupportedOperationException.class,
+                     () -> snap.columns().add(c1));
+    }
+
+    // --- Round-trip: live ColumnSet → snapshot ---
+
+    @Test
+    void roundTripFromColumnSetCapturesState() {
+        RelationStyle style = mockRelationStyle();
+
+        ColumnSet cs = new ColumnSet();
+        // cs starts with one empty Column; add two fields to it
+        PrimitiveLayout p1 = makePrimitive("title", 120.0);
+        PrimitiveLayout p2 = makePrimitive("author", 80.0);
+        cs.add(p1);
+        cs.add(p2);
+        // Manually set column width via compress-like operation
+        cs.getColumns().get(0).setWidth(200.0);
+
+        ColumnSetSnapshot snap = cs.toSnapshot(42.5);
+
+        assertEquals(42.5, snap.height(), 0.001);
+        assertEquals(1, snap.columns().size());
+
+        ColumnSnapshot colSnap = snap.columns().get(0);
+        assertEquals(200.0, colSnap.width(), 0.001);
+        assertEquals(List.of("title", "author"), colSnap.fieldNames());
+    }
+
+    @Test
+    void roundTripWithMultipleColumns() {
+        ColumnSet cs = new ColumnSet();
+        // Add a field to the initial column, then manually add a second column
+        PrimitiveLayout p1 = makePrimitive("description", 300.0);
+        PrimitiveLayout p2 = makePrimitive("credits", 50.0);
+        cs.add(p1);
+        // Second column added by compress; simulate by accessing columns list
+        Column col2 = new Column(100.0);
+        col2.add(p2);
+        cs.getColumns().add(col2);
+        cs.getColumns().get(0).setWidth(300.0);
+
+        ColumnSetSnapshot snap = cs.toSnapshot(60.0);
+
+        assertEquals(2, snap.columns().size());
+        assertEquals(List.of("description"), snap.columns().get(0).fieldNames());
+        assertEquals(List.of("credits"), snap.columns().get(1).fieldNames());
+        assertEquals(300.0, snap.columns().get(0).width(), 0.001);
+        assertEquals(100.0, snap.columns().get(1).width(), 0.001);
+    }
+
+    // --- Infrastructure ---
+
+    private static PrimitiveLayout makePrimitive(String name, double width) {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        PrimitiveStyle primStyle = mock(PrimitiveStyle.class);
+        when(primStyle.getLabelStyle()).thenReturn(labelStyle);
+        when(primStyle.getHeight(anyDouble(), anyDouble())).thenReturn(20.0);
+        when(primStyle.getListVerticalInset()).thenReturn(0.0);
+        when(primStyle.getMinValueWidth()).thenReturn(30.0);
+        when(primStyle.getMaxTablePrimitiveWidth()).thenReturn(350.0);
+        when(primStyle.getVerticalHeaderThreshold()).thenReturn(1.5);
+        when(primStyle.getVariableLengthThreshold()).thenReturn(2.0);
+        when(primStyle.getOutlineSnapValueWidth()).thenReturn(0.0);
+
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive(name), primStyle);
+        layout.columnWidth = width;
+        layout.dataWidth = width;
+        layout.labelWidth = 0;
+        return layout;
+    }
+
+    private static RelationStyle mockRelationStyle() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.width(anyString())).thenReturn(10.0);
+
+        RelationStyle style = mock(RelationStyle.class);
+        when(style.getLabelStyle()).thenReturn(labelStyle);
+        when(style.getOutlineColumnMinWidth()).thenReturn(60.0);
+        when(style.getColumnHorizontalInset()).thenReturn(0.0);
+        when(style.getElementHorizontalInset()).thenReturn(0.0);
+        when(style.getColumnVerticalInset()).thenReturn(0.0);
+        when(style.getElementVerticalInset()).thenReturn(0.0);
+        when(style.getNestedInsets()).thenReturn(new Insets(0));
+        return style;
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/ConvergentWidthStabilityTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/ConvergentWidthStabilityTest.java
@@ -153,7 +153,7 @@ class ConvergentWidthStabilityTest {
         double width2 = 258.7; // bucket 25 — same bucket
 
         LayoutDecisionKey key1 = LayoutDecisionKey.of(path, width1, cardinality);
-        LayoutResult result = new LayoutResult(false, false, 0.0, 0.0, 250.0, List.of());
+        LayoutResult result = new LayoutResult(RelationRenderMode.OUTLINE, PrimitiveRenderMode.TEXT, false, 0.0, 0.0, 250.0, List.of());
         cache.put(key1, result);
 
         // Same-bucket width should hit the same cache entry
@@ -176,7 +176,7 @@ class ConvergentWidthStabilityTest {
         double width2 = 260.0; // bucket 26 — different bucket
 
         LayoutDecisionKey key1 = LayoutDecisionKey.of(path, width1, cardinality);
-        cache.put(key1, new LayoutResult(false, false, 0.0, 0.0, 250.0, List.of()));
+        cache.put(key1, new LayoutResult(RelationRenderMode.OUTLINE, PrimitiveRenderMode.TEXT, false, 0.0, 0.0, 250.0, List.of()));
 
         LayoutDecisionKey key2 = LayoutDecisionKey.of(path, width2, cardinality);
         assertNull(cache.get(key2),
@@ -258,7 +258,7 @@ class ConvergentWidthStabilityTest {
         double width = 300.0;
         int cardinality = data.size();
         LayoutDecisionKey key = LayoutDecisionKey.of(rootPath, width, cardinality);
-        cache.put(key, new LayoutResult(false, false, 0.0, 0.0, 295.0, List.of()));
+        cache.put(key, new LayoutResult(RelationRenderMode.OUTLINE, PrimitiveRenderMode.TEXT, false, 0.0, 0.0, 295.0, List.of()));
 
         // Both conditions met: converged + cache hit
         assertTrue(rl.isConverged(), "allConverged() precondition met");
@@ -284,7 +284,7 @@ class ConvergentWidthStabilityTest {
         for (int bucket = 20; bucket < 30; bucket++) {
             double w = bucket * 10.0;
             cache.put(LayoutDecisionKey.of(path, w, 5),
-                      new LayoutResult(false, false, 0, 0, w, List.of()));
+                      new LayoutResult(RelationRenderMode.OUTLINE, PrimitiveRenderMode.TEXT, false, 0, 0, w, List.of()));
         }
         assertEquals(10, cache.size(), "Cache populated with 10 entries");
 

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionCacheTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionCacheTest.java
@@ -67,7 +67,7 @@ class LayoutDecisionCacheTest {
 
         var path = new SchemaPath("root");
         var key = LayoutDecisionKey.of(path, 400.0, 7);
-        var result = new LayoutResult(true, false, 120.0, 0.0, 100.0, List.of());
+        var result = new LayoutResult(RelationRenderMode.TABLE, PrimitiveRenderMode.TEXT, false, 120.0, 0.0, 100.0, List.of());
 
         cache.put(key, result);
 
@@ -92,9 +92,9 @@ class LayoutDecisionCacheTest {
 
         var path = new SchemaPath("root");
         cache.put(LayoutDecisionKey.of(path, 100.0, 2),
-                  new LayoutResult(false, false, 50.0, 0.0, 40.0, List.of()));
+                  new LayoutResult(RelationRenderMode.OUTLINE, PrimitiveRenderMode.TEXT, false, 50.0, 0.0, 40.0, List.of()));
         cache.put(LayoutDecisionKey.of(path, 200.0, 3),
-                  new LayoutResult(true, false, 80.0, 0.0, 70.0, List.of()));
+                  new LayoutResult(RelationRenderMode.TABLE, PrimitiveRenderMode.TEXT, false, 80.0, 0.0, 70.0, List.of()));
         assertEquals(2, cache.size());
 
         // Simulates stylesheet change or autoLayout() reset
@@ -113,7 +113,7 @@ class LayoutDecisionCacheTest {
         int newCardinality = 10;
 
         var oldKey = LayoutDecisionKey.of(path, width, oldCardinality);
-        cache.put(oldKey, new LayoutResult(false, false, 60.0, 0.0, 50.0, List.of()));
+        cache.put(oldKey, new LayoutResult(RelationRenderMode.OUTLINE, PrimitiveRenderMode.TEXT, false, 60.0, 0.0, 50.0, List.of()));
 
         // When data changes cardinality the caller must re-measure; old key is stale.
         var newKey = LayoutDecisionKey.of(path, width, newCardinality);

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RenderModeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RenderModeTest.java
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Kramer-8tu: RelationRenderMode and PrimitiveRenderMode enum migration.
+ */
+class RenderModeTest {
+
+    @Test
+    void relationRenderModeValues() {
+        var values = RelationRenderMode.values();
+        assertEquals(4, values.length);
+        assertNotNull(RelationRenderMode.valueOf("AUTO"));
+        assertNotNull(RelationRenderMode.valueOf("TABLE"));
+        assertNotNull(RelationRenderMode.valueOf("OUTLINE"));
+        assertNotNull(RelationRenderMode.valueOf("CROSSTAB"));
+    }
+
+    @Test
+    void primitiveRenderModeValues() {
+        var values = PrimitiveRenderMode.values();
+        assertEquals(3, values.length);
+        assertNotNull(PrimitiveRenderMode.valueOf("TEXT"));
+        assertNotNull(PrimitiveRenderMode.valueOf("BAR"));
+        assertNotNull(PrimitiveRenderMode.valueOf("BADGE"));
+    }
+
+    @Test
+    void layoutResultWithTableModeUseTableReturnsTrue() {
+        var result = new LayoutResult(RelationRenderMode.TABLE, PrimitiveRenderMode.TEXT,
+                                      false, 100.0, 0.0, 90.0, List.of());
+        assertTrue(result.useTable());
+    }
+
+    @Test
+    void layoutResultWithOutlineModeUseTableReturnsFalse() {
+        var result = new LayoutResult(RelationRenderMode.OUTLINE, PrimitiveRenderMode.TEXT,
+                                      false, 0.0, 0.0, 80.0, List.of());
+        assertFalse(result.useTable());
+    }
+
+    @Test
+    void layoutResultAutoModeUseTableReturnsFalse() {
+        var result = new LayoutResult(RelationRenderMode.AUTO, PrimitiveRenderMode.TEXT,
+                                      false, 0.0, 0.0, 80.0, List.of());
+        assertFalse(result.useTable());
+    }
+
+    @Test
+    void layoutResultCrosstabModeUseTableReturnsFalse() {
+        var result = new LayoutResult(RelationRenderMode.CROSSTAB, PrimitiveRenderMode.TEXT,
+                                      false, 0.0, 0.0, 80.0, List.of());
+        assertFalse(result.useTable());
+    }
+
+    @Test
+    void layoutResultAccessorsWork() {
+        var children = List.<LayoutResult>of();
+        var result = new LayoutResult(RelationRenderMode.TABLE, PrimitiveRenderMode.BAR,
+                                      true, 120.0, 5.0, 110.0, children);
+        assertEquals(RelationRenderMode.TABLE, result.relationMode());
+        assertEquals(PrimitiveRenderMode.BAR, result.primitiveMode());
+        assertTrue(result.useVerticalHeader());
+        assertEquals(120.0, result.tableColumnWidth());
+        assertEquals(5.0, result.columnHeaderIndentation());
+        assertEquals(110.0, result.constrainedColumnWidth());
+        assertTrue(result.childResults().isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-011** (Kramer-zq2): `ColumnSnapshot`/`ColumnSetSnapshot` immutable records + `ColumnSet.toSnapshot()`. Captures mutable column layout state for protocol extraction.
- **RDR-015** (Kramer-8tu): `RelationRenderMode` (AUTO/TABLE/OUTLINE/CROSSTAB) + `PrimitiveRenderMode` (TEXT/BAR/BADGE) enums. `LayoutResult` migrated from `boolean useTable` with backward-compat `useTable()` accessor. 13 construction sites updated.

## Test plan
- [x] 363 tests pass (13 new)
- [x] ColumnSetSnapshot: 6 tests (record construction, immutability, toSnapshot round-trip)
- [x] RenderMode: 7 tests (enum values, LayoutResult construction, useTable() derived accessor)

Ref: Kramer-zq2, Kramer-8tu