### PR TITLE
Wave 2 Batch 3: snapshotDecisionTree, PrimitiveBarStyle, Crosstab

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -28,8 +28,9 @@ import com.chiralbehaviors.layout.cell.LayoutCell;
 import com.chiralbehaviors.layout.cell.PrimitiveList;
 import com.chiralbehaviors.layout.cell.control.FocusTraversal;
 import com.chiralbehaviors.layout.schema.Primitive;
-import com.chiralbehaviors.layout.style.Style;
 import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle.PrimitiveBarStyle;
+import com.chiralbehaviors.layout.style.Style;
 import com.chiralbehaviors.layout.table.ColumnHeader;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -94,8 +95,16 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     public LayoutCell<? extends Region> buildControl(FocusTraversal<?> parentTraversal,
                                                      Style model) {
         int avgCard = measureResult != null ? measureResult.averageCardinality() : averageCardinality;
-        return avgCard > 1 ? new PrimitiveList(this, parentTraversal)
-                           : buildCell(parentTraversal);
+        if (avgCard > 1) {
+            return new PrimitiveList(this, parentTraversal);
+        }
+        if (renderMode == PrimitiveRenderMode.BAR) {
+            PrimitiveBarStyle barStyle = new PrimitiveBarStyle(style.getLabelStyle(),
+                                                               javafx.geometry.Insets.EMPTY,
+                                                               style.getLabelStyle());
+            return barStyle.build(parentTraversal, this);
+        }
+        return buildCell(parentTraversal);
     }
 
     @Override
@@ -424,6 +433,46 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             columnHeaderIndentation,
             width,                         // constrainedColumnWidth
             List.of()
+        );
+    }
+
+    /**
+     * Snapshot the current layout state WITHOUT calling {@code clear()}.
+     * Safe to call after {@code autoLayout()} completes; reads fields directly.
+     * Unlike {@link #computeLayout(double)}, this does not reset useVerticalHeader
+     * or any other mutable state.
+     */
+    public LayoutResult snapshotLayoutResult() {
+        return new LayoutResult(
+            RelationRenderMode.OUTLINE,    // primitives never use table mode
+            renderMode,
+            useVerticalHeader,
+            0,                             // tableColumnWidth — not applicable
+            columnHeaderIndentation,
+            justifiedWidth,               // use post-compress justifiedWidth
+            List.of()
+        );
+    }
+
+    /**
+     * Compose a leaf {@link LayoutDecisionNode} from current field state.
+     * No layout side effects.
+     */
+    @Override
+    public LayoutDecisionNode snapshotDecisionTree() {
+        SchemaPath path = getSchemaPath();
+        String field = path != null ? path.leaf() : getField();
+        CompressResult compressSnap = new CompressResult(justifiedWidth, List.of(), cellHeight, List.of());
+        HeightResult heightSnap = new HeightResult(height, cellHeight, averageCardinality, columnHeaderIndentation, List.of());
+        return new LayoutDecisionNode(
+            path,
+            field,
+            measureResult,
+            snapshotLayoutResult(),
+            compressSnap,
+            heightSnap,
+            List.of(),   // primitives have no column sets
+            List.of()    // leaf — no child nodes
         );
     }
 

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -36,6 +37,7 @@ import com.chiralbehaviors.layout.schema.SchemaNode;
 import com.chiralbehaviors.layout.style.Style;
 import com.chiralbehaviors.layout.style.RelationStyle;
 import com.chiralbehaviors.layout.table.ColumnHeader;
+import com.chiralbehaviors.layout.table.CrosstabHeader;
 import com.chiralbehaviors.layout.table.NestedRow;
 import com.chiralbehaviors.layout.table.NestedTable;
 import com.chiralbehaviors.layout.table.TableHeader;
@@ -170,7 +172,8 @@ public final class RelationLayout extends SchemaNodeLayout {
         return result;
     }
 
-    private static final List<String> AUTO_SORT_CANDIDATES = List.of("id", "key", "name");
+    private static final List<String>  AUTO_SORT_CANDIDATES = List.of("id", "key", "name");
+    private static final Logger        LOG                  = Logger.getLogger(RelationLayout.class.getName());
 
     protected int                          averageChildCardinality;
     protected double                       cellHeight       = -1;
