### PR TITLE
Wave 2 Final: decision tree API, Jackson serialization, BADGE mode — closes both epics

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -339,6 +339,23 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         return layout != null && layout.isConverged();
     }
 
+    /**
+     * Returns the current layout decision tree as an {@link Optional}.
+     *
+     * <p>Returns {@link Optional#empty()} if no layout has been measured yet,
+     * or if the layout has not yet converged (i.e., primitive widths are still
+     * stabilizing across resize cycles).
+     *
+     * <p>When present, the returned tree reflects all four layout phases
+     * (measure, layout, compress, height) at the time of the last resize.
+     *
+     * @return the decision tree rooted at the top-level schema node, or empty
+     */
+    public Optional<LayoutDecisionNode> getLayoutDecisionTree() {
+        if (layout == null || !layout.isConverged()) return Optional.empty();
+        return Optional.of(layout.snapshotDecisionTree());
+    }
+
     private void autoLayout(JsonNode zeeData, double width) {
         if (width < 10.0) {
             return;

--- a/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSet.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/ColumnSet.java
@@ -20,6 +20,7 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -42,6 +43,11 @@ public class ColumnSet {
     public void add(SchemaNodeLayout node) {
         columns.get(0)
                .add(node);
+    }
+
+    /** Package-private: append a pre-built Column. Used by compress() and tests. */
+    void addColumn(Column column) {
+        columns.add(column);
     }
 
     public void adjustHeight(double delta) {
@@ -97,7 +103,7 @@ public class ColumnSet {
     }
 
     public List<Column> getColumns() {
-        return columns;
+        return Collections.unmodifiableList(columns);
     }
 
     public ColumnSetSnapshot toSnapshot(double height) {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/CompressResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/CompressResult.java
@@ -3,21 +3,14 @@ package com.chiralbehaviors.layout;
 
 import java.util.List;
 
-/**
- * Immutable result of the compress phase. Captures justified geometry and
- * column set assignments for outline mode. In outline mode, cellHeight is set
- * here; in table mode it is set in HeightResult instead.
- *
- * @see SchemaNodeLayout#compress(double)
- */
 public record CompressResult(
     double justifiedWidth,
-    List<ColumnSet> columnSets,
+    List<ColumnSetSnapshot> columnSetSnapshots,
     double cellHeight,
     List<CompressResult> childResults
 ) {
     public CompressResult {
-        columnSets = columnSets == null ? List.of() : List.copyOf(columnSets);
+        columnSetSnapshots = columnSetSnapshots == null ? List.of() : List.copyOf(columnSetSnapshots);
         childResults = childResults == null ? List.of() : List.copyOf(childResults);
     }
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutDecisionNode.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutDecisionNode.java
@@ -2,16 +2,8 @@
 package com.chiralbehaviors.layout;
 
 import java.util.List;
+import java.util.Objects;
 
-/**
- * Unified decision tree node that captures all four layout phase results for a
- * single schema node. Combines measure, layout, compress, and height results
- * alongside the column-set snapshots and child sub-trees produced during layout.
- *
- * <p>{@code fieldName} mirrors {@code path.leaf()} and is retained as a
- * convenience so renderers can call {@code data.get(fieldName)} without
- * re-deriving the leaf segment on every access.
- */
 public record LayoutDecisionNode(
     SchemaPath path,
     String fieldName,
@@ -23,6 +15,10 @@ public record LayoutDecisionNode(
     List<LayoutDecisionNode> childNodes
 ) {
     public LayoutDecisionNode {
+        Objects.requireNonNull(path, "path must not be null");
+        Objects.requireNonNull(fieldName, "fieldName must not be null");
+        assert fieldName.equals(path.leaf()) : "fieldName must match path.leaf(); got fieldName='" + fieldName + "', path.leaf()='" + path.leaf() + "'";
+        // measureResult/layoutResult/compressResult/heightResult may be partially populated (nullable)
         childNodes = childNodes == null ? List.of() : List.copyOf(childNodes);
         columnSetSnapshots = columnSetSnapshots == null ? List.of() : List.copyOf(columnSetSnapshots);
     }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
@@ -4,6 +4,7 @@ package com.chiralbehaviors.layout;
 import java.util.List;
 import java.util.function.Function;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
@@ -29,5 +30,11 @@ public record MeasureResult(
 ) {
     public MeasureResult {
         childResults = childResults == null ? List.of() : List.copyOf(childResults);
+    }
+
+    @JsonIgnore
+    @Override
+    public Function<JsonNode, JsonNode> extractor() {
+        return extractor;
     }
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PivotStats.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PivotStats.java
@@ -18,5 +18,6 @@ import java.util.List;
 public record PivotStats(List<String> pivotValues, int pivotCount) {
     public PivotStats {
         pivotValues = List.copyOf(pivotValues);
+        assert pivotCount == pivotValues.size() : "pivotCount mismatch";
     }
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -59,6 +59,10 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     /** Sorted distinct string values for BADGE CSS class assignment; null when not BADGE. */
     private List<String>           badgeValues               = null;
 
+    // Cached style instances — re-used across buildControl() calls to avoid per-call allocation
+    private PrimitiveBarStyle      cachedBarStyle;
+    private PrimitiveBadgeStyle    cachedBadgeStyle;
+
     // Convergence detection state (Kramer-16k)
     private MeasureResult          frozenResult;
     private long                   frozenStylesheetVersion   = -1;
@@ -103,16 +107,20 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             return new PrimitiveList(this, parentTraversal);
         }
         if (renderMode == PrimitiveRenderMode.BAR) {
-            PrimitiveBarStyle barStyle = new PrimitiveBarStyle(style.getLabelStyle(),
-                                                               javafx.geometry.Insets.EMPTY,
-                                                               style.getLabelStyle());
-            return barStyle.build(parentTraversal, this);
+            if (cachedBarStyle == null) {
+                cachedBarStyle = new PrimitiveBarStyle(style.getLabelStyle(),
+                                                       javafx.geometry.Insets.EMPTY,
+                                                       style.getLabelStyle());
+            }
+            return cachedBarStyle.build(parentTraversal, this);
         }
         if (renderMode == PrimitiveRenderMode.BADGE) {
-            PrimitiveBadgeStyle badgeStyle = new PrimitiveBadgeStyle(style.getLabelStyle(),
-                                                                     javafx.geometry.Insets.EMPTY,
-                                                                     style.getLabelStyle());
-            return badgeStyle.build(parentTraversal, this);
+            if (cachedBadgeStyle == null) {
+                cachedBadgeStyle = new PrimitiveBadgeStyle(style.getLabelStyle(),
+                                                           javafx.geometry.Insets.EMPTY,
+                                                           style.getLabelStyle());
+            }
+            return cachedBadgeStyle.build(parentTraversal, this);
         }
         return buildCell(parentTraversal);
     }
@@ -338,6 +346,8 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
         // Badge auto-detection: when renderMode is still TEXT after numeric check,
         // count distinct string values and promote to BADGE if below cardinality threshold.
+        // Two-pass approach is intentional: numeric width computation (pass 1) is independent
+        // of badge cardinality detection (pass 2), so merging them would not reduce complexity.
         badgeValues = null;
         if (renderMode == PrimitiveRenderMode.TEXT) {
             int badgeThreshold = (stylesheet != null && path != null)
@@ -590,6 +600,9 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         // isVariableLength lifecycle is now explicit in MeasureResult (RDR-009 SC-6).
         // useVerticalHeader resets because nestTableColumn() runs after clear().
         useVerticalHeader = false;
+        // Invalidate cached style objects so they are rebuilt after a layout cycle.
+        cachedBarStyle = null;
+        cachedBadgeStyle = null;
     }
 
     protected double width(JsonNode row) {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -22,6 +22,7 @@ import static com.chiralbehaviors.layout.style.Style.snap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.function.Function;
 
 import com.chiralbehaviors.layout.cell.LayoutCell;
@@ -30,6 +31,7 @@ import com.chiralbehaviors.layout.cell.control.FocusTraversal;
 import com.chiralbehaviors.layout.schema.Primitive;
 import com.chiralbehaviors.layout.style.PrimitiveStyle;
 import com.chiralbehaviors.layout.style.PrimitiveStyle.PrimitiveBarStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle.PrimitiveBadgeStyle;
 import com.chiralbehaviors.layout.style.Style;
 import com.chiralbehaviors.layout.table.ColumnHeader;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -54,6 +56,8 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     private boolean                useVerticalHeader         = false;
     private MeasureResult          measureResult;
     private PrimitiveRenderMode    renderMode                = PrimitiveRenderMode.TEXT;
+    /** Sorted distinct string values for BADGE CSS class assignment; null when not BADGE. */
+    private List<String>           badgeValues               = null;
 
     // Convergence detection state (Kramer-16k)
     private MeasureResult          frozenResult;
@@ -103,6 +107,12 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
                                                                javafx.geometry.Insets.EMPTY,
                                                                style.getLabelStyle());
             return barStyle.build(parentTraversal, this);
+        }
+        if (renderMode == PrimitiveRenderMode.BADGE) {
+            PrimitiveBadgeStyle badgeStyle = new PrimitiveBadgeStyle(style.getLabelStyle(),
+                                                                     javafx.geometry.Insets.EMPTY,
+                                                                     style.getLabelStyle());
+            return badgeStyle.build(parentTraversal, this);
         }
         return buildCell(parentTraversal);
     }
@@ -326,6 +336,29 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             };
         }
 
+        // Badge auto-detection: when renderMode is still TEXT after numeric check,
+        // count distinct string values and promote to BADGE if below cardinality threshold.
+        badgeValues = null;
+        if (renderMode == PrimitiveRenderMode.TEXT) {
+            int badgeThreshold = (stylesheet != null && path != null)
+                                 ? stylesheet.getInt(path, "badge-cardinality-threshold", 10)
+                                 : 10;
+            TreeSet<String> distinct = new TreeSet<>();
+            for (JsonNode prim : normalized) {
+                if (prim.isArray()) {
+                    for (JsonNode row : prim) {
+                        distinct.add(row.asText());
+                    }
+                } else if (!prim.isNull() && !prim.isMissingNode()) {
+                    distinct.add(prim.asText());
+                }
+            }
+            if (!distinct.isEmpty() && distinct.size() < badgeThreshold) {
+                renderMode = PrimitiveRenderMode.BADGE;
+                badgeValues = List.copyOf(distinct); // TreeSet is already sorted
+            }
+        }
+
         // RF-3: p90 replaces averageWidth ONLY in isVariableLength==true branch,
         // and only when we have sufficient samples. Fixed-length always uses maxWidth.
         double effectiveWidth;
@@ -415,6 +448,26 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     public PrimitiveRenderMode getRenderMode() {
         return renderMode;
+    }
+
+    /**
+     * Returns the sorted list of distinct string values used for BADGE CSS class assignment,
+     * or {@code null} if the current render mode is not BADGE.
+     */
+    public List<String> getBadgeValues() {
+        return badgeValues;
+    }
+
+    /**
+     * Returns the sorted index of {@code value} in the badge value set, or {@code -1}
+     * if the value is not present (unknown value — TEXT fallback applies).
+     */
+    public int badgeIndex(String value) {
+        if (badgeValues == null || value == null) {
+            return -1;
+        }
+        int idx = Collections.binarySearch(badgeValues, value);
+        return idx >= 0 ? idx : -1;
     }
 
     /** Returns true when a frozen (converged) result is cached and valid. */

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -479,8 +479,11 @@ public final class RelationLayout extends SchemaNodeLayout {
 
     public LayoutResult computeLayout(double width) {
         layout(width);
+        // primitiveMode is not applicable to relation nodes; TEXT is a sentinel value
         return new LayoutResult(
-            useTable ? RelationRenderMode.TABLE : RelationRenderMode.OUTLINE,
+            useCrosstab ? RelationRenderMode.CROSSTAB
+                        : useTable ? RelationRenderMode.TABLE
+                        : RelationRenderMode.OUTLINE,
             PrimitiveRenderMode.TEXT,
             false,
             tableColumnWidth,
@@ -505,17 +508,13 @@ public final class RelationLayout extends SchemaNodeLayout {
     public LayoutResult snapshotLayoutResult() {
         return new LayoutResult(
             useTable ? RelationRenderMode.TABLE : RelationRenderMode.OUTLINE,
-            PrimitiveRenderMode.TEXT,
-            false,
+            PrimitiveRenderMode.TEXT,  // primitiveMode is not applicable to relations; TEXT is a sentinel
+            false,                     // useVerticalHeader: not applicable at relation level
             tableColumnWidth,
             columnHeaderIndentation,
             columnWidth,
             children.stream()
-                .map(c -> {
-                    if (c instanceof PrimitiveLayout pl) return pl.snapshotLayoutResult();
-                    if (c instanceof RelationLayout rl) return rl.snapshotLayoutResult();
-                    return null;
-                })
+                .map(SchemaNodeLayout::snapshotLayoutResult)
                 .toList()
         );
     }
@@ -534,7 +533,7 @@ public final class RelationLayout extends SchemaNodeLayout {
             .toList();
 
         CompressResult compressSnap = new CompressResult(
-            justifiedWidth, List.copyOf(columnSets), cellHeight, List.of());
+            justifiedWidth, colSetSnaps, cellHeight, List.of());
 
         HeightResult heightSnap = new HeightResult(
             height, cellHeight, resolvedCardinality, columnHeaderHeight, List.of());
@@ -557,9 +556,12 @@ public final class RelationLayout extends SchemaNodeLayout {
 
     public CompressResult computeCompress(double justified) {
         compress(justified);
+        List<ColumnSetSnapshot> snaps = columnSets.stream()
+            .map(cs -> cs.toSnapshot(cellHeight))
+            .toList();
         return new CompressResult(
             justifiedWidth,
-            List.copyOf(columnSets),
+            snaps,
             cellHeight,
             children.stream()
                 .map(c -> {
@@ -1023,8 +1025,7 @@ public final class RelationLayout extends SchemaNodeLayout {
 
         // Distribute remaining width equally across pivot columns
         double remaining = availableWidth - rowHeaderWidth;
-        crosstabColumnWidth = pivotValues.isEmpty() ? 0.0
-                                                     : Style.snap(remaining / pivotValues.size());
+        crosstabColumnWidth = Style.snap(remaining / pivotValues.size());
 
         // Overall width = rowHeader + all pivot columns
         double totalWidth = Style.snap(rowHeaderWidth + crosstabColumnWidth * pivotValues.size());

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SchemaNodeLayout.java
@@ -252,6 +252,15 @@ public abstract sealed class SchemaNodeLayout permits PrimitiveLayout, RelationL
      */
     public abstract LayoutDecisionNode snapshotDecisionTree();
 
+    /**
+     * Snapshot the layout result from the current in-memory state without
+     * triggering any layout side effects (no {@code clear()} calls).
+     * Must be called after {@code layout()} has run.
+     *
+     * @return a point-in-time immutable snapshot of the layout result
+     */
+    public abstract LayoutResult snapshotLayoutResult();
+
     public SchemaPath getSchemaPath() {
         return schemaPath;
     }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
@@ -251,6 +251,78 @@ abstract public class PrimitiveStyle extends NodeStyle {
 
     }
 
+    public static class PrimitiveBadgeStyle extends PrimitiveStyle {
+
+        public static final String PRIMITIVE_BADGE_CLASS = "primitive-badge";
+
+        private final LabelStyle primitiveStyle;
+
+        public PrimitiveBadgeStyle(LabelStyle labelStyle, Insets listInsets,
+                                   LabelStyle primitiveStyle) {
+            super(labelStyle, listInsets);
+            this.primitiveStyle = primitiveStyle;
+        }
+
+        @Override
+        public LayoutCell<?> build(FocusTraversal<?> pt, PrimitiveLayout p) {
+            Label label = new Label();
+            label.getStyleClass().clear();
+            label.setMinSize(p.getJustifiedWidth(), p.getCellHeight());
+            label.setPrefSize(p.getJustifiedWidth(), p.getCellHeight());
+            label.setMaxSize(p.getJustifiedWidth(), p.getCellHeight());
+            label.focusedProperty()
+                 .addListener((javafx.beans.InvalidationListener) property -> {
+                     if (label.isFocused()) {
+                         pt.setCurrent();
+                     }
+                 });
+
+            return new PrimitiveLayoutCell<Region>(p, PRIMITIVE_BADGE_CLASS, pt) {
+                /** Track the last assigned badge CSS class to remove it on update. */
+                private String lastBadgeClass = null;
+
+                @Override
+                public Label getNode() {
+                    return label;
+                }
+
+                @Override
+                public boolean isReusable() {
+                    return true;
+                }
+
+                @Override
+                public void updateItem(com.fasterxml.jackson.databind.JsonNode item) {
+                    super.updateItem(item);
+                    // Remove previous badge index class before applying new one
+                    if (lastBadgeClass != null) {
+                        label.getStyleClass().remove(lastBadgeClass);
+                        lastBadgeClass = null;
+                    }
+                    String text = com.chiralbehaviors.layout.schema.SchemaNode.asText(item);
+                    label.setText(text);
+                    int idx = p.badgeIndex(text);
+                    if (idx >= 0) {
+                        lastBadgeClass = "badge-" + idx;
+                        label.getStyleClass().add(lastBadgeClass);
+                    }
+                }
+            };
+        }
+
+        @Override
+        public double getHeight(double maxWidth, double justified) {
+            return primitiveStyle.getHeight(1);
+        }
+
+        @Override
+        public double width(com.fasterxml.jackson.databind.JsonNode row) {
+            return primitiveStyle.width(Style.toString(row))
+                   + primitiveStyle.getHorizontalInset();
+        }
+
+    }
+
     private final Insets listInsets;
     private final double minValueWidth            = 30;
     private final double maxTablePrimitiveWidth   = 350.0;

--- a/kramer/src/main/resources/com/chiralbehaviors/layout/default.css
+++ b/kramer/src/main/resources/com/chiralbehaviors/layout/default.css
@@ -23,3 +23,8 @@
     -fx-background-insets: -0.2, 1, -1.4, 3;
     -fx-background-radius: 3, 2, 4, 0;
 }
+
+.crosstab-header { /* inherits from .kramer-container */ }
+.crosstab-header-label { -fx-font-weight: bold; }
+.crosstab-row { /* inherits from .kramer-container */ }
+.crosstab-cell { /* inherits from .kramer-container */ }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/AutoLayoutDecisionTreeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/AutoLayoutDecisionTreeTest.java
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * TDD tests for AutoLayout.getLayoutDecisionTree() (Kramer-73j).
+ */
+class AutoLayoutDecisionTreeTest {
+
+    // -----------------------------------------------------------------------
+    // 1. Returns Optional.empty() when layout field is null (no measure yet)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void returnsEmptyWhenLayoutIsNull() {
+        // Directly test the SchemaNodeLayout-level guard via a RelationLayout
+        // that has never been measured — isConverged() returns false, and
+        // snapshotDecisionTree() is therefore never called.
+        // We verify via a thin wrapper that matches AutoLayout's logic.
+        SchemaNodeLayout nullLayout = null;
+
+        // Emulate AutoLayout.getLayoutDecisionTree() logic
+        Optional<LayoutDecisionNode> result = getLayoutDecisionTree(nullLayout);
+
+        assertTrue(result.isEmpty(), "Must return Optional.empty() when layout is null");
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Returns Optional.empty() when layout is not converged
+    // -----------------------------------------------------------------------
+
+    @Test
+    void returnsEmptyWhenNotConverged() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("field"), style);
+        // Not yet measured — not converged
+        assertFalse(layout.isConverged(), "precondition: layout is not converged");
+
+        Optional<LayoutDecisionNode> result = getLayoutDecisionTree(layout);
+
+        assertTrue(result.isEmpty(), "Must return Optional.empty() when layout is not converged");
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Returns present Optional when layout is converged
+    // -----------------------------------------------------------------------
+
+    @Test
+    void returnsPresentWhenConverged() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        RelationStyle relStyle   = TestLayouts.mockRelationStyle();
+
+        Primitive p = new Primitive("score");
+        Relation  r = new Relation("root");
+        r.addChild(p);
+
+        PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+        SchemaPath path = new SchemaPath("root", "score");
+        pl.setSchemaPath(path);
+
+        // Force convergence via repeated measure with fast-converge settings
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 2);
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 6; i++) {
+            data.add("value" + i);
+        }
+        for (int i = 0; i < 2; i++) {
+            pl.measure(data, n -> n, model);
+        }
+        assertTrue(pl.isConverged(), "precondition: layout must be converged");
+
+        pl.buildPaths(path, model);
+
+        Optional<LayoutDecisionNode> result = getLayoutDecisionTree(pl);
+
+        assertTrue(result.isPresent(), "Must return present Optional when layout is converged");
+        assertNotNull(result.get());
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. Returned node has expected path when converged
+    // -----------------------------------------------------------------------
+
+    @Test
+    void returnedNodeHasCorrectFieldName() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+
+        Primitive p = new Primitive("amount");
+        PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+        SchemaPath path = new SchemaPath("root", "amount");
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 2);
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 6; i++) {
+            data.add("item" + i);
+        }
+        for (int i = 0; i < 2; i++) {
+            pl.measure(data, n -> n, model);
+        }
+        pl.buildPaths(path, model);
+
+        Optional<LayoutDecisionNode> result = getLayoutDecisionTree(pl);
+
+        assertTrue(result.isPresent());
+        assertEquals("amount", result.get().fieldName());
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: mirrors AutoLayout.getLayoutDecisionTree() logic
+    // -----------------------------------------------------------------------
+
+    private static Optional<LayoutDecisionNode> getLayoutDecisionTree(SchemaNodeLayout layout) {
+        if (layout == null || !layout.isConverged()) return Optional.empty();
+        return Optional.of(layout.snapshotDecisionTree());
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/AutoLayoutDecisionTreeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/AutoLayoutDecisionTreeTest.java
@@ -17,6 +17,10 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
 /**
  * TDD tests for AutoLayout.getLayoutDecisionTree() (Kramer-73j).
+ *
+ * Tests guard logic directly (AutoLayout requires JavaFX toolkit for full integration test).
+ * The helper method {@link #getLayoutDecisionTree} mirrors AutoLayout's guard logic so that
+ * the null / unconverged / converged state transitions can be exercised without a live scene.
  */
 class AutoLayoutDecisionTreeTest {
 

--- a/kramer/src/test/java/com/chiralbehaviors/layout/BadgeRenderModeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/BadgeRenderModeTest.java
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.LabelStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for Kramer-bdv: BADGE rendering mode auto-detection and CSS class assignment.
+ */
+class BadgeRenderModeTest {
+
+    // ---- Auto-detection: cardinality threshold ----
+
+    /**
+     * Low-cardinality text field (< 10 distinct values) must be auto-detected as BADGE.
+     */
+    @Test
+    void lowCardinalityTextAutoDetectedAsBadge() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("status"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // 5 distinct values, repeated to create a realistic sample
+        String[] values = { "active", "inactive", "pending", "deleted", "archived" };
+        for (int i = 0; i < 25; i++) {
+            data.add(values[i % values.length]);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BADGE, layout.getRenderMode(),
+                     "Low-cardinality field (5 distinct) must be auto-detected as BADGE");
+    }
+
+    /**
+     * High-cardinality text field (>= 10 distinct values) must stay TEXT.
+     */
+    @Test
+    void highCardinalityTextStaysText() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("country"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // 12 distinct values — at or above threshold
+        String[] values = {
+            "USA", "UK", "France", "Germany", "Japan",
+            "Canada", "Australia", "Brazil", "India", "China",
+            "Mexico", "Spain"
+        };
+        for (String v : values) {
+            data.add(v);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.TEXT, layout.getRenderMode(),
+                     "High-cardinality field (12 distinct) must remain TEXT");
+    }
+
+    /**
+     * Exactly 9 distinct values (< 10 default threshold) must be auto-detected as BADGE.
+     */
+    @Test
+    void exactlyNineDistinctValuesBecomesBadge() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("priority"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 9; i++) {
+            data.add("p" + i);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BADGE, layout.getRenderMode(),
+                     "Exactly 9 distinct values (< threshold 10) must be BADGE");
+    }
+
+    /**
+     * Exactly 10 distinct values (== threshold) must stay TEXT (threshold is exclusive).
+     */
+    @Test
+    void exactlyTenDistinctValuesStaysText() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("category"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 10; i++) {
+            data.add("cat" + i);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.TEXT, layout.getRenderMode(),
+                     "Exactly 10 distinct values (== threshold) must remain TEXT");
+    }
+
+    /**
+     * All-numeric fields must not be promoted to BADGE — BAR takes precedence.
+     */
+    @Test
+    void numericFieldStaysBarNotBadge() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("score"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // Only 3 distinct numeric values — would qualify for BADGE cardinality-wise,
+        // but numeric auto-detection must take priority and yield BAR.
+        data.add(1.0);
+        data.add(2.0);
+        data.add(3.0);
+        data.add(1.0);
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BAR, layout.getRenderMode(),
+                     "All-numeric field must remain BAR even if cardinality is low");
+    }
+
+    // ---- Stylesheet threshold override ----
+
+    /**
+     * badge-cardinality-threshold stylesheet property overrides the default of 10.
+     * Setting threshold=3 means a field with 4 distinct values must stay TEXT.
+     */
+    @Test
+    void badgeCardinalityThresholdHonored() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("status"), style);
+
+        // Build a mock stylesheet that returns threshold=3 for badge-cardinality-threshold
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("status");
+        sheet.setOverride(path, "badge-cardinality-threshold", 3);
+
+        layout.buildPaths(path, null);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // 4 distinct values — below default (10) but at/above custom threshold (3)
+        data.add("a");
+        data.add("b");
+        data.add("c");
+        data.add("d");
+
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.TEXT, layout.getRenderMode(),
+                     "4 distinct values >= threshold 3 must remain TEXT");
+    }
+
+    /**
+     * badge-cardinality-threshold=15 makes a 12-distinct-value field become BADGE.
+     */
+    @Test
+    void highThresholdPromotsLargerCardinality() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("region"), style);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("region");
+        sheet.setOverride(path, "badge-cardinality-threshold", 15);
+
+        layout.buildPaths(path, null);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 12; i++) {
+            data.add("region-" + i);
+        }
+
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BADGE, layout.getRenderMode(),
+                     "12 distinct values < threshold 15 must become BADGE");
+    }
+
+    // ---- Explicit render-mode=badge stylesheet override ----
+
+    /**
+     * Explicit render-mode=badge in stylesheet forces BADGE even for numeric data.
+     */
+    @Test
+    void explicitRenderModeBadgeOverridesNumericAutoDetection() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("code"), style);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("code");
+        sheet.setOverride(path, "render-mode", "badge");
+
+        layout.buildPaths(path, null);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // Numeric data — would normally be BAR, but explicit override wins
+        data.add(1.0);
+        data.add(2.0);
+        data.add(3.0);
+
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BADGE, layout.getRenderMode(),
+                     "Explicit render-mode=badge must override numeric auto-detection (BAR)");
+    }
+
+    /**
+     * Explicit render-mode=badge forces BADGE for a high-cardinality field
+     * that would normally stay TEXT.
+     */
+    @Test
+    void explicitRenderModeBadgeOverridesHighCardinality() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("tag"), style);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("tag");
+        sheet.setOverride(path, "render-mode", "badge");
+
+        layout.buildPaths(path, null);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 20; i++) {
+            data.add("tag-" + i);
+        }
+
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BADGE, layout.getRenderMode(),
+                     "Explicit render-mode=badge must override high-cardinality TEXT fallback");
+    }
+
+    // ---- CSS class assignment: badge-{sorted-index} ----
+
+    /**
+     * badge-{sorted-index} CSS class is assigned using sorted position in distinct value set.
+     * Values "pending", "active", "inactive" sorted: ["active"=0, "inactive"=1, "pending"=2].
+     */
+    @Test
+    void badgeSortedIndexStoredInMeasureResult() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("status"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("pending");
+        data.add("active");
+        data.add("inactive");
+        data.add("pending");
+        data.add("active");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BADGE, layout.getRenderMode());
+
+        // Sorted: ["active", "inactive", "pending"]
+        List<String> badgeValues = layout.getBadgeValues();
+        assertNotNull(badgeValues, "getBadgeValues() must not be null after BADGE detection");
+        assertEquals(3, badgeValues.size());
+        assertEquals("active",   badgeValues.get(0), "index 0 must be 'active'");
+        assertEquals("inactive", badgeValues.get(1), "index 1 must be 'inactive'");
+        assertEquals("pending",  badgeValues.get(2), "index 2 must be 'pending'");
+    }
+
+    /**
+     * getBadgeValues() returns null (or empty) when render mode is TEXT.
+     */
+    @Test
+    void badgeValuesNullForTextMode() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("name"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 15; i++) {
+            data.add("value-" + i);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.TEXT, layout.getRenderMode());
+
+        List<String> badgeValues = layout.getBadgeValues();
+        assertTrue(badgeValues == null || badgeValues.isEmpty(),
+                   "getBadgeValues() must be null or empty when mode is TEXT");
+    }
+
+    /**
+     * badgeIndex() returns the correct sorted position for a known value.
+     */
+    @Test
+    void badgeIndexReturnsCorrectSortedPosition() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("severity"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // 4 distinct values
+        data.add("high");
+        data.add("critical");
+        data.add("low");
+        data.add("medium");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BADGE, layout.getRenderMode());
+
+        // Sorted: ["critical"=0, "high"=1, "low"=2, "medium"=3]
+        assertEquals(0, layout.badgeIndex("critical"), "critical must be index 0");
+        assertEquals(1, layout.badgeIndex("high"),     "high must be index 1");
+        assertEquals(2, layout.badgeIndex("low"),      "low must be index 2");
+        assertEquals(3, layout.badgeIndex("medium"),   "medium must be index 3");
+    }
+
+    /**
+     * badgeIndex() returns -1 for values not in the sorted set (beyond-threshold fallback).
+     */
+    @Test
+    void badgeIndexReturnsMinus1ForUnknownValue() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("status"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("active");
+        data.add("inactive");
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BADGE, layout.getRenderMode());
+
+        assertEquals(-1, layout.badgeIndex("unknown"),
+                     "Unknown value must return -1 (TEXT fallback)");
+        assertEquals(-1, layout.badgeIndex(null),
+                     "null must return -1 (TEXT fallback)");
+    }
+
+    // ---- PrimitiveBadgeStyle class structure ----
+
+    /**
+     * PrimitiveBadgeStyle exists as a public static inner class of PrimitiveStyle.
+     */
+    @Test
+    void primitiveBadgeStyleExistsAsStaticInnerClass() {
+        Class<?> enclosing = PrimitiveStyle.PrimitiveBadgeStyle.class.getEnclosingClass();
+        assertNotNull(enclosing, "PrimitiveBadgeStyle must be an inner class");
+        assertEquals(PrimitiveStyle.class, enclosing,
+                     "PrimitiveBadgeStyle must be enclosed in PrimitiveStyle");
+        assertTrue(java.lang.reflect.Modifier.isStatic(PrimitiveStyle.PrimitiveBadgeStyle.class.getModifiers()),
+                   "PrimitiveBadgeStyle must be a static inner class");
+        assertTrue(java.lang.reflect.Modifier.isPublic(PrimitiveStyle.PrimitiveBadgeStyle.class.getModifiers()),
+                   "PrimitiveBadgeStyle must be public");
+    }
+
+    @Test
+    void primitiveBadgeStyleExtendsPrimitiveStyle() {
+        assertTrue(PrimitiveStyle.class.isAssignableFrom(PrimitiveStyle.PrimitiveBadgeStyle.class),
+                   "PrimitiveBadgeStyle must extend PrimitiveStyle");
+    }
+
+    /**
+     * PrimitiveBadgeStyle.getHeight() returns single-line height (same as TEXT).
+     */
+    @Test
+    void badgeStyleGetHeightReturnsSingleLine() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight(anyDouble())).thenReturn(20.0);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+
+        PrimitiveStyle.PrimitiveBadgeStyle badgeStyle =
+            new PrimitiveStyle.PrimitiveBadgeStyle(labelStyle, javafx.geometry.Insets.EMPTY, labelStyle);
+
+        double h1 = badgeStyle.getHeight(100.0, 50.0);
+        double h2 = badgeStyle.getHeight(9999.0, 1.0);
+        assertEquals(h1, h2, 1e-9,
+                     "BADGE height must not depend on maxWidth or justified arguments");
+        assertEquals(20.0, h1, 1e-9, "BADGE height must equal single-line height");
+    }
+
+    /**
+     * PRIMITIVE_BADGE_CLASS constant is "primitive-badge".
+     */
+    @Test
+    void primitiveBadgeClassConstant() {
+        assertEquals("primitive-badge", PrimitiveStyle.PrimitiveBadgeStyle.PRIMITIVE_BADGE_CLASS);
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/ColumnSetSnapshotTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/ColumnSetSnapshotTest.java
@@ -94,10 +94,10 @@ class ColumnSetSnapshotTest {
         PrimitiveLayout p1 = makePrimitive("description", 300.0);
         PrimitiveLayout p2 = makePrimitive("credits", 50.0);
         cs.add(p1);
-        // Second column added by compress; simulate by accessing columns list
+        // Second column added by compress; simulate via package-private addColumn
         Column col2 = new Column(100.0);
         col2.add(p2);
-        cs.getColumns().add(col2);
+        cs.addColumn(col2);
         cs.getColumns().get(0).setWidth(300.0);
 
         ColumnSetSnapshot snap = cs.toSnapshot(60.0);

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeSerializationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeSerializationTest.java
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * TDD tests for Jackson serialization of LayoutDecisionNode (Kramer-c3l).
+ *
+ * Verifies that:
+ *   - LayoutDecisionNode serializes to JSON without error
+ *   - MeasureResult.extractor is excluded from serialization
+ *   - Nested childNodes serialize correctly
+ */
+class LayoutDecisionNodeSerializationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static MeasureResult measureResult() {
+        return new MeasureResult(10.0, 100.0, 90.0, 120.0, 3, false, 1, 5,
+                                 node -> node, List.of(), null, null, null);
+    }
+
+    private static MeasureResult measureResultWithChildren() {
+        MeasureResult child = new MeasureResult(5.0, 50.0, 45.0, 60.0, 1, false, 0, 2,
+                                                node -> node, List.of(), null, null, null);
+        return new MeasureResult(10.0, 100.0, 90.0, 120.0, 3, false, 1, 5,
+                                 node -> node, List.of(child), null, null, null);
+    }
+
+    private static LayoutResult layoutResult() {
+        return new LayoutResult(RelationRenderMode.OUTLINE, PrimitiveRenderMode.TEXT,
+                                false, 0.0, 0.0, 100.0, List.of());
+    }
+
+    private static LayoutDecisionNode leafNode(String field) {
+        return new LayoutDecisionNode(
+            new SchemaPath("root", field),
+            field,
+            measureResult(),
+            layoutResult(),
+            null, null, null, null
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. LayoutDecisionNode serializes to JSON without error
+    // -----------------------------------------------------------------------
+
+    @Test
+    void layoutDecisionNodeSerializesToJsonWithoutError() throws Exception {
+        LayoutDecisionNode node = leafNode("price");
+        String json = MAPPER.writeValueAsString(node);
+        assertNotNull(json);
+        assertFalse(json.isEmpty());
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. extractor field is excluded from serialization
+    // -----------------------------------------------------------------------
+
+    @Test
+    void extractorFieldExcludedFromMeasureResultSerialization() throws Exception {
+        MeasureResult mr = measureResult();
+        String json = MAPPER.writeValueAsString(mr);
+        JsonNode tree = MAPPER.readTree(json);
+        assertFalse(tree.has("extractor"),
+                    "extractor must be excluded from MeasureResult JSON serialization");
+    }
+
+    @Test
+    void extractorExcludedWhenMeasureResultNestedInDecisionNode() throws Exception {
+        LayoutDecisionNode node = leafNode("qty");
+        String json = MAPPER.writeValueAsString(node);
+        // extractor must not appear anywhere in the serialized tree
+        assertFalse(json.contains("\"extractor\""),
+                    "extractor must not appear in serialized LayoutDecisionNode JSON");
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Nested childNodes serialize correctly
+    // -----------------------------------------------------------------------
+
+    @Test
+    void nestedChildNodesSerializeCorrectly() throws Exception {
+        LayoutDecisionNode child1 = leafNode("firstName");
+        LayoutDecisionNode child2 = leafNode("lastName");
+
+        LayoutDecisionNode parent = new LayoutDecisionNode(
+            new SchemaPath("root"),
+            "root",
+            measureResult(),
+            layoutResult(),
+            null, null, null,
+            List.of(child1, child2)
+        );
+
+        String json = MAPPER.writeValueAsString(parent);
+        JsonNode tree = MAPPER.readTree(json);
+
+        assertTrue(tree.has("childNodes"), "childNodes field must be present in JSON");
+        assertEquals(2, tree.get("childNodes").size(), "childNodes must serialize both children");
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. MeasureResult childResults serialize correctly (extractor excluded throughout)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void measureResultChildResultsSerializeWithoutExtractor() throws Exception {
+        MeasureResult mr = measureResultWithChildren();
+        String json = MAPPER.writeValueAsString(mr);
+        JsonNode tree = MAPPER.readTree(json);
+
+        assertTrue(tree.has("childResults"), "childResults must be present");
+        assertEquals(1, tree.get("childResults").size());
+        // extractor must not appear anywhere, including nested
+        assertFalse(json.contains("\"extractor\""),
+                    "extractor must not appear in childResults serialization");
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. fieldName and path serialize correctly
+    // -----------------------------------------------------------------------
+
+    @Test
+    void fieldNameAndPathSerializeCorrectly() throws Exception {
+        LayoutDecisionNode node = leafNode("amount");
+        String json = MAPPER.writeValueAsString(node);
+        JsonNode tree = MAPPER.readTree(json);
+
+        assertTrue(tree.has("fieldName"), "fieldName must be present");
+        assertEquals("amount", tree.get("fieldName").asText());
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeSerializationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeSerializationTest.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 class LayoutDecisionNodeSerializationTest {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
 
     // -----------------------------------------------------------------------
     // Helpers

--- a/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveBarStyleTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/PrimitiveBarStyleTest.java
@@ -131,19 +131,21 @@ class PrimitiveBarStyleTest {
 
     @Test
     void buildControlUsesTextStyleWhenRenderModeTEXT() {
-        // measure() with text data → renderMode=TEXT
+        // measure() with high-cardinality text data (>= 10 distinct) → renderMode=TEXT
         PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
         PrimitiveLayout layout = new PrimitiveLayout(new Primitive("name"), primStyle);
 
         ArrayNode data = JsonNodeFactory.instance.arrayNode();
-        data.add("Alice");
-        data.add("Bob");
+        // 10 distinct values — at the default badge threshold, stays TEXT
+        for (int i = 1; i <= 10; i++) {
+            data.add("name-" + i);
+        }
 
         com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
         layout.measure(data, n -> n, model);
 
         assertEquals(PrimitiveRenderMode.TEXT, layout.getRenderMode(),
-                     "Precondition: renderMode must be TEXT for text data");
+                     "High-cardinality text data (10 distinct) must remain TEXT (not BAR or BADGE)");
     }
 
     @Test

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutCompressTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RelationLayoutCompressTest.java
@@ -399,4 +399,33 @@ class RelationLayoutCompressTest {
         assertEquals(layout1.columnSets.size(), layout2.columnSets.size(),
                      "Parameterized compress(w, true) must match compress(w)");
     }
+
+    // -----------------------------------------------------------------------
+    // S4: CompressResult snapshot immutability (covers C2: ColumnSetSnapshot)
+    // -----------------------------------------------------------------------
+
+    @Test
+    void compressResultSnapshotIsImmutableAfterSubsequentCompress() {
+        RelationStyle style = mockRelationStyle();
+        Relation parent = new Relation("parent");
+        RelationLayout layout = new RelationLayout(parent, style);
+        layout.children.clear();
+        layout.children.add(makePrimitive("a", 30));
+        layout.children.add(makePrimitive("b", 30));
+        layout.labelWidth = 10;
+        layout.averageChildCardinality = 1;
+
+        // Take snapshot at width=400
+        CompressResult snapshot = layout.computeCompress(400);
+        List<ColumnSetSnapshot> snapshotsBefore = List.copyOf(snapshot.columnSetSnapshots());
+        int countBefore = snapshotsBefore.size();
+
+        // Compress again at a very different width — should not alter first snapshot
+        layout.computeCompress(100);
+
+        assertEquals(countBefore, snapshot.columnSetSnapshots().size(),
+                     "CompressResult snapshot must not be mutated by subsequent compress calls");
+        assertEquals(snapshotsBefore, snapshot.columnSetSnapshots(),
+                     "CompressResult columnSetSnapshots must be immutable across compress calls");
+    }
 }


### PR DESCRIPTION
## Summary
Final batch of Wave 2. Closes both RDR epics.

- **RDR-011** (Kramer-73j): `AutoLayout.getLayoutDecisionTree()` — `Optional<LayoutDecisionNode>`, guarded by `isConverged()`.
- **RDR-011** (Kramer-c3l): `@JsonIgnore` on `MeasureResult.extractor()`. Full JSON serialization of `LayoutDecisionNode` tree.
- **RDR-015** (Kramer-bdv): BADGE rendering mode — auto-detect low-cardinality, `badge-{sorted-index}` CSS class, `badge-cardinality-threshold` property.

**Epic Kramer-43t (RDR-011) closed** — 16/16 beads, Phase 1 complete.
**Epic Kramer-3ir (RDR-015) closed** — 6/6 beads, Phases 1-3 complete.

## Test plan
- [x] 448 tests pass (26 new)
- [x] Decision tree API: 4 tests
- [x] Jackson serialization: 5 tests
- [x] BADGE mode: 17 tests

Ref: Kramer-73j, Kramer-c3l, Kramer-bdv