### PR TITLE
Wave 3 Batch 1: LayoutPropertyKeys, SPARKLINE enum, SparklineStats

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutPropertyKeys.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutPropertyKeys.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+/**
+ * CSS / schema property key constants used by the Kramer layout engine.
+ *
+ * <p>Deferred consolidation: the following additional property keys exist in
+ * the codebase but have not been centralised here yet:
+ * {@code stat-min-samples}, {@code stat-convergence-epsilon},
+ * {@code stat-convergence-k}, {@code badge-cardinality-threshold},
+ * {@code pivot-field}.
+ */
+public final class LayoutPropertyKeys {
+
+    public static final String VISIBLE      = "visible";
+    public static final String RENDER_MODE  = "render-mode";
+    public static final String HIDE_IF_EMPTY = "hide-if-empty";
+    public static final String SORT_FIELDS  = "sort-fields";
+
+    private LayoutPropertyKeys() {}
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/MeasureResult.java
@@ -26,7 +26,8 @@ public record MeasureResult(
     List<MeasureResult> childResults,
     ContentWidthStats contentStats,
     NumericStats numericStats,
-    PivotStats pivotStats
+    PivotStats pivotStats,
+    SparklineStats sparklineStats
 ) {
     public MeasureResult {
         childResults = childResults == null ? List.of() : List.copyOf(childResults);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -384,7 +384,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         measureResult = new MeasureResult(
             labelWidth, columnWidth, dataWidth, maxWidth,
             averageCardinality, isVariableLength,
-            0, 0, null, List.of(), contentStats, numericStats, null
+            0, 0, null, List.of(), contentStats, numericStats, null, null
         );
 
         // Freeze result when convergence is achieved.

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveRenderMode.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveRenderMode.java
@@ -8,8 +8,9 @@ package com.chiralbehaviors.layout;
  *   <li>TEXT — plain text label (default)</li>
  *   <li>BAR — horizontal bar chart representation</li>
  *   <li>BADGE — badge / chip representation</li>
+ *   <li>SPARKLINE — mini time-series sparkline chart</li>
  * </ul>
  */
 public enum PrimitiveRenderMode {
-    TEXT, BAR, BADGE
+    TEXT, BAR, BADGE, SPARKLINE
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -726,7 +726,7 @@ public final class RelationLayout extends SchemaNodeLayout {
             labelWidth, columnWidth, 0, 0,
             0, false,
             averageChildCardinality, maxCardinality,
-            extractor, childResults, null, null, pivotStats
+            extractor, childResults, null, null, pivotStats, null
         );
 
         return columnWidth + style.getElementHorizontalInset()

--- a/kramer/src/main/java/com/chiralbehaviors/layout/SparklineStats.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/SparklineStats.java
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+/**
+ * Statistical summary for sparkline rendering of a primitive series.
+ * Captured during the measure phase; used by sparkline renderers at layout time.
+ *
+ * <p>No {@code lastValue} field is included here — that is per-cell state
+ * supplied in {@code updateItem} rather than a measure-phase aggregate.
+ *
+ * @param seriesMin    minimum value in the series
+ * @param seriesMax    maximum value in the series
+ * @param q1           first quartile (25th percentile)
+ * @param q3           third quartile (75th percentile)
+ * @param seriesLength number of data points in the series
+ */
+public record SparklineStats(double seriesMin, double seriesMax, double q1, double q3, int seriesLength) {
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/ContentWidthStatsTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/ContentWidthStatsTest.java
@@ -70,7 +70,7 @@ class ContentWidthStatsTest {
             1, false,
             0, 0,
             null, List.of(),
-            null, null, null
+            null, null, null, null
         );
 
         assertNull(result.contentStats(),
@@ -87,7 +87,7 @@ class ContentWidthStatsTest {
             1, false,
             0, 0,
             null, List.of(),
-            stats, null, null
+            stats, null, null, null
         );
 
         assertNotNull(result.contentStats());
@@ -127,7 +127,7 @@ class ContentWidthStatsTest {
             0, false,
             2, 5,
             Function.identity(), List.of(),
-            null, null, null
+            null, null, null, null
         );
 
         assertNull(result.contentStats(),

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeSerializationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeSerializationTest.java
@@ -28,14 +28,14 @@ class LayoutDecisionNodeSerializationTest {
 
     private static MeasureResult measureResult() {
         return new MeasureResult(10.0, 100.0, 90.0, 120.0, 3, false, 1, 5,
-                                 node -> node, List.of(), null, null, null);
+                                 node -> node, List.of(), null, null, null, null);
     }
 
     private static MeasureResult measureResultWithChildren() {
         MeasureResult child = new MeasureResult(5.0, 50.0, 45.0, 60.0, 1, false, 0, 2,
-                                                node -> node, List.of(), null, null, null);
+                                                node -> node, List.of(), null, null, null, null);
         return new MeasureResult(10.0, 100.0, 90.0, 120.0, 3, false, 1, 5,
-                                 node -> node, List.of(child), null, null, null);
+                                 node -> node, List.of(child), null, null, null, null);
     }
 
     private static LayoutResult layoutResult() {

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionNodeTest.java
@@ -12,7 +12,7 @@ class LayoutDecisionNodeTest {
 
     private static MeasureResult measureResult() {
         return new MeasureResult(10.0, 100.0, 90.0, 120.0, 1, false, 0, 5,
-                                 node -> node, List.of(), null, null, null);
+                                 node -> node, List.of(), null, null, null, null);
     }
 
     private static LayoutResult layoutResult() {

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutPropertyKeysTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutPropertyKeysTest.java
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LayoutPropertyKeysTest {
+
+    @Test
+    void visibleHasCorrectValue() {
+        assertEquals("visible", LayoutPropertyKeys.VISIBLE);
+    }
+
+    @Test
+    void renderModeHasCorrectValue() {
+        assertEquals("render-mode", LayoutPropertyKeys.RENDER_MODE);
+    }
+
+    @Test
+    void hideIfEmptyHasCorrectValue() {
+        assertEquals("hide-if-empty", LayoutPropertyKeys.HIDE_IF_EMPTY);
+    }
+
+    @Test
+    void sortFieldsHasCorrectValue() {
+        assertEquals("sort-fields", LayoutPropertyKeys.SORT_FIELDS);
+    }
+
+    @Test
+    void constantsArePublicStaticFinalString() throws NoSuchFieldException {
+        for (String name : new String[]{"VISIBLE", "RENDER_MODE", "HIDE_IF_EMPTY", "SORT_FIELDS"}) {
+            Field f = LayoutPropertyKeys.class.getDeclaredField(name);
+            int mods = f.getModifiers();
+            assertTrue(Modifier.isPublic(mods), name + " must be public");
+            assertTrue(Modifier.isStatic(mods), name + " must be static");
+            assertTrue(Modifier.isFinal(mods), name + " must be final");
+            assertEquals(String.class, f.getType(), name + " must be String");
+        }
+    }
+
+    @Test
+    void classIsNotInstantiable() {
+        var ctors = LayoutPropertyKeys.class.getDeclaredConstructors();
+        assertEquals(1, ctors.length);
+        assertTrue(Modifier.isPrivate(ctors[0].getModifiers()));
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/NumericStatsTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/NumericStatsTest.java
@@ -45,7 +45,7 @@ class NumericStatsTest {
             1, false,
             0, 0,
             null, List.of(),
-            null, ns, null
+            null, ns, null, null
         );
         assertNotNull(result.numericStats());
         assertEquals(5.0, result.numericStats().numericMin(), 1e-9);
@@ -59,7 +59,7 @@ class NumericStatsTest {
             1, false,
             0, 0,
             null, List.of(),
-            null, null, null
+            null, null, null, null
         );
         assertNull(result.numericStats());
     }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/PivotStatsTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/PivotStatsTest.java
@@ -60,7 +60,7 @@ class PivotStatsTest {
             1, false,
             0, 0,
             null, List.of(),
-            null, null, ps
+            null, null, ps, null
         );
         assertNotNull(result.pivotStats());
         assertEquals(2, result.pivotStats().pivotCount());
@@ -74,7 +74,7 @@ class PivotStatsTest {
             1, false,
             0, 0,
             null, List.of(),
-            null, null, null
+            null, null, null, null
         );
         assertNull(result.pivotStats());
     }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/RenderModeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/RenderModeTest.java
@@ -25,10 +25,11 @@ class RenderModeTest {
     @Test
     void primitiveRenderModeValues() {
         var values = PrimitiveRenderMode.values();
-        assertEquals(3, values.length);
+        assertEquals(4, values.length);
         assertNotNull(PrimitiveRenderMode.valueOf("TEXT"));
         assertNotNull(PrimitiveRenderMode.valueOf("BAR"));
         assertNotNull(PrimitiveRenderMode.valueOf("BADGE"));
+        assertNotNull(PrimitiveRenderMode.valueOf("SPARKLINE"));
     }
 
     @Test

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SparklineStatsTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SparklineStatsTest.java
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Kramer-woy: SparklineStats record and MeasureResult integration.
+ */
+class SparklineStatsTest {
+
+    // --- SparklineStats record construction and accessors ---
+
+    @Test
+    void constructionAndAccessors() {
+        SparklineStats stats = new SparklineStats(1.0, 99.0, 25.0, 75.0, 50);
+
+        assertEquals(1.0, stats.seriesMin(), 1e-9);
+        assertEquals(99.0, stats.seriesMax(), 1e-9);
+        assertEquals(25.0, stats.q1(), 1e-9);
+        assertEquals(75.0, stats.q3(), 1e-9);
+        assertEquals(50, stats.seriesLength());
+    }
+
+    @Test
+    void equalityAndHashCode() {
+        SparklineStats a = new SparklineStats(0.0, 100.0, 20.0, 80.0, 10);
+        SparklineStats b = new SparklineStats(0.0, 100.0, 20.0, 80.0, 10);
+        SparklineStats c = new SparklineStats(0.0, 100.0, 20.0, 80.0, 11);
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+    }
+
+    @Test
+    void zeroSeriesLength() {
+        SparklineStats stats = new SparklineStats(0.0, 0.0, 0.0, 0.0, 0);
+        assertEquals(0, stats.seriesLength());
+    }
+
+    @Test
+    void negativeRangeAllowed() {
+        SparklineStats stats = new SparklineStats(-50.0, -10.0, -40.0, -20.0, 5);
+        assertEquals(-50.0, stats.seriesMin(), 1e-9);
+        assertEquals(-10.0, stats.seriesMax(), 1e-9);
+        assertEquals(-40.0, stats.q1(), 1e-9);
+        assertEquals(-20.0, stats.q3(), 1e-9);
+    }
+
+    // --- MeasureResult with non-null sparklineStats ---
+
+    @Test
+    void measureResultWithNonNullSparklineStats() {
+        SparklineStats ss = new SparklineStats(2.0, 98.0, 30.0, 70.0, 20);
+        MeasureResult result = new MeasureResult(
+            10.0, 20.0, 15.0, 25.0,
+            1, false,
+            0, 0,
+            null, List.of(),
+            null, null, null, ss
+        );
+
+        assertNotNull(result.sparklineStats());
+        assertEquals(2.0, result.sparklineStats().seriesMin(), 1e-9);
+        assertEquals(98.0, result.sparklineStats().seriesMax(), 1e-9);
+        assertEquals(30.0, result.sparklineStats().q1(), 1e-9);
+        assertEquals(70.0, result.sparklineStats().q3(), 1e-9);
+        assertEquals(20, result.sparklineStats().seriesLength());
+    }
+
+    // --- MeasureResult with null sparklineStats (backward compatibility) ---
+
+    @Test
+    void measureResultWithNullSparklineStats() {
+        MeasureResult result = new MeasureResult(
+            10.0, 20.0, 15.0, 25.0,
+            1, false,
+            0, 0,
+            null, List.of(),
+            null, null, null, null
+        );
+
+        assertNull(result.sparklineStats(),
+                   "sparklineStats should be null when not provided");
+    }
+
+    @Test
+    void existingThirteenParamSitesStillCompileWithNull() {
+        // Simulate the pattern used at all existing call sites after migration:
+        // pass null as the 14th argument
+        MeasureResult result = new MeasureResult(
+            5.0, 10.0, 8.0, 12.0,
+            2, true,
+            1, 3,
+            n -> n, List.of(),
+            new ContentWidthStats(5.0, 9.0, 30, true),
+            new NumericStats(0.0, 10.0),
+            null,
+            null   // sparklineStats = null
+        );
+
+        assertNull(result.sparklineStats());
+        assertNotNull(result.contentStats());
+        assertNotNull(result.numericStats());
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-018** (Kramer-f56): `LayoutPropertyKeys` — 4 property key constants (VISIBLE, RENDER_MODE, HIDE_IF_EMPTY, SORT_FIELDS)
- **RDR-019** (Kramer-czi): `SPARKLINE` added to `PrimitiveRenderMode` (4th value)
- **RDR-019** (Kramer-woy): `SparklineStats` record as 14th nullable param on `MeasureResult`. All 11 construction sites updated.

## Test plan
- [x] 462 tests pass (14 new)

Ref: Kramer-f56, Kramer-czi, Kramer-woy