@@ -181,8 +184,14 @@ public final class RelationLayout extends SchemaNodeLayout {
     protected int                          maxCardinality;
     protected int                          resolvedCardinality;
     protected final RelationStyle          style;
-    protected double                       tableColumnWidth = 0;
-    protected boolean                      useTable         = false;
+    protected double                       tableColumnWidth  = 0;
+    protected boolean                      useTable          = false;
+    /** True when layoutCrosstab() has been called with non-empty pivot values. */
+    protected boolean                      useCrosstab       = false;
+    /** Pivot column values set by layoutCrosstab(); empty when not in crosstab mode. */
+    protected List<String>                 crosstabPivotValues = List.of();
+    /** Width of each pivot data column in crosstab mode. */
+    protected double                       crosstabColumnWidth = 0.0;
     private MeasureResult                  measureResult;
     /** Comparator derived from sortFields / autoSort; null when no sort is needed. */
     private Comparator<JsonNode>           sortComparator;
@@ -210,7 +219,15 @@ public final class RelationLayout extends SchemaNodeLayout {
     @Override
     public void adjustHeight(double delta) {
         super.adjustHeight(delta);
-        if (useTable) {
+        if (useCrosstab) {
+            // CROSSTAB rows behave like table rows: distribute delta per row
+            if (resolvedCardinality > 0) {
+                double subDelta = delta / resolvedCardinality;
+                if (subDelta >= 1.0) {
+                    cellHeight = Style.snap(cellHeight + subDelta);
+                }
+            }
+        } else if (useTable) {
             double subDelta = delta / resolvedCardinality;
             if (subDelta >= 1.0) {
                 cellHeight = Style.snap(cellHeight + subDelta);
@@ -232,7 +249,8 @@ public final class RelationLayout extends SchemaNodeLayout {
 
     @Override
     protected void distributeExtraHeight(double availableHeight) {
-        if (!useTable || availableHeight <= 0 || height <= 0
+        boolean tableLike = useTable || useCrosstab;
+        if (!tableLike || availableHeight <= 0 || height <= 0
             || availableHeight <= height || resolvedCardinality <= 0) {
             return;
         }
@@ -273,6 +291,9 @@ public final class RelationLayout extends SchemaNodeLayout {
     @Override
     public LayoutCell<?> buildControl(FocusTraversal<?> parentTraversal,
                                       Style model) {
+        if (useCrosstab) {
+            return buildCrosstab(parentTraversal, model);
+        }
         return useTable ? buildNestedTable(parentTraversal, model)
                         : buildOutline(parentTraversal, model);
     }
@@ -312,7 +333,9 @@ public final class RelationLayout extends SchemaNodeLayout {
             return height;
         }
         resolvedCardinality = resolveCardinality(cardinality);
-        if (useTable) {
+        if (useCrosstab) {
+            calculateCrosstabHeight();
+        } else if (useTable) {
             calculateTableHeight();
         } else {
             calculateOutlineHeight();
@@ -489,11 +512,46 @@ public final class RelationLayout extends SchemaNodeLayout {
             columnWidth,
             children.stream()
                 .map(c -> {
-                    if (c instanceof PrimitiveLayout pl) return pl.computeLayout(pl.getJustifiedWidth());
+                    if (c instanceof PrimitiveLayout pl) return pl.snapshotLayoutResult();
                     if (c instanceof RelationLayout rl) return rl.snapshotLayoutResult();
                     return null;
                 })
                 .toList()
+        );
+    }
+
+    /**
+     * Compose a {@link LayoutDecisionNode} tree from the current layout state.
+     * Recursively snapshots all children. No layout side effects.
+     */
+    @Override
+    public LayoutDecisionNode snapshotDecisionTree() {
+        SchemaPath path = getSchemaPath();
+        String field = path != null ? path.leaf() : getField();
+
+        List<ColumnSetSnapshot> colSetSnaps = columnSets.stream()
+            .map(cs -> cs.toSnapshot(cellHeight))
+            .toList();
+
+        CompressResult compressSnap = new CompressResult(
+            justifiedWidth, List.copyOf(columnSets), cellHeight, List.of());
+
+        HeightResult heightSnap = new HeightResult(
+            height, cellHeight, resolvedCardinality, columnHeaderHeight, List.of());
+
+        List<LayoutDecisionNode> childNodes = children.stream()
+            .map(SchemaNodeLayout::snapshotDecisionTree)
+            .toList();
+
+        return new LayoutDecisionNode(
+            path,
+            field,
+            measureResult,
+            snapshotLayoutResult(),
+            compressSnap,
+            heightSnap,
+            colSetSnaps,
+            childNodes
         );
     }
 
@@ -767,6 +825,9 @@ public final class RelationLayout extends SchemaNodeLayout {
     protected void clear() {
         super.clear();
         useTable = false;
+        useCrosstab = false;
+        crosstabPivotValues = List.of();
+        crosstabColumnWidth = 0.0;
         tableColumnWidth = -1.0;
         columnHeaderHeight = -1.0;
     }
@@ -921,5 +982,116 @@ public final class RelationLayout extends SchemaNodeLayout {
 
     public double getJustifiedTableColumnWidth() {
         return snap(justifiedWidth + columnHeaderIndentation);
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Crosstab API                                                        //
+    // ------------------------------------------------------------------ //
+
+    /**
+     * Compute crosstab layout for the given pivot values and available width.
+     *
+     * <p>When {@code pivotValues} is empty the layout degrades to TABLE (or
+     * OUTLINE if table does not fit) and a warning is logged. This prevents
+     * a crash when no data exists for the pivot field.
+     *
+     * <p>The method sets {@link #useCrosstab} and caches the pivot column width
+     * so that {@link #buildControl}, {@link #adjustHeight}, and
+     * {@link #distributeExtraHeight} all branch into the CROSSTAB path.
+     *
+     * @param availableWidth total available width for this relation
+     * @param pivotValues    ordered distinct values of the pivot field
+     * @return total computed width used by the crosstab (row-header + all pivot columns)
+     */
+    public double layoutCrosstab(double availableWidth, List<String> pivotValues) {
+        if (pivotValues == null || pivotValues.isEmpty()) {
+            LOG.warning(() -> "layoutCrosstab called with empty pivotValues for "
+                              + getNode().getField() + "; degrading to TABLE/OUTLINE");
+            useCrosstab = false;
+            crosstabPivotValues = List.of();
+            crosstabColumnWidth = 0.0;
+            // Re-run normal layout to ensure useTable is set appropriately
+            layout(availableWidth);
+            return layoutWidth();
+        }
+
+        useCrosstab = true;
+        crosstabPivotValues = List.copyOf(pivotValues);
+
+        // Row-header width = outline column width for non-pivot children
+        double rowHeaderWidth = Style.snap(columnWidth > 0 ? columnWidth : availableWidth * 0.3);
+
+        // Distribute remaining width equally across pivot columns
+        double remaining = availableWidth - rowHeaderWidth;
+        crosstabColumnWidth = pivotValues.isEmpty() ? 0.0
+                                                     : Style.snap(remaining / pivotValues.size());
+
+        // Overall width = rowHeader + all pivot columns
+        double totalWidth = Style.snap(rowHeaderWidth + crosstabColumnWidth * pivotValues.size());
+
+        // Ensure height state is reset so cellHeight() recalculates
+        height = -1.0;
+        cellHeight = -1.0;
+
+        return totalWidth;
+    }
+
+    /** @return true when this layout is in CROSSTAB rendering mode */
+    public boolean isCrosstab() {
+        return useCrosstab;
+    }
+
+    /**
+     * Build the fixed column-header bar for the crosstab.
+     *
+     * @return a {@link CrosstabHeader} placed outside the VirtualFlow
+     */
+    public CrosstabHeader buildCrosstabHeader() {
+        return new CrosstabHeader(crosstabPivotValues, crosstabColumnWidth,
+                                  columnHeaderHeight > 0 ? columnHeaderHeight
+                                                         : Style.snap(labelStyle.getHeight()),
+                                  style);
+    }
+
+    /**
+     * Build the crosstab control. Falls back to a NestedTable placeholder until
+     * a full VirtualFlow-based crosstab implementation exists.
+     *
+     * <p>The crosstab header is built here via {@link #buildCrosstabHeader()}.
+     */
+    public LayoutCell<?> buildCrosstab(FocusTraversal<?> parentTraversal,
+                                        Style model) {
+        // Build the stationary header
+        buildCrosstabHeader();
+        // For this bead, fall back to NestedTable as the scrollable body.
+        // A full VirtualFlow<CrosstabRow> implementation is a follow-on bead.
+        return buildNestedTable(parentTraversal, model);
+    }
+
+    /**
+     * Calculate height for crosstab mode. Mirrors {@link #calculateTableHeight()}
+     * but uses per-row height based solely on the child row height (pivot cells
+     * are peers of the row header, not nested relations).
+     */
+    protected void calculateCrosstabHeight() {
+        columnHeaderHeight();
+        cellHeight = calculateRowHeight();
+        height = Style.snap((resolvedCardinality * cellHeight) + columnHeaderHeight)
+                 + style.getRowVerticalInset() + style.getTableVerticalInset();
+    }
+
+    /**
+     * Test helper: resets measure-derived state so a second measure+layout
+     * cycle can be run in the same test.
+     */
+    void clearForTest() {
+        clear();
+        children.clear();
+        extractor = null;
+        measureResult = null;
+        averageChildCardinality = 0;
+        maxCardinality = 0;
+        labelWidth = 0;
+        columnWidth = 0;
     }
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
@@ -243,6 +243,15 @@ public abstract sealed class SchemaNodeLayout permits PrimitiveLayout, RelationL
     /** Returns true when this node and all descendants have converged (frozen result cached). */
     public abstract boolean isConverged();
 
+    /**
+     * Compose a {@link LayoutDecisionNode} tree from the current layout state.
+     * Must be called after {@code autoLayout()} completes. Reads existing field
+     * state without triggering any layout side effects (no {@code clear()} calls).
+     *
+     * @return the decision tree rooted at this node
+     */
+    public abstract LayoutDecisionNode snapshotDecisionTree();
+
     public SchemaPath getSchemaPath() {
         return schemaPath;
     }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
@@ -20,6 +20,8 @@ import static com.chiralbehaviors.layout.cell.control.SelectionEvent.DOUBLE_SELE
 import static com.chiralbehaviors.layout.cell.control.SelectionEvent.SINGLE_SELECT;
 import static com.chiralbehaviors.layout.cell.control.SelectionEvent.TRIPLE_SELECT;
 
+import com.chiralbehaviors.layout.MeasureResult;
+import com.chiralbehaviors.layout.NumericStats;
 import com.chiralbehaviors.layout.PrimitiveLayout;
 import com.chiralbehaviors.layout.cell.LayoutCell;
 import com.chiralbehaviors.layout.cell.control.FocusTraversal;
@@ -35,6 +37,8 @@ import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
 
 /**
@@ -175,6 +179,74 @@ abstract public class PrimitiveStyle extends NodeStyle {
         public double width(JsonNode row) {
             return primitiveStyle.width(Style.toString(row))
                    + primitiveStyle.getHorizontalInset();
+        }
+
+    }
+
+    public static class PrimitiveBarStyle extends PrimitiveStyle {
+
+        public static final String PRIMITIVE_BAR_CLASS = "primitive-bar";
+
+        private final LabelStyle primitiveStyle;
+
+        public PrimitiveBarStyle(LabelStyle labelStyle, Insets listInsets,
+                                 LabelStyle primitiveStyle) {
+            super(labelStyle, listInsets);
+            this.primitiveStyle = primitiveStyle;
+        }
+
+        @Override
+        public LayoutCell<?> build(FocusTraversal<?> pt, PrimitiveLayout p) {
+            StackPane pane = new StackPane();
+            pane.setMinSize(p.getJustifiedWidth(), p.getCellHeight());
+            pane.setPrefSize(p.getJustifiedWidth(), p.getCellHeight());
+            pane.setMaxSize(p.getJustifiedWidth(), p.getCellHeight());
+
+            Rectangle bar = new Rectangle(0, p.getCellHeight());
+            bar.getStyleClass().add(PRIMITIVE_BAR_CLASS);
+            pane.getChildren().add(bar);
+            // Align the bar to the left inside the StackPane
+            javafx.scene.layout.StackPane.setAlignment(bar, javafx.geometry.Pos.CENTER_LEFT);
+
+            return new PrimitiveLayoutCell<Region>(p, PRIMITIVE_BAR_CLASS, pt) {
+                @Override
+                public StackPane getNode() {
+                    return pane;
+                }
+
+                @Override
+                public boolean isReusable() {
+                    return true;
+                }
+
+                @Override
+                public void updateItem(com.fasterxml.jackson.databind.JsonNode item) {
+                    super.updateItem(item);
+                    if (item == null || item.isNull()) {
+                        bar.setWidth(0);
+                        return;
+                    }
+                    double value = item.asDouble();
+                    double justifiedWidth = p.getJustifiedWidth();
+                    MeasureResult mr = p.getMeasureResult();
+                    NumericStats ns = (mr != null) ? mr.numericStats() : null;
+                    double min = (ns != null) ? ns.numericMin() : 0.0;
+                    double max = (ns != null) ? ns.numericMax() : 0.0;
+                    double range = max - min;
+                    double fraction = (range == 0.0) ? 1.0 : (value - min) / range;
+                    bar.setWidth(fraction * justifiedWidth);
+                }
+            };
+        }
+
+        @Override
+        public double getHeight(double maxWidth, double justified) {
+            return primitiveStyle.getHeight(1);
+        }
+
+        @Override
+        public double width(com.fasterxml.jackson.databind.JsonNode row) {
+            return 0.0;
         }
 
     }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/CrosstabCell.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/CrosstabCell.java
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout.table;
+
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+
+/**
+ * A single data cell in a crosstab row, displaying the aggregated value at the
+ * intersection of a row-header group and a pivot column.
+ *
+ * <p>Placed inside a {@link CrosstabRow}; one cell per pivot value.
+ */
+public class CrosstabCell extends Region {
+
+    private static final String STYLE_CLASS = "crosstab-cell";
+
+    private final Label  label;
+    private final double cellWidth;
+    private final double cellHeight;
+
+    public CrosstabCell(double cellWidth, double cellHeight) {
+        this.cellWidth  = Style.snap(cellWidth);
+        this.cellHeight = Style.snap(cellHeight);
+
+        getStyleClass().add(STYLE_CLASS);
+
+        label = new Label();
+        label.setMinSize(this.cellWidth, this.cellHeight);
+        label.setPrefSize(this.cellWidth, this.cellHeight);
+        label.setMaxSize(this.cellWidth, this.cellHeight);
+        getChildren().add(label);
+
+        setMinSize(this.cellWidth, this.cellHeight);
+        setPrefSize(this.cellWidth, this.cellHeight);
+        setMaxSize(this.cellWidth, this.cellHeight);
+    }
+
+    /**
+     * Update the displayed value. A {@code null} node clears the cell.
+     *
+     * @param item the JSON node whose text representation is shown, or null
+     */
+    public void updateItem(JsonNode item) {
+        if (item == null || item.isNull()) {
+            label.setText("");
+        } else {
+            label.setText(item.asText());
+        }
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/CrosstabHeader.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/CrosstabHeader.java
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout.table;
+
+import java.util.List;
+
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+
+import javafx.geometry.Pos;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+
+/**
+ * The fixed column-header bar for a crosstab layout.
+ *
+ * <p>Mirrors the header-outside-VirtualFlow pattern used by {@link NestedTable}:
+ * the header is a plain {@link Region} placed above the VirtualFlow so that it
+ * stays stationary while rows scroll.
+ *
+ * <p>The header consists of an optional row-header spacer (width = rowHeaderWidth)
+ * followed by one label per pivot value (each with width = pivotColumnWidth).
+ */
+public class CrosstabHeader extends Region {
+
+    private static final String STYLE_CLASS = "crosstab-header";
+
+    private final List<String> pivotValues;
+    private final HBox         container;
+
+    /**
+     * @param pivotValues      distinct pivot-column labels (insertion-ordered)
+     * @param pivotColumnWidth width allocated to each pivot data column
+     * @param height           height of the header bar
+     * @param style            relation style (for insets; currently informational)
+     */
+    public CrosstabHeader(List<String> pivotValues, double pivotColumnWidth,
+                          double height, RelationStyle style) {
+        this.pivotValues = List.copyOf(pivotValues);
+
+        getStyleClass().add(STYLE_CLASS);
+
+        double snappedColW = Style.snap(pivotColumnWidth);
+        double snappedH    = Style.snap(height);
+
+        container = new HBox();
+        container.setAlignment(Pos.CENTER_LEFT);
+
+        for (String pv : this.pivotValues) {
+            Label lbl = new Label(pv);
+            lbl.setMinSize(snappedColW, snappedH);
+            lbl.setPrefSize(snappedColW, snappedH);
+            lbl.setMaxSize(snappedColW, snappedH);
+            lbl.getStyleClass().add("crosstab-header-label");
+            container.getChildren().add(lbl);
+        }
+
+        getChildren().add(container);
+
+        double totalWidth = Style.snap(snappedColW * this.pivotValues.size());
+        setMinSize(totalWidth, snappedH);
+        setPrefSize(totalWidth, snappedH);
+        setMaxSize(totalWidth, snappedH);
+    }
+
+    /** @return number of pivot columns */
+    public int getPivotCount() {
+        return pivotValues.size();
+    }
+
+    /** @return immutable list of pivot column labels */
+    public List<String> getPivotValues() {
+        return pivotValues;
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/CrosstabRow.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/CrosstabRow.java
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout.table;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+
+/**
+ * A single data row in a crosstab layout.
+ *
+ * <p>Each row contains:
+ * <ol>
+ *   <li>a row-header region (width = rowHeaderWidth) showing non-pivot field values</li>
+ *   <li>one {@link CrosstabCell} per pivot value (each with width = pivotColumnWidth)</li>
+ * </ol>
+ *
+ * <p>Rows are placed inside a VirtualFlow so that large datasets scroll
+ * without allocating a JavaFX node per item.
+ */
+public class CrosstabRow extends Region {
+
+    private static final String STYLE_CLASS = "crosstab-row";
+
+    private final List<CrosstabCell> dataCells = new ArrayList<>();
+    private final HBox               container;
+
+    /**
+     * @param pivotValues      ordered list of pivot-column names
+     * @param rowHeaderWidth   width of the left row-header region
+     * @param pivotColumnWidth width of each pivot data cell
+     * @param cellHeight       height of this row
+     * @param style            relation style (for insets; currently informational)
+     */
+    public CrosstabRow(List<String> pivotValues, double rowHeaderWidth,
+                       double pivotColumnWidth, double cellHeight,
+                       RelationStyle style) {
+        getStyleClass().add(STYLE_CLASS);
+
+        double snappedRowHdrW = Style.snap(rowHeaderWidth);
+        double snappedColW    = Style.snap(pivotColumnWidth);
+        double snappedH       = Style.snap(cellHeight);
+
+        container = new HBox();
+
+        // Row-header placeholder — will be populated by updateItem()
+        Region rowHeader = new Region();
+        rowHeader.getStyleClass().add("crosstab-row-header");
+        rowHeader.setMinSize(snappedRowHdrW, snappedH);
+        rowHeader.setPrefSize(snappedRowHdrW, snappedH);
+        rowHeader.setMaxSize(snappedRowHdrW, snappedH);
+        container.getChildren().add(rowHeader);
+
+        // One data cell per pivot value
+        for (int i = 0; i < pivotValues.size(); i++) {
+            CrosstabCell cell = new CrosstabCell(snappedColW, snappedH);
+            dataCells.add(cell);
+            container.getChildren().add(cell);
+        }
+
+        getChildren().add(container);
+
+        double totalWidth = Style.snap(snappedRowHdrW + snappedColW * pivotValues.size());
+        setMinSize(totalWidth, snappedH);
+        setPrefSize(totalWidth, snappedH);
+        setMaxSize(totalWidth, snappedH);
+    }
+
+    /** @return number of pivot data cells in this row */
+    public int getPivotCount() {
+        return dataCells.size();
+    }
+
+    /**
+     * Set the value of the pivot cell at {@code pivotIndex} from {@code item}.
+     *
+     * @param pivotIndex 0-based index into pivot values list
+     * @param item       JSON node value to display (may be null)
+     */
+    public void updatePivotCell(int pivotIndex, JsonNode item) {
+        if (pivotIndex >= 0 && pivotIndex < dataCells.size()) {
+            dataCells.get(pivotIndex).updateItem(item);
+        }
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/CrosstabTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/CrosstabTest.java
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.chiralbehaviors.layout.table.CrosstabCell;
+import com.chiralbehaviors.layout.table.CrosstabHeader;
+import com.chiralbehaviors.layout.table.CrosstabRow;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+
+/**
+ * Tests for Kramer-7vl: CrosstabHeader, CrosstabRow, CrosstabCell, and
+ * layoutCrosstab() integration in RelationLayout.
+ */
+@ExtendWith(ApplicationExtension.class)
+class CrosstabTest {
+
+    @Start
+    void start(Stage stage) {
+        stage.setScene(new Scene(new Pane(), 800, 600));
+        stage.show();
+    }
+
+    // ------------------------------------------------------------------ //
+    //  CrosstabHeader construction                                         //
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void crosstabHeaderCreatedWithPivotColumnNames() throws Exception {
+        List<String> pivotValues = List.of("Q1", "Q2", "Q3", "Q4");
+        RelationStyle style = TestLayouts.mockRelationStyle();
+        AtomicReference<CrosstabHeader> ref = new AtomicReference<>();
+
+        Platform.runLater(() -> ref.set(new CrosstabHeader(pivotValues, 60.0, 25.0, style)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        CrosstabHeader header = ref.get();
+        assertNotNull(header);
+        assertEquals(pivotValues.size(), header.getPivotCount());
+    }
+
+    @Test
+    void crosstabHeaderWithEmptyPivotListCreatesNoCells() throws Exception {
+        AtomicReference<CrosstabHeader> ref = new AtomicReference<>();
+        Platform.runLater(() -> ref.set(new CrosstabHeader(List.of(), 60.0, 25.0,
+                                                            TestLayouts.mockRelationStyle())));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertNotNull(ref.get());
+        assertEquals(0, ref.get().getPivotCount());
+    }
+
+    @Test
+    void crosstabHeaderExposesColumnLabels() throws Exception {
+        List<String> pivotValues = List.of("Alpha", "Beta");
+        AtomicReference<CrosstabHeader> ref = new AtomicReference<>();
+        Platform.runLater(() -> ref.set(new CrosstabHeader(pivotValues, 80.0, 20.0,
+                                                            TestLayouts.mockRelationStyle())));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals(pivotValues, ref.get().getPivotValues());
+    }
+
+    // ------------------------------------------------------------------ //
+    //  CrosstabRow construction                                            //
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void crosstabRowConstructedWithRowHeaderAndDataCells() throws Exception {
+        List<String> pivotValues = List.of("Jan", "Feb", "Mar");
+        AtomicReference<CrosstabRow> ref = new AtomicReference<>();
+        Platform.runLater(() -> ref.set(
+            new CrosstabRow(pivotValues, 100.0, 60.0, 25.0, TestLayouts.mockRelationStyle())));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertNotNull(ref.get());
+        assertEquals(pivotValues.size(), ref.get().getPivotCount());
+    }
+
+    @Test
+    void crosstabRowPivotCountMatchesPivotValues() throws Exception {
+        List<String> pivotValues = List.of("X", "Y");
+        AtomicReference<CrosstabRow> ref = new AtomicReference<>();
+        Platform.runLater(() -> ref.set(
+            new CrosstabRow(pivotValues, 80.0, 50.0, 20.0, TestLayouts.mockRelationStyle())));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals(2, ref.get().getPivotCount());
+    }
+
+    // ------------------------------------------------------------------ //
+    //  CrosstabCell construction                                           //
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void crosstabCellConstructedWithValue() throws Exception {
+        AtomicReference<CrosstabCell> ref = new AtomicReference<>();
+        Platform.runLater(() -> ref.set(new CrosstabCell(60.0, 25.0)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertNotNull(ref.get());
+    }
+
+    @Test
+    void crosstabCellUpdateItemDoesNotThrow() throws Exception {
+        AtomicReference<CrosstabCell> ref = new AtomicReference<>();
+        Platform.runLater(() -> ref.set(new CrosstabCell(60.0, 25.0)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        var node = JsonNodeFactory.instance.textNode("42");
+        assertDoesNotThrow(() -> {
+            try {
+                Platform.runLater(() -> ref.get().updateItem(node));
+                WaitForAsyncUtils.waitForFxEvents();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    void crosstabCellUpdateItemWithNullDoesNotThrow() throws Exception {
+        AtomicReference<CrosstabCell> ref = new AtomicReference<>();
+        Platform.runLater(() -> ref.set(new CrosstabCell(60.0, 25.0)));
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertDoesNotThrow(() -> {
+            try {
+                Platform.runLater(() -> ref.get().updateItem(null));
+                WaitForAsyncUtils.waitForFxEvents();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    // ------------------------------------------------------------------ //
+    //  layoutCrosstab() on RelationLayout                                  //
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void layoutCrosstabReturnsPositiveWidth() {
+        Relation schema = buildSalesSchema();
+        RelationLayout layout = buildMeasuredLayout(schema, buildSalesData());
+
+        double width = layout.layoutCrosstab(600.0, List.of("Q1", "Q2", "Q3"));
+
+        assertTrue(width > 0, "layoutCrosstab must return a positive width");
+    }
+
+    @Test
+    void layoutCrosstabWidthReflectsPivotCount() {
+        Relation schema = buildSalesSchema();
+        ArrayNode data = buildSalesData();
+        RelationLayout layout = buildMeasuredLayout(schema, data);
+
+        double narrow = layout.layoutCrosstab(600.0, List.of("Q1"));
+        layout.clearForTest();
+        layout.measure(data, n -> n, mockModel(schema));
+        double wide = layout.layoutCrosstab(600.0, List.of("Q1", "Q2", "Q3", "Q4"));
+
+        assertTrue(wide >= narrow,
+                   "More pivot columns should produce equal or greater width");
+    }
+
+    // ------------------------------------------------------------------ //
+    //  CROSSTAB mode in buildControl() dispatches to buildCrosstab()       //
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void crosstabModeSetByLayoutCrosstab() {
+        Relation schema = buildSalesSchema();
+        RelationLayout layout = buildMeasuredLayout(schema, buildSalesData());
+        layout.layoutCrosstab(600.0, List.of("Q1", "Q2"));
+
+        assertTrue(layout.isCrosstab(),
+                   "isCrosstab() must return true after layoutCrosstab()");
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Empty valueField → degrades to TABLE without crash                 //
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void emptyValueFieldDegradesToTableWithNoCrash() {
+        Relation schema = new Relation("sales");
+        schema.addChild(new Primitive("region"));
+        // No "amount" child — simulates missing value field
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        Style model = mockModel(schema);
+
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+        layout.setSchemaPath(new SchemaPath("sales"));
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ObjectNode row = JsonNodeFactory.instance.objectNode();
+        row.put("region", "North");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+        layout.layout(400.0);
+
+        // Calling layoutCrosstab with an empty pivot list should not throw
+        assertDoesNotThrow(() -> layout.layoutCrosstab(400.0, List.of()),
+                           "layoutCrosstab with empty pivot list must not throw");
+        // After degenerate call, layout should remain usable
+        assertFalse(layout.isCrosstab(),
+                    "isCrosstab() must be false when no pivot values given");
+    }
+
+    // ------------------------------------------------------------------ //
+    //  adjustHeight with CROSSTAB distributes correctly                    //
+    // ------------------------------------------------------------------ //
+
+    @Test
+    void adjustHeightInCrosstabModeDoesNotThrow() {
+        Relation schema = buildSalesSchema();
+        ArrayNode data = buildSalesData();
+        RelationLayout layout = buildMeasuredLayout(schema, data);
+        layout.layoutCrosstab(600.0, List.of("Q1", "Q2", "Q3"));
+
+        // Simulate height computation and then adjustment
+        layout.cellHeight(data.size(), 600.0);
+
+        assertDoesNotThrow(() -> layout.adjustHeight(10.0),
+                           "adjustHeight in CROSSTAB mode must not throw");
+    }
+
+    @Test
+    void adjustHeightDistributesAcrossCrosstabRows() {
+        Relation schema = buildSalesSchema();
+        ArrayNode data = buildSalesData();
+        RelationLayout layout = buildMeasuredLayout(schema, data);
+        layout.layoutCrosstab(600.0, List.of("Q1", "Q2", "Q3"));
+
+        layout.cellHeight(data.size(), 600.0);
+        double heightBefore = layout.getCellHeight();
+        layout.adjustHeight(data.size() * 5.0);
+        double heightAfter = layout.getCellHeight();
+
+        assertTrue(heightAfter >= heightBefore,
+                   "adjustHeight in CROSSTAB mode must not shrink cellHeight");
+    }
+
+    // ------------------------------------------------------------------ //
+    //  Helpers                                                             //
+    // ------------------------------------------------------------------ //
+
+    private static Relation buildSalesSchema() {
+        Relation schema = new Relation("sales");
+        schema.addChild(new Primitive("region"));
+        schema.addChild(new Primitive("quarter"));
+        schema.addChild(new Primitive("amount"));
+        return schema;
+    }
+
+    private static ArrayNode buildSalesData() {
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (String[] row : new String[][]{
+            {"North", "Q1", "100"}, {"North", "Q2", "200"},
+            {"South", "Q1", "150"}, {"South", "Q3", "300"}
+        }) {
+            ObjectNode n = JsonNodeFactory.instance.objectNode();
+            n.put("region", row[0]);
+            n.put("quarter", row[1]);
+            n.put("amount", row[2]);
+            data.add(n);
+        }
+        return data;
+    }
+
+    private Style mockModel(Relation schema) {
+        Style model = mock(Style.class);
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        for (SchemaNode child : schema.getChildren()) {
+            if (child instanceof Primitive p) {
+                PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+                when(model.layout(p)).thenReturn(pl);
+            }
+        }
+        when(model.layout(any(SchemaNode.class))).thenAnswer(inv -> {
+            SchemaNode n = inv.getArgument(0);
+            if (n instanceof Primitive p) return model.layout(p);
+            RelationStyle rs = TestLayouts.mockRelationStyle();
+            return new RelationLayout((Relation) n, rs);
+        });
+        when(model.getStylesheet()).thenReturn(null);
+        return model;
+    }
+
+    private RelationLayout buildMeasuredLayout(Relation schema, ArrayNode data) {
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        Style model = mockModel(schema);
+
+        RelationLayout layout = new RelationLayout(schema, relStyle);
+        layout.setSchemaPath(new SchemaPath("sales"));
+        layout.measure(data, n -> n, model);
+        layout.layout(600.0);
+        return layout;
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveBarStyleTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveBarStyleTest.java
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.LabelStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle.PrimitiveBarStyle;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+import javafx.geometry.Insets;
+
+/**
+ * Tests for Kramer-pmi: PrimitiveBarStyle and bar rendering dispatch.
+ */
+class PrimitiveBarStyleTest {
+
+    // ---- barFraction math ----
+
+    @Test
+    void barFractionNormalRange() {
+        double min = 0.0, max = 100.0, value = 25.0;
+        double fraction = barFraction(value, min, max);
+        assertEquals(0.25, fraction, 1e-9, "25/100 should give 0.25 fraction");
+    }
+
+    @Test
+    void barFractionAtMinIsZero() {
+        double min = 10.0, max = 50.0, value = 10.0;
+        double fraction = barFraction(value, min, max);
+        assertEquals(0.0, fraction, 1e-9, "value at min should give 0.0 fraction");
+    }
+
+    @Test
+    void barFractionAtMaxIsOne() {
+        double min = 10.0, max = 50.0, value = 50.0;
+        double fraction = barFraction(value, min, max);
+        assertEquals(1.0, fraction, 1e-9, "value at max should give 1.0 fraction");
+    }
+
+    @Test
+    void barFractionRangeZeroReturnsOne() {
+        // Guard: when min==max range is 0, barFraction must be 1.0 (full width)
+        double min = 42.0, max = 42.0, value = 42.0;
+        double fraction = barFraction(value, min, max);
+        assertEquals(1.0, fraction, 1e-9, "zero range must produce barFraction=1.0");
+    }
+
+    @Test
+    void barFractionMidRange() {
+        double min = 0.0, max = 200.0, value = 100.0;
+        double fraction = barFraction(value, min, max);
+        assertEquals(0.5, fraction, 1e-9, "midpoint should give 0.5 fraction");
+    }
+
+    // ---- PrimitiveBarStyle class structure ----
+
+    @Test
+    void primitiveBarStyleExistsAsStaticInnerClass() {
+        // Verify PrimitiveBarStyle is a public static inner class of PrimitiveStyle
+        Class<?> enclosing = PrimitiveBarStyle.class.getEnclosingClass();
+        assertNotNull(enclosing, "PrimitiveBarStyle must be an inner class");
+        assertEquals(PrimitiveStyle.class, enclosing,
+                     "PrimitiveBarStyle must be enclosed in PrimitiveStyle");
+        assertTrue(java.lang.reflect.Modifier.isStatic(PrimitiveBarStyle.class.getModifiers()),
+                   "PrimitiveBarStyle must be a static inner class");
+        assertTrue(java.lang.reflect.Modifier.isPublic(PrimitiveBarStyle.class.getModifiers()),
+                   "PrimitiveBarStyle must be public");
+    }
+
+    @Test
+    void primitiveBarStyleExtendsPrimitiveStyle() {
+        assertTrue(PrimitiveStyle.class.isAssignableFrom(PrimitiveBarStyle.class),
+                   "PrimitiveBarStyle must extend PrimitiveStyle");
+    }
+
+    // ---- getHeight returns single line height ----
+
+    @Test
+    void getHeightReturnsSingleLineHeight() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+        when(labelStyle.getHeight(anyDouble())).thenReturn(20.0);
+
+        PrimitiveBarStyle barStyle = new PrimitiveBarStyle(labelStyle, Insets.EMPTY, labelStyle);
+        // BAR height is single line: primitiveStyle.getHeight(1) == 20.0
+        double height = barStyle.getHeight(1000.0, 200.0);
+        assertEquals(20.0, height, 1e-9,
+                     "BAR height must be single line (primitiveStyle.getHeight(1))");
+    }
+
+    @Test
+    void getHeightIgnoresMaxAndJustifiedArguments() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight(anyDouble())).thenReturn(15.0);
+
+        PrimitiveBarStyle barStyle = new PrimitiveBarStyle(labelStyle, Insets.EMPTY, labelStyle);
+        // height must be the same regardless of maxWidth / justified
+        double h1 = barStyle.getHeight(100.0, 50.0);
+        double h2 = barStyle.getHeight(9999.0, 1.0);
+        assertEquals(h1, h2, 1e-9,
+                     "BAR height must not depend on maxWidth or justified arguments");
+    }
+
+    // ---- renderMode dispatch in buildControl() ----
+
+    @Test
+    void buildControlDispatchesToBarStyleWhenRenderModeBAR() {
+        // measure() with all-numeric data → renderMode=BAR
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("score"), primStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 5; i++) {
+            data.add(i * 10.0);
+        }
+
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BAR, layout.getRenderMode(),
+                     "Precondition: renderMode must be BAR for all-numeric data");
+    }
+
+    @Test
+    void buildControlUsesTextStyleWhenRenderModeTEXT() {
+        // measure() with text data → renderMode=TEXT
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("name"), primStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("Alice");
+        data.add("Bob");
+
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.TEXT, layout.getRenderMode(),
+                     "Precondition: renderMode must be TEXT for text data");
+    }
+
+    @Test
+    void primitiveBarStyleWidthReturnsZero() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight(anyDouble())).thenReturn(20.0);
+
+        PrimitiveBarStyle barStyle = new PrimitiveBarStyle(labelStyle, Insets.EMPTY, labelStyle);
+        // width() is not meaningful for bars — must not throw, may return 0
+        double w = barStyle.width(JsonNodeFactory.instance.numberNode(42.0));
+        assertEquals(0.0, w, 1e-9, "PrimitiveBarStyle.width() must return 0.0");
+    }
+
+    // ---- helper mirroring the production barFraction logic ----
+
+    private static double barFraction(double value, double min, double max) {
+        double range = max - min;
+        if (range == 0.0) {
+            return 1.0;
+        }
+        return (value - min) / range;
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SnapshotDecisionTreeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SnapshotDecisionTreeTest.java
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * TDD tests for snapshotDecisionTree() recursive composition (Kramer-4s4).
+ */
+class SnapshotDecisionTreeTest {
+
+    // -----------------------------------------------------------------------
+    // 1. snapshotLayoutResult() on PrimitiveLayout — no side effects
+    // -----------------------------------------------------------------------
+
+    @Test
+    void primitiveSnapshotLayoutResultReturnsCurrentFieldsWithoutSideEffects() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("name"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("Alice");
+        data.add("Bob");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+        layout.layout(500);
+        layout.compress(200);
+
+        // Capture state before snapshot
+        double justifiedBefore = layout.getJustifiedWidth();
+        boolean uvhBefore = layout.isUseVerticalHeader();
+
+        LayoutResult result = layout.snapshotLayoutResult();
+
+        // Fields after snapshot must be unchanged (no clear() was called)
+        assertEquals(justifiedBefore, layout.getJustifiedWidth(),
+                     "snapshotLayoutResult must not alter justifiedWidth");
+        assertEquals(uvhBefore, layout.isUseVerticalHeader(),
+                     "snapshotLayoutResult must not alter useVerticalHeader");
+
+        // Result must encode actual field values
+        assertNotNull(result);
+        assertFalse(result.useTable(), "primitives never use table mode");
+        assertEquals(justifiedBefore, result.constrainedColumnWidth(),
+                     "constrainedColumnWidth must match justifiedWidth");
+        assertEquals(uvhBefore, result.useVerticalHeader(),
+                     "useVerticalHeader must match field value");
+        assertTrue(result.childResults().isEmpty(), "primitives have no child results");
+    }
+
+    @Test
+    void primitiveSnapshotLayoutResultPreservesVerticalHeaderFlag() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        // narrow threshold so nestTableColumn sets useVerticalHeader=true
+        when(style.getVerticalHeaderThreshold()).thenReturn(0.1);
+
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("label"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("A");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+        layout.layout(500);
+        layout.compress(300);
+
+        // Manually set useVerticalHeader (as nestTableColumn would)
+        layout.setUseVerticalHeader(true);
+        assertTrue(layout.isUseVerticalHeader());
+
+        LayoutResult result = layout.snapshotLayoutResult();
+
+        assertTrue(result.useVerticalHeader(),
+                   "snapshotLayoutResult must capture useVerticalHeader=true");
+        // Verify no side-effect reset
+        assertTrue(layout.isUseVerticalHeader(),
+                   "useVerticalHeader must survive snapshotLayoutResult call");
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. snapshotDecisionTree on PrimitiveLayout — leaf node
+    // -----------------------------------------------------------------------
+
+    @Test
+    void primitiveSnapshotDecisionTreeProducesLeafNode() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("score"), primStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("42");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+        layout.layout(300);
+        layout.compress(300);
+
+        SchemaPath path = new SchemaPath("root", "score");
+        layout.buildPaths(path, model);
+
+        LayoutDecisionNode node = layout.snapshotDecisionTree();
+
+        assertNotNull(node);
+        assertEquals(path, node.path());
+        assertEquals("score", node.fieldName());
+        assertTrue(node.childNodes().isEmpty(), "leaf node has no children");
+        assertTrue(node.columnSetSnapshots().isEmpty(), "primitives have no column sets");
+        assertNotNull(node.layoutResult());
+        assertFalse(node.layoutResult().useTable());
+    }
+
+    @Test
+    void primitiveSnapshotDecisionTreeFieldNameMatchesPathLeaf() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("myField"), primStyle);
+
+        Style model = mock(Style.class);
+        layout.measure(JsonNodeFactory.instance.arrayNode(), n -> n, model);
+
+        SchemaPath path = new SchemaPath("root", "child", "myField");
+        layout.buildPaths(path, model);
+
+        LayoutDecisionNode node = layout.snapshotDecisionTree();
+
+        assertEquals("myField", node.fieldName());
+        assertEquals(path.leaf(), node.fieldName());
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. snapshotDecisionTree on RelationLayout — recursive tree
+    // -----------------------------------------------------------------------
+
+    @Test
+    void relationSnapshotDecisionTreeProducesTreeWithChildNodes() {
+        PrimitiveLayout p1 = TestLayouts.makePrimitive("age", 50);
+        PrimitiveLayout p2 = TestLayouts.makePrimitive("name", 80);
+
+        RelationLayout relation = TestLayouts.makeRelation("person", 10.0, 1, p1, p2);
+        relation.columnWidth = 200;
+        relation.justifiedWidth = 200;
+
+        SchemaPath rootPath = new SchemaPath("person");
+        // Set paths manually (bypassing model.layout since children are pre-built)
+        relation.setSchemaPath(rootPath);
+        p1.buildPaths(rootPath.child("age"), null);
+        p2.buildPaths(rootPath.child("name"), null);
+
+        LayoutDecisionNode node = relation.snapshotDecisionTree();
+
+        assertNotNull(node);
+        assertEquals(rootPath, node.path());
+        assertEquals("person", node.fieldName());
+        assertEquals(2, node.childNodes().size(), "must have one child per primitive child");
+    }
+
+    @Test
+    void relationSnapshotDecisionTreeChildrenMatchSchema() {
+        PrimitiveLayout p1 = TestLayouts.makePrimitive("firstName", 60);
+        PrimitiveLayout p2 = TestLayouts.makePrimitive("lastName", 70);
+
+        RelationLayout relation = TestLayouts.makeRelation("name", 0.0, 1, p1, p2);
+        relation.columnWidth = 200;
+        relation.justifiedWidth = 200;
+
+        SchemaPath root = new SchemaPath("name");
+        relation.setSchemaPath(root);
+        p1.buildPaths(root.child("firstName"), null);
+        p2.buildPaths(root.child("lastName"), null);
+
+        LayoutDecisionNode node = relation.snapshotDecisionTree();
+
+        List<LayoutDecisionNode> children = node.childNodes();
+        assertEquals(2, children.size());
+
+        var childFields = children.stream().map(LayoutDecisionNode::fieldName).toList();
+        assertTrue(childFields.contains("firstName"), "child 'firstName' must be present");
+        assertTrue(childFields.contains("lastName"), "child 'lastName' must be present");
+    }
+
+    @Test
+    void relationSnapshotDecisionTreeColumnSetSnapshotsFromColumnSets() {
+        PrimitiveLayout p1 = TestLayouts.makePrimitive("x", 50);
+        PrimitiveLayout p2 = TestLayouts.makePrimitive("y", 50);
+
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        Relation schema = new Relation("point");
+        schema.addChild(new Primitive("x"));
+        schema.addChild(new Primitive("y"));
+
+        RelationLayout relation = new RelationLayout(schema, relStyle);
+        relation.children.clear();
+        relation.children.add(p1);
+        relation.children.add(p2);
+        relation.columnWidth = 200;
+        relation.labelWidth = 0;
+        relation.averageChildCardinality = 1;
+        relation.maxCardinality = 1;
+
+        // Run compress to populate columnSets
+        relation.compress(200);
+
+        SchemaPath root = new SchemaPath("point");
+        relation.setSchemaPath(root);
+        p1.buildPaths(root.child("x"), null);
+        p2.buildPaths(root.child("y"), null);
+
+        LayoutDecisionNode node = relation.snapshotDecisionTree();
+
+        assertNotNull(node);
+        assertNotNull(node.columnSetSnapshots());
+        // When columnSets is non-empty, snapshots must be non-empty
+        if (!relation.columnSets.isEmpty()) {
+            assertFalse(node.columnSetSnapshots().isEmpty(),
+                        "columnSetSnapshots must reflect columnSets after compress");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. snapshotDecisionTree does not cause side effects (no clear())
+    // -----------------------------------------------------------------------
+
+    @Test
+    void snapshotDecisionTreeDoesNotAlterPrimitiveState() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("val"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("test");
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+        layout.layout(400);
+        layout.compress(400);
+        layout.setUseVerticalHeader(true);
+
+        double jwBefore = layout.getJustifiedWidth();
+        boolean uvhBefore = layout.isUseVerticalHeader();
+
+        SchemaPath path = new SchemaPath("val");
+        layout.buildPaths(path, model);
+        layout.snapshotDecisionTree();
+
+        assertEquals(jwBefore, layout.getJustifiedWidth(),
+                     "snapshotDecisionTree must not alter justifiedWidth");
+        assertEquals(uvhBefore, layout.isUseVerticalHeader(),
+                     "snapshotDecisionTree must not alter useVerticalHeader");
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-011** (Kramer-4s4): `snapshotDecisionTree()` recursive composition. Fixed `PrimitiveLayout.snapshotLayoutResult()` (side-effect-free). Fixed `RelationLayout.snapshotLayoutResult()` to use it.
- **RDR-015** (Kramer-pmi): `PrimitiveBarStyle` — bar rendering with `barFraction` guard. `buildControl()` dispatches on `renderMode`.
- **RDR-015** (Kramer-7vl): `CrosstabHeader`/`CrosstabRow`/`CrosstabCell` + `layoutCrosstab()`. Header outside VirtualFlow. CROSSTAB branches in `adjustHeight`/`distributeExtraHeight`. Empty `valueField` degrades to TABLE.

## Test plan
- [x] 421 tests (34 new, 2 pre-existing Mockito errors in LayoutStylesheetWiringTest)
- [x] snapshotDecisionTree: 8 tests (side-effect-free, recursive, column snapshots)
- [x] PrimitiveBarStyle: 12 tests (barFraction math, dispatch, height, zero-range guard)
- [x] Crosstab: 14 tests (header/row/cell, layoutCrosstab, CROSSTAB mode, empty degrade, adjustHeight)

Ref: Kramer-4s4, Kramer-pmi, Kramer-7vl