### PR TITLE
Wave 2 Batch 2: LayoutDecisionNode, NumericStats+BAR, PivotStats

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutDecisionNode.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutDecisionNode.java
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+/**
+ * Unified decision tree node that captures all four layout phase results for a
+ * single schema node. Combines measure, layout, compress, and height results
+ * alongside the column-set snapshots and child sub-trees produced during layout.
+ *
+ * <p>{@code fieldName} mirrors {@code path.leaf()} and is retained as a
+ * convenience so renderers can call {@code data.get(fieldName)} without
+ * re-deriving the leaf segment on every access.
+ */
+public record LayoutDecisionNode(
+    SchemaPath path,
+    String fieldName,
+    MeasureResult measureResult,
+    LayoutResult layoutResult,
+    CompressResult compressResult,
+    HeightResult heightResult,
+    List<ColumnSetSnapshot> columnSetSnapshots,
+    List<LayoutDecisionNode> childNodes
+) {
+    public LayoutDecisionNode {
+        childNodes = childNodes == null ? List.of() : List.copyOf(childNodes);
+        columnSetSnapshots = columnSetSnapshots == null ? List.of() : List.copyOf(columnSetSnapshots);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
@@ -23,7 +23,9 @@ public record MeasureResult(
     int maxCardinality,
     Function<JsonNode, JsonNode> extractor,
     List<MeasureResult> childResults,
-    ContentWidthStats contentStats
+    ContentWidthStats contentStats,
+    NumericStats numericStats,
+    PivotStats pivotStats
 ) {
     public MeasureResult {
         childResults = childResults == null ? List.of() : List.copyOf(childResults);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/NumericStats.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/NumericStats.java
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+/**
+ * Statistical summary of numeric content widths — or, more precisely, the
+ * actual numeric values observed during the measure phase when a Primitive
+ * field is found to be entirely numeric.
+ *
+ * <p>This record is set on {@link MeasureResult} only when every sampled value
+ * can be parsed as a number. When present it signals that the field should be
+ * rendered in {@link PrimitiveRenderMode#BAR} mode.
+ *
+ * @param numericMin  smallest numeric value observed across all sampled rows
+ * @param numericMax  largest  numeric value observed across all sampled rows
+ */
+public record NumericStats(double numericMin, double numericMax) {
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PivotStats.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PivotStats.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+/**
+ * Distinct pivot values collected during the measure phase for a Relation field
+ * configured with a {@code pivot-field} stylesheet property.
+ *
+ * <p>When a relation's stylesheet specifies {@code pivot-field}, RelationLayout
+ * scans the sorted+filtered datum array after sort/filter and collects the set
+ * of distinct string values for that field. The result is stored here for use
+ * by downstream layout and rendering phases.
+ *
+ * @param pivotValues  immutable list of distinct pivot-field values (insertion-ordered)
+ * @param pivotCount   number of distinct pivot values; equals {@code pivotValues.size()}
+ */
+public record PivotStats(List<String> pivotValues, int pivotCount) {
+    public PivotStats {
+        pivotValues = List.copyOf(pivotValues);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -52,6 +52,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     private double                 cellHeight;
     private boolean                useVerticalHeader         = false;
     private MeasureResult          measureResult;
+    private PrimitiveRenderMode    renderMode                = PrimitiveRenderMode.TEXT;
 
     // Convergence detection state (Kramer-16k)
     private MeasureResult          frozenResult;
@@ -265,6 +266,57 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             contentStats = new ContentWidthStats(p50, p90, sampleCount, converged);
         }
 
+        // Numeric auto-detection: scan all raw values to determine if the field is entirely numeric.
+        // This is independent of the MIN_SAMPLES requirement for percentile stats.
+        NumericStats numericStats = null;
+        String renderModeOverride = (stylesheet != null && path != null)
+                                    ? stylesheet.getString(path, "render-mode", "auto")
+                                    : "auto";
+        if ("auto".equals(renderModeOverride)) {
+            boolean allNumeric = !normalized.isEmpty();
+            double nMin = Double.POSITIVE_INFINITY;
+            double nMax = Double.NEGATIVE_INFINITY;
+            outer:
+            for (JsonNode prim : normalized) {
+                if (prim.isArray()) {
+                    if (prim.isEmpty()) {
+                        // treat empty arrays as non-numeric
+                        allNumeric = false;
+                        break;
+                    }
+                    for (JsonNode row : prim) {
+                        if (!row.isNumber()) {
+                            allNumeric = false;
+                            break outer;
+                        }
+                        double v = row.doubleValue();
+                        if (v < nMin) nMin = v;
+                        if (v > nMax) nMax = v;
+                    }
+                } else {
+                    if (!prim.isNumber()) {
+                        allNumeric = false;
+                        break;
+                    }
+                    double v = prim.doubleValue();
+                    if (v < nMin) nMin = v;
+                    if (v > nMax) nMax = v;
+                }
+            }
+            if (allNumeric && !normalized.isEmpty()) {
+                numericStats = new NumericStats(nMin, nMax);
+                renderMode = PrimitiveRenderMode.BAR;
+            } else {
+                renderMode = PrimitiveRenderMode.TEXT;
+            }
+        } else {
+            renderMode = switch (renderModeOverride.toUpperCase()) {
+                case "BAR"   -> PrimitiveRenderMode.BAR;
+                case "BADGE" -> PrimitiveRenderMode.BADGE;
+                default      -> PrimitiveRenderMode.TEXT;
+            };
+        }
+
         // RF-3: p90 replaces averageWidth ONLY in isVariableLength==true branch,
         // and only when we have sufficient samples. Fixed-length always uses maxWidth.
         double effectiveWidth;
@@ -280,7 +332,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         measureResult = new MeasureResult(
             labelWidth, columnWidth, dataWidth, maxWidth,
             averageCardinality, isVariableLength,
-            0, 0, null, List.of(), contentStats
+            0, 0, null, List.of(), contentStats, numericStats, null
         );
 
         // Freeze result when convergence is achieved.
@@ -350,6 +402,10 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     public MeasureResult getMeasureResult() {
         return measureResult;
+    }
+
+    public PrimitiveRenderMode getRenderMode() {
+        return renderMode;
     }
 
     /** Returns true when a frozen (converged) result is cached and valid. */

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -19,6 +19,7 @@ package com.chiralbehaviors.layout;
 import static com.chiralbehaviors.layout.style.Style.*;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -591,12 +592,33 @@ public final class RelationLayout extends SchemaNodeLayout {
         } else {
             hideIfEmptyFilter = null;
         }
+        // Collect pivot values AFTER sort+filter, BEFORE child iteration.
+        // Reads pivot-field from stylesheet; if non-empty, scans datum for distinct values.
+        PivotStats pivotStats = null;
+        SchemaPath myPath = getSchemaPath();
+        LayoutStylesheet stylesheet = (model != null) ? model.getStylesheet() : null;
+        if (stylesheet != null && myPath != null) {
+            String pivotField = stylesheet.getString(myPath, "pivot-field", "");
+            if (!pivotField.isEmpty()) {
+                LinkedHashSet<String> seen = new LinkedHashSet<>();
+                if (datum instanceof ArrayNode pivotArray) {
+                    for (JsonNode item : pivotArray) {
+                        JsonNode fieldNode = item.get(pivotField);
+                        if (fieldNode != null && !fieldNode.isNull()) {
+                            seen.add(fieldNode.asText());
+                        }
+                    }
+                }
+                pivotStats = new PivotStats(new ArrayList<>(seen), seen.size());
+            }
+        }
+
         double sum = 0;
         columnWidth = 0;
         int singularChildren = 0;
         maxCardinality = datum.size();
 
-        SchemaPath parentPath = getSchemaPath();
+        SchemaPath parentPath = myPath;
         for (SchemaNode child : getNode().getChildren()) {
             Fold fold = model.layout(child)
                              .fold(datum, extractor, model);
@@ -644,7 +666,7 @@ public final class RelationLayout extends SchemaNodeLayout {
             labelWidth, columnWidth, 0, 0,
             0, false,
             averageChildCardinality, maxCardinality,
-            extractor, childResults, null
+            extractor, childResults, null, null, pivotStats
         );
 
         return columnWidth + style.getElementHorizontalInset()

--- a/kramer/src/test/java/com/chiralbehaviors/layout/ContentWidthStatsTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/ContentWidthStatsTest.java
@@ -70,7 +70,7 @@ class ContentWidthStatsTest {
             1, false,
             0, 0,
             null, List.of(),
-            null
+            null, null, null
         );
 
         assertNull(result.contentStats(),
@@ -87,7 +87,7 @@ class ContentWidthStatsTest {
             1, false,
             0, 0,
             null, List.of(),
-            stats
+            stats, null, null
         );
 
         assertNotNull(result.contentStats());
@@ -127,7 +127,7 @@ class ContentWidthStatsTest {
             0, false,
             2, 5,
             Function.identity(), List.of(),
-            null
+            null, null, null
         );
 
         assertNull(result.contentStats(),

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeTest.java
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class LayoutDecisionNodeTest {
+
+    private static MeasureResult measureResult() {
+        return new MeasureResult(10.0, 100.0, 90.0, 120.0, 1, false, 0, 5,
+                                 node -> node, List.of(), null, null, null);
+    }
+
+    private static LayoutResult layoutResult() {
+        return new LayoutResult(RelationRenderMode.OUTLINE, PrimitiveRenderMode.TEXT,
+                                false, 0.0, 0.0, 100.0, List.of());
+    }
+
+    private static CompressResult compressResult() {
+        return new CompressResult(100.0, List.of(), 20.0, List.of());
+    }
+
+    private static HeightResult heightResult() {
+        return new HeightResult(200.0, 20.0, 5, 0.0, List.of());
+    }
+
+    private static ColumnSetSnapshot columnSetSnapshot() {
+        return new ColumnSetSnapshot(List.of(new ColumnSnapshot(100.0, List.of("f1"))), 20.0);
+    }
+
+    @Test
+    void constructionWithAllFieldsPopulated() {
+        var path = new SchemaPath("root", "child");
+        var measure = measureResult();
+        var layout = layoutResult();
+        var compress = compressResult();
+        var height = heightResult();
+        var snapshots = List.of(columnSetSnapshot());
+        var child = new LayoutDecisionNode(new SchemaPath("root", "child", "leaf"),
+                                           "leaf", measure, layout, compress, height,
+                                           List.of(), List.of());
+        var children = List.of(child);
+
+        var node = new LayoutDecisionNode(path, "child", measure, layout, compress, height,
+                                          snapshots, children);
+
+        assertEquals(path, node.path());
+        assertEquals("child", node.fieldName());
+        assertSame(measure, node.measureResult());
+        assertSame(layout, node.layoutResult());
+        assertSame(compress, node.compressResult());
+        assertSame(height, node.heightResult());
+        assertEquals(1, node.columnSetSnapshots().size());
+        assertEquals(1, node.childNodes().size());
+    }
+
+    @Test
+    void fieldNameFromSchemaPathLeaf() {
+        var path = new SchemaPath("root", "child", "myField");
+        var node = new LayoutDecisionNode(path, path.leaf(), null, null, null, null,
+                                          null, null);
+        assertEquals("myField", node.fieldName());
+        assertEquals("myField", path.leaf());
+    }
+
+    @Test
+    void childNodesIsDefensivelyCopied() {
+        var child = new LayoutDecisionNode(new SchemaPath("a"), "a",
+                                           null, null, null, null, null, null);
+        var mutable = new ArrayList<>(List.of(child));
+        var node = new LayoutDecisionNode(new SchemaPath("root"), "root",
+                                          null, null, null, null, null, mutable);
+
+        mutable.add(child);  // mutate original list after construction
+
+        assertEquals(1, node.childNodes().size(), "childNodes must be defensively copied");
+        assertThrows(UnsupportedOperationException.class,
+                     () -> node.childNodes().add(child));
+    }
+
+    @Test
+    void nullChildNodesNormalizedToEmptyList() {
+        var node = new LayoutDecisionNode(new SchemaPath("root"), "root",
+                                          null, null, null, null, null, null);
+
+        assertNotNull(node.childNodes());
+        assertTrue(node.childNodes().isEmpty());
+    }
+
+    @Test
+    void columnSetSnapshotsIsDefensivelyCopied() {
+        var snap = columnSetSnapshot();
+        var mutable = new ArrayList<>(List.of(snap));
+        var node = new LayoutDecisionNode(new SchemaPath("root"), "root",
+                                          null, null, null, null, mutable, null);
+
+        mutable.add(snap);  // mutate after construction
+
+        assertEquals(1, node.columnSetSnapshots().size(),
+                     "columnSetSnapshots must be defensively copied");
+        assertThrows(UnsupportedOperationException.class,
+                     () -> node.columnSetSnapshots().add(snap));
+    }
+
+    @Test
+    void nullColumnSetSnapshotsNormalizedToEmptyList() {
+        var node = new LayoutDecisionNode(new SchemaPath("root"), "root",
+                                          null, null, null, null, null, null);
+
+        assertNotNull(node.columnSetSnapshots());
+        assertTrue(node.columnSetSnapshots().isEmpty());
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/NumericStatsTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/NumericStatsTest.java
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+class NumericStatsTest {
+
+    // --- NumericStats record construction ---
+
+    @Test
+    void numericStatsRecordConstruction() {
+        NumericStats stats = new NumericStats(1.5, 99.9);
+        assertEquals(1.5, stats.numericMin(), 1e-9);
+        assertEquals(99.9, stats.numericMax(), 1e-9);
+    }
+
+    @Test
+    void numericStatsEquality() {
+        NumericStats a = new NumericStats(0.0, 100.0);
+        NumericStats b = new NumericStats(0.0, 100.0);
+        NumericStats c = new NumericStats(1.0, 100.0);
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
+
+    // --- MeasureResult with non-null numericStats ---
+
+    @Test
+    void measureResultAcceptsNonNullNumericStats() {
+        NumericStats ns = new NumericStats(5.0, 50.0);
+        MeasureResult result = new MeasureResult(
+            10.0, 20.0, 15.0, 25.0,
+            1, false,
+            0, 0,
+            null, List.of(),
+            null, ns, null
+        );
+        assertNotNull(result.numericStats());
+        assertEquals(5.0, result.numericStats().numericMin(), 1e-9);
+        assertEquals(50.0, result.numericStats().numericMax(), 1e-9);
+    }
+
+    @Test
+    void measureResultAcceptsNullNumericStats() {
+        MeasureResult result = new MeasureResult(
+            10.0, 20.0, 15.0, 25.0,
+            1, false,
+            0, 0,
+            null, List.of(),
+            null, null, null
+        );
+        assertNull(result.numericStats());
+    }
+
+    // --- All-numeric data produces numericStats with correct min/max ---
+
+    @Test
+    void allNumericDataProducesNumericStatsWithMinMax() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("value"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 40; i++) {
+            data.add(i * 10.0);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result);
+        assertNotNull(result.numericStats(), "All-numeric data must produce non-null numericStats");
+        assertEquals(10.0, result.numericStats().numericMin(), 1e-9,
+                     "numericMin should be the smallest value");
+        assertEquals(400.0, result.numericStats().numericMax(), 1e-9,
+                     "numericMax should be the largest value");
+    }
+
+    // --- Mixed numeric/text data produces null numericStats ---
+
+    @Test
+    void mixedDataProducesNullNumericStats() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("value"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 35; i++) {
+            if (i % 5 == 0) {
+                data.add("text_value_" + i);
+            } else {
+                data.add(i * 3.0);
+            }
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result);
+        assertNull(result.numericStats(), "Mixed numeric/text data must produce null numericStats");
+    }
+
+    // --- renderMode set to BAR when all numeric ---
+
+    @Test
+    void allNumericDataSetsRenderModeBAR() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("score"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 40; i++) {
+            data.add(i * 2.5);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BAR, layout.getRenderMode(),
+                     "renderMode should be BAR when all data is numeric");
+    }
+
+    @Test
+    void mixedDataKeepsRenderModeTEXT() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("label"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 35; i++) {
+            if (i % 4 == 0) {
+                data.add("non-numeric");
+            } else {
+                data.add(i * 1.0);
+            }
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.TEXT, layout.getRenderMode(),
+                     "renderMode should remain TEXT when data contains non-numeric values");
+    }
+
+    // --- Double.NEGATIVE_INFINITY / POSITIVE_INFINITY init produces correct range ---
+
+    @Test
+    void infinityInitProducesCorrectRange() {
+        // Verify that initializing min=+INF, max=-INF then updating with a single value yields [v, v]
+        double initMin = Double.POSITIVE_INFINITY;
+        double initMax = Double.NEGATIVE_INFINITY;
+        double v = 42.0;
+        double min = Math.min(initMin, v);
+        double max = Math.max(initMax, v);
+        assertEquals(42.0, min, 1e-9);
+        assertEquals(42.0, max, 1e-9);
+    }
+
+    @Test
+    void allNumericSingleValueRangeIsMinEqualsMax() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("count"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 35; i++) {
+            data.add(7.0);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result.numericStats());
+        assertEquals(7.0, result.numericStats().numericMin(), 1e-9);
+        assertEquals(7.0, result.numericStats().numericMax(), 1e-9);
+    }
+
+    // --- Below MIN_SAMPLES: numericStats still computed (all-numeric detection is separate) ---
+
+    @Test
+    void belowMinSamplesAllNumericStillDetected() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("val"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // Only 2 elements — below MIN_SAMPLES=30, but still all numeric
+        data.add(1.0);
+        data.add(9.0);
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result);
+        // numericStats should be non-null even with < MIN_SAMPLES because numeric detection is independent
+        assertNotNull(result.numericStats(),
+                      "numericStats should be set for all-numeric data regardless of sample count");
+        assertEquals(1.0, result.numericStats().numericMin(), 1e-9);
+        assertEquals(9.0, result.numericStats().numericMax(), 1e-9);
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/PivotStatsTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/PivotStatsTest.java
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for PivotStats record and pivot collection in RelationLayout.measure().
+ */
+class PivotStatsTest {
+
+    // --- PivotStats record construction ---
+
+    @Test
+    void pivotStatsRecordConstruction() {
+        PivotStats stats = new PivotStats(List.of("A", "B", "C"), 3);
+        assertEquals(List.of("A", "B", "C"), stats.pivotValues());
+        assertEquals(3, stats.pivotCount());
+    }
+
+    @Test
+    void pivotValuesDefensivelyCopied() {
+        List<String> mutable = new ArrayList<>(List.of("X", "Y"));
+        PivotStats stats = new PivotStats(mutable, 2);
+        mutable.add("Z");
+        assertEquals(2, stats.pivotValues().size(),
+                     "pivotValues should be immutably copied at construction");
+        assertThrows(UnsupportedOperationException.class,
+                     () -> stats.pivotValues().add("W"),
+                     "pivotValues list must be unmodifiable");
+    }
+
+    @Test
+    void pivotCountMatchesPivotValuesSize() {
+        List<String> values = List.of("cat", "dog", "bird");
+        PivotStats stats = new PivotStats(values, values.size());
+        assertEquals(stats.pivotValues().size(), stats.pivotCount());
+    }
+
+    @Test
+    void measureResultWithNonNullPivotStats() {
+        PivotStats ps = new PivotStats(List.of("alpha", "beta"), 2);
+        MeasureResult result = new MeasureResult(
+            10.0, 20.0, 15.0, 25.0,
+            1, false,
+            0, 0,
+            null, List.of(),
+            null, null, ps
+        );
+        assertNotNull(result.pivotStats());
+        assertEquals(2, result.pivotStats().pivotCount());
+        assertEquals(List.of("alpha", "beta"), result.pivotStats().pivotValues());
+    }
+
+    @Test
+    void measureResultWithNullPivotStats() {
+        MeasureResult result = new MeasureResult(
+            10.0, 20.0, 15.0, 25.0,
+            1, false,
+            0, 0,
+            null, List.of(),
+            null, null, null
+        );
+        assertNull(result.pivotStats());
+    }
+
+    // --- pivot-field configured → non-null pivotStats with distinct values ---
+
+    @Test
+    void pivotFieldConfiguredExtractsDistinctValues() {
+        Relation schema = new Relation("orders");
+        Primitive status = new Primitive("status");
+        Primitive amount = new Primitive("amount");
+        schema.addChild(status);
+        schema.addChild(amount);
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        SchemaPath rootPath = new SchemaPath("orders");
+        LayoutStylesheet stylesheet = stylesheetWithPivot("status");
+        Style model = mockStyleModel(schema, stylesheet);
+
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+        layout.setSchemaPath(rootPath);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (String s : new String[]{"open", "closed", "open", "pending", "closed", "open"}) {
+            var row = JsonNodeFactory.instance.objectNode();
+            row.put("status", s);
+            row.put("amount", 100);
+            data.add(row);
+        }
+
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result.pivotStats(),
+                     "pivotStats must be non-null when pivot-field is configured");
+        List<String> values = result.pivotStats().pivotValues();
+        assertEquals(3, values.size(), "should have 3 distinct pivot values");
+        assertTrue(values.containsAll(List.of("open", "closed", "pending")));
+        assertEquals(3, result.pivotStats().pivotCount());
+    }
+
+    @Test
+    void noPivotFieldConfiguredYieldsNullPivotStats() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        SchemaPath rootPath = new SchemaPath("items");
+        LayoutStylesheet stylesheet = stylesheetNoPivot();
+        Style model = mockStyleModel(schema, stylesheet);
+
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+        layout.setSchemaPath(rootPath);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        var row = JsonNodeFactory.instance.objectNode();
+        row.put("name", "widget");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNull(result.pivotStats(),
+                   "pivotStats must be null when no pivot-field is configured");
+    }
+
+    // --- helpers ---
+
+    private LayoutStylesheet stylesheetWithPivot(String pivotField) {
+        return new DefaultLayoutStylesheet(null) {
+            @Override
+            public String getString(SchemaPath path, String property, String defaultValue) {
+                if ("pivot-field".equals(property)) return pivotField;
+                return defaultValue;
+            }
+
+            @Override
+            public long getVersion() { return 0; }
+        };
+    }
+
+    private LayoutStylesheet stylesheetNoPivot() {
+        return new DefaultLayoutStylesheet(null) {
+            @Override
+            public String getString(SchemaPath path, String property, String defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public long getVersion() { return 0; }
+        };
+    }
+
+    private Style mockStyleModel(Relation schema, LayoutStylesheet stylesheet) {
+        Style model = mock(Style.class);
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        for (SchemaNode child : schema.getChildren()) {
+            if (child instanceof Primitive p) {
+                PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+                when(model.layout(p)).thenReturn(pl);
+            }
+        }
+        when(model.layout(any(SchemaNode.class))).thenAnswer(inv -> {
+            SchemaNode n = inv.getArgument(0);
+            if (n instanceof Primitive p) return model.layout(p);
+            return model.layout((Relation) n);
+        });
+        when(model.getStylesheet()).thenReturn(stylesheet);
+        return model;
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-011** (Kramer-e18): `LayoutDecisionNode` record — unifies path, fieldName, all 4 result records, columnSetSnapshots, childNodes
- **RDR-015** (Kramer-a6l): `NumericStats` sub-record + BAR auto-detection in `PrimitiveLayout.measure()`. Stylesheet `render-mode` override. `renderMode` field on `PrimitiveLayout`.
- **RDR-015** (Kramer-4zt): `PivotStats` sub-record + pivot value collection in `RelationLayout.measure()` after sort+filter pipeline

## Test plan
- [x] 387 tests pass (24 new)
- [x] LayoutDecisionNode: 6 tests
- [x] NumericStats+BAR: 11 tests (auto-detect, min/max, mixed data, stylesheet override)
- [x] PivotStats: 7 tests (collection, defensive copy, MeasureResult integration)

Ref: Kramer-e18, Kramer-a6l, Kramer-4zt