### PR TITLE
Wave 3 Batch 2: stylesheet routing, visible, sparkline detection, LayoutRenderer

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AbstractLayoutRenderer.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AbstractLayoutRenderer.java
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Base implementation of {@link LayoutRenderer} that walks the
+ * {@link LayoutDecisionNode} tree recursively.
+ * <p>
+ * Leaf nodes (no children) are dispatched to {@link #renderPrimitive}.
+ * Interior nodes collect rendered children and are dispatched to
+ * {@link #renderRelation}.
+ *
+ * @param <T> the render output type
+ */
+public abstract class AbstractLayoutRenderer<T> implements LayoutRenderer<T> {
+
+    @Override
+    public T render(LayoutDecisionNode node, JsonNode data) {
+        if (node.childNodes().isEmpty()) {
+            return renderPrimitive(node, data);
+        }
+        var childResults = new ArrayList<T>(node.childNodes().size());
+        for (var child : node.childNodes()) {
+            JsonNode childData = data != null ? data.get(child.fieldName()) : null;
+            childResults.add(render(child, childData));
+        }
+        return renderRelation(node, data, List.copyOf(childResults));
+    }
+
+    /**
+     * Render a leaf node (a node with no children).
+     *
+     * @param node the leaf decision node
+     * @param data the JSON value for this node; may be {@code null}
+     * @return the rendered result
+     */
+    protected abstract T renderPrimitive(LayoutDecisionNode node, JsonNode data);
+
+    /**
+     * Render an interior node after all children have been rendered.
+     *
+     * @param node     the interior decision node
+     * @param data     the JSON object for this node; may be {@code null}
+     * @param children rendered results for each child, in child order
+     * @return the rendered result
+     */
+    protected abstract T renderRelation(LayoutDecisionNode node, JsonNode data, List<T> children);
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutRenderer.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutRenderer.java
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Renders a {@link LayoutDecisionNode} tree into a target type {@code T}.
+ *
+ * @param <T> the render output type
+ */
+public interface LayoutRenderer<T> {
+
+    /**
+     * Render the given {@code node} using {@code data} as the JSON context.
+     *
+     * @param node the layout decision node to render
+     * @param data the JSON data for this node; may be {@code null}
+     * @return the rendered result
+     */
+    T render(LayoutDecisionNode node, JsonNode data);
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -211,6 +211,14 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
             return frozenResult.columnWidth();
         }
 
+        // Invisible primitives produce no width contribution.
+        SchemaPath path = getSchemaPath();
+        if (stylesheet != null && path != null
+                && !stylesheet.getBoolean(path, LayoutPropertyKeys.VISIBLE, true)) {
+            measureResult = new MeasureResult(0, 0, 0, 0, 0, false, 0, 0, null, List.of(), null, null, null, null);
+            return 0;
+        }
+
         clear();
         labelWidth = labelWidth(node.getLabel());
         double summedDataWidth = 0;
@@ -261,7 +269,6 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         int minSamples = MIN_SAMPLES;
         double epsilon = 1.0;
         int k = 3;
-        SchemaPath path = getSchemaPath();
         if (stylesheet != null && path != null) {
             minSamples = stylesheet.getInt(path, "stat-min-samples", MIN_SAMPLES);
             epsilon    = stylesheet.getDouble(path, "stat-convergence-epsilon", 1.0);
@@ -294,13 +301,19 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         }
 
         // Numeric auto-detection: scan all raw values to determine if the field is entirely numeric.
+        // Tracks isArrayValued separately from allNumeric to distinguish:
+        //   scalar numeric values → BAR
+        //   array-of-numbers      → SPARKLINE
         // This is independent of the MIN_SAMPLES requirement for percentile stats.
         NumericStats numericStats = null;
+        SparklineStats sparklineStats = null;
         String renderModeOverride = (stylesheet != null && path != null)
                                     ? stylesheet.getString(path, "render-mode", "auto")
                                     : "auto";
         if ("auto".equals(renderModeOverride)) {
             boolean allNumeric = !normalized.isEmpty();
+            boolean isArrayValued = false;
+            boolean hasScalar = false;
             double nMin = Double.POSITIVE_INFINITY;
             double nMax = Double.NEGATIVE_INFINITY;
             outer:
@@ -311,6 +324,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
                         allNumeric = false;
                         break;
                     }
+                    isArrayValued = true;
                     for (JsonNode row : prim) {
                         if (!row.isNumber()) {
                             allNumeric = false;
@@ -321,6 +335,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
                         if (v > nMax) nMax = v;
                     }
                 } else {
+                    hasScalar = true;
                     if (!prim.isNumber()) {
                         allNumeric = false;
                         break;
@@ -330,17 +345,37 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
                     if (v > nMax) nMax = v;
                 }
             }
-            if (allNumeric && !normalized.isEmpty()) {
-                numericStats = new NumericStats(nMin, nMax);
-                renderMode = PrimitiveRenderMode.BAR;
+            // Mixed scalar+array → not purely one type → fall through to TEXT
+            if (allNumeric && !normalized.isEmpty() && !(isArrayValued && hasScalar)) {
+                if (isArrayValued) {
+                    // Compute SparklineStats: flatten all array values, sort for quartiles
+                    List<Double> allValues = new ArrayList<>();
+                    for (JsonNode prim : normalized) {
+                        if (prim.isArray()) {
+                            for (JsonNode row : prim) {
+                                allValues.add(row.doubleValue());
+                            }
+                        }
+                    }
+                    Collections.sort(allValues);
+                    int n = allValues.size();
+                    double q1 = n > 0 ? allValues.get(n / 4) : 0.0;
+                    double q3 = n > 0 ? allValues.get(n * 3 / 4) : 0.0;
+                    sparklineStats = new SparklineStats(nMin, nMax, q1, q3, n);
+                    renderMode = PrimitiveRenderMode.SPARKLINE;
+                } else {
+                    numericStats = new NumericStats(nMin, nMax);
+                    renderMode = PrimitiveRenderMode.BAR;
+                }
             } else {
                 renderMode = PrimitiveRenderMode.TEXT;
             }
         } else {
             renderMode = switch (renderModeOverride.toUpperCase()) {
-                case "BAR"   -> PrimitiveRenderMode.BAR;
-                case "BADGE" -> PrimitiveRenderMode.BADGE;
-                default      -> PrimitiveRenderMode.TEXT;
+                case "BAR"       -> PrimitiveRenderMode.BAR;
+                case "BADGE"     -> PrimitiveRenderMode.BADGE;
+                case "SPARKLINE" -> PrimitiveRenderMode.SPARKLINE;
+                default          -> PrimitiveRenderMode.TEXT;
             };
         }
 
@@ -384,7 +419,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         measureResult = new MeasureResult(
             labelWidth, columnWidth, dataWidth, maxWidth,
             averageCardinality, isVariableLength,
-            0, 0, null, List.of(), contentStats, numericStats, null, null
+            0, 0, null, List.of(), contentStats, numericStats, null, sparklineStats
         );
 
         // Freeze result when convergence is achieved.

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -632,7 +632,31 @@ public final class RelationLayout extends SchemaNodeLayout {
             this.extractor = extractor;
         }
         // Compute sort comparator once per measure phase; stored for extractFrom().
-        sortComparator = buildSortComparator(getNode());
+        // Check stylesheet for sort-fields override; Relation is the fallback.
+        {
+            LayoutStylesheet _ss = (model != null) ? model.getStylesheet() : null;
+            SchemaPath _path = getSchemaPath();
+            Relation _relation = getNode();
+            List<String> _relFields = _relation.getSortFields();
+            if (!_relFields.isEmpty()) {
+                // Relation has explicit sortFields — use them directly (highest priority)
+                sortComparator = buildSortComparator(_relation);
+            } else {
+                // Check stylesheet for sort-fields
+                String _stylesheetSort = (_ss != null && _path != null)
+                    ? _ss.getString(_path, LayoutPropertyKeys.SORT_FIELDS, "") : "";
+                if (!_stylesheetSort.isEmpty()) {
+                    List<String> _fields = List.of(_stylesheetSort.split(","));
+                    Comparator<JsonNode> _cmp = fieldComparator(_fields.get(0));
+                    for (int _i = 1; _i < _fields.size(); _i++) {
+                        _cmp = _cmp.thenComparing(fieldComparator(_fields.get(_i)));
+                    }
+                    sortComparator = _cmp;
+                } else {
+                    sortComparator = buildSortComparator(_relation);
+                }
+            }
+        }
         // Sort the datum array before measuring children so that measurement
         // reflects data order consistent with the build phase.
         // Copy before sorting to avoid mutating the caller's datum in-place.
@@ -643,9 +667,18 @@ public final class RelationLayout extends SchemaNodeLayout {
         }
         // Resolve hide-if-empty filter: only active when hideIfEmpty=true and
         // autoFoldable is null (filtering is incompatible with autoFold).
+        // Priority: Relation.getHideIfEmpty() (when non-null) > stylesheet > false.
         Boolean hideOverride = getNode().getHideIfEmpty();
-        boolean shouldFilter = Boolean.TRUE.equals(hideOverride)
-                               && getNode().getAutoFoldable() == null;
+        boolean shouldHide;
+        if (hideOverride != null) {
+            shouldHide = hideOverride;
+        } else {
+            LayoutStylesheet _hideSheet = (model != null) ? model.getStylesheet() : null;
+            SchemaPath _hidePath = getSchemaPath();
+            shouldHide = (_hideSheet != null && _hidePath != null)
+                && _hideSheet.getBoolean(_hidePath, LayoutPropertyKeys.HIDE_IF_EMPTY, false);
+        }
+        boolean shouldFilter = shouldHide && getNode().getAutoFoldable() == null;
         if (shouldFilter) {
             hideIfEmptyFilter = item -> hasNonEmptyChildren(item, getNode());
             datum = filterArrayNode(datum, hideIfEmptyFilter);
@@ -683,8 +716,15 @@ public final class RelationLayout extends SchemaNodeLayout {
             Fold fold = model.layout(child)
                              .fold(datum, extractor, model);
             SchemaNodeLayout childLayout = fold.layout();
-            if (parentPath != null) {
-                childLayout.setSchemaPath(parentPath.child(child.getField()));
+            SchemaPath childPath = (parentPath != null)
+                ? parentPath.child(child.getField()) : null;
+            if (childPath != null) {
+                childLayout.setSchemaPath(childPath);
+            }
+            // Skip invisible children — visible defaults to true.
+            if (stylesheet != null && childPath != null
+                    && !stylesheet.getBoolean(childPath, LayoutPropertyKeys.VISIBLE, true)) {
+                continue;
             }
             children.add(childLayout);
             columnWidth = Style.snap(Math.max(columnWidth, childLayout

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutRendererTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutRendererTest.java
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+class LayoutRendererTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Minimal concrete renderer that records calls and returns string tokens. */
+    private static class StringRenderer extends AbstractLayoutRenderer<String> {
+        int primitiveCallCount = 0;
+        int relationCallCount  = 0;
+
+        @Override
+        protected String renderPrimitive(LayoutDecisionNode node, JsonNode data) {
+            primitiveCallCount++;
+            return "primitive:" + node.fieldName() + "=" + (data == null ? "null" : data.asText());
+        }
+
+        @Override
+        protected String renderRelation(LayoutDecisionNode node, JsonNode data, List<String> children) {
+            relationCallCount++;
+            return "relation:" + node.fieldName() + "[" + String.join(",", children) + "]";
+        }
+    }
+
+    private static LayoutDecisionNode leaf(String name) {
+        var path = new SchemaPath(name);
+        return new LayoutDecisionNode(path, path.leaf(), null, null, null, null, null, null);
+    }
+
+    private static LayoutDecisionNode parent(String name, List<LayoutDecisionNode> children) {
+        var path = new SchemaPath(name);
+        return new LayoutDecisionNode(path, path.leaf(), null, null, null, null, null, children);
+    }
+
+    @Test
+    void leafNodeCallsRenderPrimitive() {
+        var renderer = new StringRenderer();
+        var node = leaf("score");
+        JsonNode data = MAPPER.getNodeFactory().textNode("42");
+
+        var result = renderer.render(node, data);
+
+        assertEquals(1, renderer.primitiveCallCount);
+        assertEquals(0, renderer.relationCallCount);
+        assertEquals("primitive:score=42", result);
+    }
+
+    @Test
+    void treeNodeRecursesThroughChildren() {
+        var child1 = leaf("name");
+        var child2 = leaf("age");
+        var root = parent("person", List.of(child1, child2));
+
+        ObjectNode data = MAPPER.createObjectNode();
+        data.put("name", "Alice");
+        data.put("age", 30);
+
+        var renderer = new StringRenderer();
+        var result = renderer.render(root, data);
+
+        assertEquals(2, renderer.primitiveCallCount);
+        assertEquals(1, renderer.relationCallCount);
+        assertEquals("relation:person[primitive:name=Alice,primitive:age=30]", result);
+    }
+
+    @Test
+    void childDataExtractionUsesFieldName() {
+        // Verify that child data is extracted via data.get(child.fieldName())
+        var child = leaf("status");
+        var root = parent("item", List.of(child));
+
+        ObjectNode data = MAPPER.createObjectNode();
+        data.put("status", "active");
+        // extra field not in schema — should be ignored
+        data.put("other", "ignored");
+
+        var renderer = new StringRenderer();
+        renderer.render(root, data);
+
+        // Only "status" should be passed to renderPrimitive
+        assertEquals(1, renderer.primitiveCallCount);
+        // Confirm by inspecting what renderPrimitive received via result
+        var result = renderer.render(root, data);
+        assertTrue(result.contains("primitive:status=active"));
+        assertFalse(result.contains("ignored"));
+    }
+
+    @Test
+    void nullDataHandledGracefully() {
+        var renderer = new StringRenderer();
+
+        // null data at leaf
+        var leafNode = leaf("x");
+        var leafResult = renderer.render(leafNode, null);
+        assertEquals("primitive:x=null", leafResult);
+
+        // null data at relation — children should receive null child data
+        var child = leaf("y");
+        var root = parent("z", List.of(child));
+        var result = renderer.render(root, null);
+        assertTrue(result.contains("primitive:y=null"));
+        assertTrue(result.contains("relation:z["));
+    }
+
+    @Test
+    void deeplyNestedTreeIsRendered() {
+        // grandchild -> child -> root
+        var grandchild = leaf("value");
+        var child = parent("nested", List.of(grandchild));
+        var root = parent("top", List.of(child));
+
+        ObjectNode grandchildData = MAPPER.createObjectNode();
+        grandchildData.put("value", "deep");
+        ObjectNode childData = MAPPER.createObjectNode();
+        childData.set("nested", grandchildData);
+        ObjectNode rootData = MAPPER.createObjectNode();
+        rootData.set("top", childData);  // top is not used by root's own render — root IS the top
+
+        // root data contains "nested" field
+        var renderer = new StringRenderer();
+        var result = renderer.render(root, childData);
+
+        assertEquals(1, renderer.primitiveCallCount);
+        assertEquals(2, renderer.relationCallCount);
+        assertTrue(result.contains("primitive:value=deep"));
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SparklineDetectionTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SparklineDetectionTest.java
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+/**
+ * Tests for Kramer-l6d: Bifurcate array-vs-scalar detection in PrimitiveLayout.measure().
+ * Verifies that scalar numeric → BAR, array-of-numbers → SPARKLINE, etc.
+ */
+class SparklineDetectionTest {
+
+    // ---- Scalar numeric → BAR (unchanged behaviour) ----
+
+    @Test
+    void scalarNumericValuesProduceBarMode() {
+        var style = TestLayouts.mockPrimitiveStyle(7.0);
+        var layout = new PrimitiveLayout(new Primitive("score"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add(10.0);
+        data.add(20.0);
+        data.add(30.0);
+        data.add(40.0);
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BAR, layout.getRenderMode(),
+                     "Scalar numeric values must produce BAR, not SPARKLINE");
+    }
+
+    // ---- Array-of-numbers → SPARKLINE ----
+
+    @Test
+    void arrayOfNumbersProducesSparklineMode() {
+        var style = TestLayouts.mockPrimitiveStyle(7.0);
+        var layout = new PrimitiveLayout(new Primitive("series"), style);
+
+        // Each row is an array of numbers (time-series per record)
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ArrayNode row1 = JsonNodeFactory.instance.arrayNode();
+        row1.add(1.0); row1.add(2.0); row1.add(3.0);
+        ArrayNode row2 = JsonNodeFactory.instance.arrayNode();
+        row2.add(4.0); row2.add(5.0); row2.add(6.0);
+        data.add(row1);
+        data.add(row2);
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                     "Array-of-numbers must produce SPARKLINE");
+    }
+
+    // ---- Array of strings → TEXT ----
+
+    @Test
+    void arrayOfStringsProducesTextMode() {
+        var style = TestLayouts.mockPrimitiveStyle(7.0);
+        var layout = new PrimitiveLayout(new Primitive("tags"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ArrayNode row1 = JsonNodeFactory.instance.arrayNode();
+        row1.add("alpha"); row1.add("beta");
+        ArrayNode row2 = JsonNodeFactory.instance.arrayNode();
+        row2.add("gamma"); row2.add("delta");
+        data.add(row1);
+        data.add(row2);
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertNotEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                        "Array of strings must not produce SPARKLINE");
+        assertNotEquals(PrimitiveRenderMode.BAR, layout.getRenderMode(),
+                        "Array of strings must not produce BAR");
+    }
+
+    // ---- Mixed scalar + array → TEXT (inconsistent types) ----
+
+    @Test
+    void mixedScalarAndArrayDataProducesTextMode() {
+        var style = TestLayouts.mockPrimitiveStyle(7.0);
+        var layout = new PrimitiveLayout(new Primitive("mixed"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // First element is a scalar number
+        data.add(42.0);
+        // Second element is an array of numbers
+        ArrayNode arr = JsonNodeFactory.instance.arrayNode();
+        arr.add(1.0); arr.add(2.0);
+        data.add(arr);
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        // Mixed types — neither purely scalar nor purely array — must not be BAR or SPARKLINE
+        assertNotEquals(PrimitiveRenderMode.BAR, layout.getRenderMode(),
+                        "Mixed scalar+array must not be BAR");
+        assertNotEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                        "Mixed scalar+array must not be SPARKLINE");
+    }
+
+    // ---- Explicit render-mode=sparkline stylesheet override ----
+
+    @Test
+    void explicitRenderModeSparklineOverrideHonored() {
+        var style = TestLayouts.mockPrimitiveStyle(7.0);
+        var layout = new PrimitiveLayout(new Primitive("metric"), style);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("metric");
+        sheet.setOverride(path, "render-mode", "sparkline");
+        layout.buildPaths(path, null);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // Plain text data — would normally be TEXT, but override forces SPARKLINE
+        data.add("some-value");
+        data.add("other-value");
+
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                     "Explicit render-mode=sparkline must force SPARKLINE regardless of data type");
+    }
+
+    // ---- Empty array → TEXT (no data to sparkline) ----
+
+    @Test
+    void emptyArrayProducesTextMode() {
+        var style = TestLayouts.mockPrimitiveStyle(7.0);
+        var layout = new PrimitiveLayout(new Primitive("empty"), style);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // A single row whose value is an empty array
+        ArrayNode emptyArr = JsonNodeFactory.instance.arrayNode();
+        data.add(emptyArr);
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertNotEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                        "Empty array must not produce SPARKLINE");
+        assertNotEquals(PrimitiveRenderMode.BAR, layout.getRenderMode(),
+                        "Empty array must not produce BAR");
+    }
+
+    // ---- SparklineStats populated with correct min/max/q1/q3/seriesLength ----
+
+    @Test
+    void sparklineStatsPopulatedCorrectly() {
+        var style = TestLayouts.mockPrimitiveStyle(7.0);
+        var layout = new PrimitiveLayout(new Primitive("values"), style);
+
+        // Rows with known numeric arrays: [1,2,3] and [4,5,6]
+        // All values flattened: [1,2,3,4,5,6]
+        // min=1, max=6, seriesLength=6
+        // sorted: [1,2,3,4,5,6] -> q1=index(1)=2, q3=index(4)=5
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ArrayNode row1 = JsonNodeFactory.instance.arrayNode();
+        row1.add(1.0); row1.add(2.0); row1.add(3.0);
+        ArrayNode row2 = JsonNodeFactory.instance.arrayNode();
+        row2.add(4.0); row2.add(5.0); row2.add(6.0);
+        data.add(row1);
+        data.add(row2);
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode());
+
+        MeasureResult result = layout.getMeasureResult();
+        assertNotNull(result);
+        SparklineStats ss = result.sparklineStats();
+        assertNotNull(ss, "sparklineStats must be populated for SPARKLINE mode");
+
+        assertEquals(1.0, ss.seriesMin(), 1e-9, "seriesMin must be 1.0");
+        assertEquals(6.0, ss.seriesMax(), 1e-9, "seriesMax must be 6.0");
+        assertEquals(6, ss.seriesLength(), "seriesLength must be 6 (all flattened values)");
+        // q1 and q3 must be within [1.0, 6.0]
+        assertTrue(ss.q1() >= ss.seriesMin() && ss.q1() <= ss.seriesMax(),
+                   "q1 must be within [seriesMin, seriesMax]");
+        assertTrue(ss.q3() >= ss.q1() && ss.q3() <= ss.seriesMax(),
+                   "q3 must be >= q1 and <= seriesMax");
+    }
+
+    @Test
+    void sparklineStatsSeriesLengthCountsAllFlattenedValues() {
+        var style = TestLayouts.mockPrimitiveStyle(7.0);
+        var layout = new PrimitiveLayout(new Primitive("ts"), style);
+
+        // 3 rows × 4 values each = 12 total
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int r = 0; r < 3; r++) {
+            ArrayNode row = JsonNodeFactory.instance.arrayNode();
+            for (int i = 0; i < 4; i++) {
+                row.add((double) (r * 4 + i));
+            }
+            data.add(row);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode());
+        SparklineStats ss = layout.getMeasureResult().sparklineStats();
+        assertNotNull(ss);
+        assertEquals(12, ss.seriesLength(), "seriesLength must count all flattened values (3×4=12)");
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/StylesheetPropertyRoutingTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/StylesheetPropertyRoutingTest.java
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Tests for Kramer-xu1: hide-if-empty and sort-fields routed through
+ * LayoutStylesheet with Relation object as fallback.
+ */
+class StylesheetPropertyRoutingTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private Style buildMockModel(Relation schema, LayoutStylesheet stylesheet) {
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(stylesheet);
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        for (SchemaNode child : schema.getChildren()) {
+            if (child instanceof Primitive p) {
+                PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+                when(model.layout(p)).thenReturn(pl);
+            }
+        }
+        when(model.layout(any(SchemaNode.class))).thenAnswer(inv -> {
+            SchemaNode n = inv.getArgument(0);
+            if (n instanceof Primitive p) return model.layout(p);
+            RelationStyle rs = TestLayouts.mockRelationStyle();
+            return new RelationLayout((Relation) n, rs);
+        });
+        return model;
+    }
+
+    /** Build a simple single-child relation with a nested array child. */
+    private Relation buildParentChild() {
+        Relation parent = new Relation("root");
+        Relation child = new Relation("items");
+        child.addChild(new Primitive("name"));
+        child.addChild(new Primitive("value"));
+        parent.addChild(child);
+        return parent;
+    }
+
+    /** Build an ArrayNode wrapping objects with optional nested arrays. */
+    private ArrayNode buildNestedData(boolean withNonEmptyChild) {
+        ArrayNode outer = JsonNodeFactory.instance.arrayNode();
+        ObjectNode row1 = JsonNodeFactory.instance.objectNode();
+        ArrayNode innerData = JsonNodeFactory.instance.arrayNode();
+        if (withNonEmptyChild) {
+            ObjectNode item = JsonNodeFactory.instance.objectNode();
+            item.put("name", "Alice");
+            item.put("value", "1");
+            innerData.add(item);
+        }
+        row1.set("items", innerData);
+        outer.add(row1);
+
+        // Second row always has a non-empty child
+        ObjectNode row2 = JsonNodeFactory.instance.objectNode();
+        ArrayNode innerData2 = JsonNodeFactory.instance.arrayNode();
+        ObjectNode item2 = JsonNodeFactory.instance.objectNode();
+        item2.put("name", "Bob");
+        item2.put("value", "2");
+        innerData2.add(item2);
+        row2.set("items", innerData2);
+        outer.add(row2);
+
+        return outer;
+    }
+
+    /** Build a simple flat array with name and score fields. */
+    private ArrayNode buildFlatData(String[][] rows) {
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (String[] row : rows) {
+            ObjectNode obj = JsonNodeFactory.instance.objectNode();
+            obj.put("name", row[0]);
+            obj.put("score", row[1]);
+            data.add(obj);
+        }
+        return data;
+    }
+
+    private RelationLayout buildLayout(Relation schema) {
+        RelationStyle relStyle = TestLayouts.mockRelationStyle();
+        return new RelationLayout(schema, relStyle);
+    }
+
+    // -----------------------------------------------------------------------
+    // hide-if-empty: stylesheet overrides null Relation.getHideIfEmpty()
+    // -----------------------------------------------------------------------
+
+    @Test
+    void hideIfEmptyFromStylesheetOverridesNullRelationValue() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("value"));
+        // Relation has no hideIfEmpty set (null)
+        assertNull(schema.getHideIfEmpty(), "precondition: Relation.hideIfEmpty must be null");
+
+        SchemaPath path = new SchemaPath("items");
+
+        LayoutStylesheet stylesheet = mock(LayoutStylesheet.class);
+        when(stylesheet.getBoolean(eq(path), eq(LayoutPropertyKeys.HIDE_IF_EMPTY), anyBoolean()))
+            .thenReturn(true);
+        // Return empty string for sort-fields and pivot-field to avoid side effects
+        when(stylesheet.getString(any(), any(), any())).thenReturn("");
+
+        Style model = buildMockModel(schema, stylesheet);
+
+        RelationLayout layout = buildLayout(schema);
+        layout.buildPaths(path, model);
+
+        // Build data where all rows have empty nested arrays — but schema is flat here,
+        // so use a simple ArrayNode. hideIfEmpty on a flat schema is irrelevant to
+        // filtering (hasNonEmptyChildren returns true when no Relation children exist).
+        // To test the routing, verify that stylesheet.getBoolean was called.
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ObjectNode row = JsonNodeFactory.instance.objectNode();
+        row.put("name", "Alice");
+        row.put("value", "1");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+
+        // Verify stylesheet was consulted for hide-if-empty
+        verify(stylesheet, atLeastOnce())
+            .getBoolean(eq(path), eq(LayoutPropertyKeys.HIDE_IF_EMPTY), anyBoolean());
+    }
+
+    // -----------------------------------------------------------------------
+    // hide-if-empty: Relation value overrides stylesheet when non-null
+    // -----------------------------------------------------------------------
+
+    @Test
+    void hideIfEmptyFromRelationOverridesStylesheetWhenNonNull() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("value"));
+        // Relation explicitly sets hideIfEmpty=false
+        schema.setHideIfEmpty(false);
+
+        SchemaPath path = new SchemaPath("items");
+
+        LayoutStylesheet stylesheet = mock(LayoutStylesheet.class);
+        // Stylesheet says true — but Relation says false, so stylesheet must NOT be consulted
+        // for hide-if-empty (Relation takes priority when non-null).
+        when(stylesheet.getString(any(), any(), any())).thenReturn("");
+
+        Style model = buildMockModel(schema, stylesheet);
+
+        RelationLayout layout = buildLayout(schema);
+        layout.buildPaths(path, model);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ObjectNode row = JsonNodeFactory.instance.objectNode();
+        row.put("name", "Alice");
+        row.put("value", "1");
+        data.add(row);
+
+        layout.measure(data, n -> n, model);
+
+        // Stylesheet must NOT be called for hide-if-empty when Relation value is non-null
+        verify(stylesheet, never())
+            .getBoolean(eq(path), eq(LayoutPropertyKeys.HIDE_IF_EMPTY), anyBoolean());
+    }
+
+    // -----------------------------------------------------------------------
+    // sort-fields: stylesheet parses comma-separated string
+    // -----------------------------------------------------------------------
+
+    @Test
+    void sortFieldsFromStylesheetParsesCommaSeparatedString() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("score"));
+        // Relation has no sortFields
+        assertEquals(List.of(), schema.getSortFields(), "precondition: Relation.sortFields must be empty");
+
+        SchemaPath path = new SchemaPath("items");
+
+        DefaultLayoutStylesheet stylesheet = new DefaultLayoutStylesheet(new Style());
+        // Set sort-fields via stylesheet: "score" (single field, sorts descending by score position)
+        stylesheet.setOverride(path, LayoutPropertyKeys.SORT_FIELDS, "name");
+
+        Style model = buildMockModel(schema, stylesheet);
+
+        RelationLayout layout = buildLayout(schema);
+        layout.buildPaths(path, model);
+
+        ArrayNode data = buildFlatData(new String[][] {
+            { "Charlie", "30" },
+            { "Alice",   "10" },
+            { "Bob",     "20" }
+        });
+
+        layout.measure(data, n -> n, model);
+
+        // Retrieve sorted data
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set("items", data);
+        JsonNode extracted = layout.extractFrom(parent);
+
+        List<String> names = new java.util.ArrayList<>();
+        extracted.forEach(row -> names.add(row.get("name").asText()));
+
+        // Stylesheet said sort by "name" — should be alphabetical
+        assertEquals(List.of("Alice", "Bob", "Charlie"), names,
+                     "sort-fields from stylesheet must sort by the specified field");
+    }
+
+    @Test
+    void sortFieldsFromStylesheetParsesMultipleCommaSeparatedFields() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("group"));
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("score"));
+        assertEquals(List.of(), schema.getSortFields(), "precondition: Relation.sortFields must be empty");
+
+        SchemaPath path = new SchemaPath("items");
+
+        DefaultLayoutStylesheet stylesheet = new DefaultLayoutStylesheet(new Style());
+        // Multiple fields: sort by group then name
+        stylesheet.setOverride(path, LayoutPropertyKeys.SORT_FIELDS, "group,name");
+
+        Style model = buildMockModel(schema, stylesheet);
+
+        RelationLayout layout = buildLayout(schema);
+        layout.buildPaths(path, model);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        // group=B, name=Alice
+        ObjectNode r1 = JsonNodeFactory.instance.objectNode();
+        r1.put("group", "B"); r1.put("name", "Alice"); r1.put("score", "1");
+        data.add(r1);
+        // group=A, name=Zed
+        ObjectNode r2 = JsonNodeFactory.instance.objectNode();
+        r2.put("group", "A"); r2.put("name", "Zed"); r2.put("score", "2");
+        data.add(r2);
+        // group=A, name=Alpha
+        ObjectNode r3 = JsonNodeFactory.instance.objectNode();
+        r3.put("group", "A"); r3.put("name", "Alpha"); r3.put("score", "3");
+        data.add(r3);
+
+        layout.measure(data, n -> n, model);
+
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set("items", data);
+        JsonNode extracted = layout.extractFrom(parent);
+
+        List<String> names = new java.util.ArrayList<>();
+        extracted.forEach(row -> names.add(row.get("name").asText()));
+
+        // Sort by group then name: A/Alpha, A/Zed, B/Alice
+        assertEquals(List.of("Alpha", "Zed", "Alice"), names,
+                     "comma-separated sort-fields from stylesheet must apply multi-field sort");
+    }
+
+    // -----------------------------------------------------------------------
+    // sort-fields: Relation overrides stylesheet when non-empty
+    // -----------------------------------------------------------------------
+
+    @Test
+    void sortFieldsFromRelationOverridesStylesheetWhenNonEmpty() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("score"));
+        // Relation explicitly sets sortFields
+        schema.setSortFields(List.of("score"));
+
+        SchemaPath path = new SchemaPath("items");
+
+        LayoutStylesheet stylesheet = mock(LayoutStylesheet.class);
+        // Stylesheet says sort by "name" — but Relation says "score", Relation wins
+        when(stylesheet.getString(eq(path), eq(LayoutPropertyKeys.SORT_FIELDS), any()))
+            .thenReturn("name");
+        // Return sensible defaults for all other stylesheet queries
+        when(stylesheet.getString(any(), any(), any())).thenReturn("");
+        when(stylesheet.getBoolean(any(), any(), anyBoolean())).thenReturn(false);
+        when(stylesheet.getDouble(any(), any(), anyDouble())).thenReturn(0.0);
+        when(stylesheet.getInt(any(), any(), anyInt())).thenReturn(0);
+
+        Style model = buildMockModel(schema, stylesheet);
+
+        RelationLayout layout = buildLayout(schema);
+        layout.buildPaths(path, model);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ObjectNode r1 = JsonNodeFactory.instance.objectNode();
+        r1.put("name", "Charlie"); r1.put("score", "30"); data.add(r1);
+        ObjectNode r2 = JsonNodeFactory.instance.objectNode();
+        r2.put("name", "Alice"); r2.put("score", "10"); data.add(r2);
+        ObjectNode r3 = JsonNodeFactory.instance.objectNode();
+        r3.put("name", "Bob"); r3.put("score", "20"); data.add(r3);
+
+        layout.measure(data, n -> n, model);
+
+        ObjectNode parent = JsonNodeFactory.instance.objectNode();
+        parent.set("items", data);
+        JsonNode extracted = layout.extractFrom(parent);
+
+        List<String> scores = new java.util.ArrayList<>();
+        extracted.forEach(row -> scores.add(row.get("score").asText()));
+
+        // Relation.sortFields=[score] must win over stylesheet sort-by-name
+        assertEquals(List.of("10", "20", "30"), scores,
+                     "Relation.sortFields must override stylesheet sort-fields when non-empty");
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/VisiblePropertyTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/VisiblePropertyTest.java
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Tests for Kramer-9cy: visible property in the layout pipeline.
+ * visible=true (default) includes field; visible=false excludes it.
+ */
+class VisiblePropertyTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private Style mockModel(Relation schema) {
+        Style model = mock(Style.class);
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        RelationStyle relStyle   = TestLayouts.mockRelationStyle();
+
+        when(model.layout(any(SchemaNode.class))).thenAnswer(inv -> {
+            SchemaNode n = inv.getArgument(0);
+            if (n instanceof Primitive p) return new PrimitiveLayout(p, primStyle);
+            if (n instanceof Relation  r) return new RelationLayout(r, relStyle);
+            return null;
+        });
+        return model;
+    }
+
+    private RelationLayout buildLayout(Relation schema) {
+        RelationStyle style = TestLayouts.mockRelationStyle();
+        return new RelationLayout(schema, style);
+    }
+
+    /** Build a single-row ArrayNode with name + description fields. */
+    private ArrayNode buildData(String name, String description) {
+        ObjectNode row = JsonNodeFactory.instance.objectNode();
+        row.put("name",        name);
+        row.put("description", description);
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add(row);
+        return data;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: visible=true (default) includes all children in layout
+    // -----------------------------------------------------------------------
+
+    /**
+     * When no visible override is set, both children must appear in the
+     * children list after measure().
+     */
+    @Test
+    void visibleTrueDefaultIncludesAllChildren() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("description"));
+
+        RelationLayout layout = buildLayout(schema);
+
+        // Wire a real Style with a real DefaultLayoutStylesheet — no overrides.
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        Style model = mockModel(schema);
+        when(model.getStylesheet()).thenReturn(sheet);
+
+        SchemaPath root = new SchemaPath("items");
+        layout.setSchemaPath(root);
+
+        ArrayNode data = buildData("Alice", "A longer description");
+        layout.measure(data, n -> n, model);
+
+        // Both children must be present
+        assertEquals(2, layout.getChildren().size(),
+                     "visible=true (default) must include both children");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: visible=false excludes the child from RelationLayout iteration
+    // -----------------------------------------------------------------------
+
+    /**
+     * When visible=false is set on a child's path, that child must be skipped
+     * during measure() — it does not appear in children and does not
+     * contribute to columnWidth.
+     */
+    @Test
+    void visibleFalseExcludesChildFromRelationLayout() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("description"));
+
+        RelationLayout layout = buildLayout(schema);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        // Mark the "description" child as not visible.
+        SchemaPath descPath = new SchemaPath("items", "description");
+        sheet.setOverride(descPath, LayoutPropertyKeys.VISIBLE, false);
+
+        Style model = mockModel(schema);
+        when(model.getStylesheet()).thenReturn(sheet);
+
+        SchemaPath root = new SchemaPath("items");
+        layout.setSchemaPath(root);
+
+        ArrayNode data = buildData("Alice", "A longer description");
+        layout.measure(data, n -> n, model);
+
+        // Only the "name" child should be present
+        assertEquals(1, layout.getChildren().size(),
+                     "visible=false must exclude child from RelationLayout");
+        SchemaNodeLayout only = layout.getChildren().get(0);
+        assertTrue(only instanceof PrimitiveLayout,
+                   "Remaining child must be PrimitiveLayout for 'name'");
+        assertEquals("name", only.getNode().getField(),
+                     "Remaining child must be the 'name' field");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: visible=false on a primitive produces zero width/height contribution
+    // -----------------------------------------------------------------------
+
+    /**
+     * When visible=false is set on a PrimitiveLayout's own path, measure()
+     * must return 0 (no width contribution).
+     */
+    @Test
+    void visibleFalseOnPrimitiveProducesZeroWidth() {
+        Primitive prim = new Primitive("description");
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(prim, primStyle);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("items", "description");
+        sheet.setOverride(path, LayoutPropertyKeys.VISIBLE, false);
+        layout.setSchemaPath(path);
+
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("A very long description that would normally occupy space");
+
+        double width = layout.measure(data, n -> n, model);
+
+        assertEquals(0.0, width, 1e-9,
+                     "visible=false on primitive must return 0 width");
+
+        MeasureResult mr = layout.getMeasureResult();
+        assertNotNull(mr, "MeasureResult must be non-null even when invisible");
+        assertEquals(0.0, mr.columnWidth(), 1e-9,
+                     "MeasureResult.columnWidth must be 0 when visible=false");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: visible=false does not affect siblings
+    // -----------------------------------------------------------------------
+
+    /**
+     * Marking one child invisible must not change the measured width of a
+     * visible sibling. The visible child's column width must be positive.
+     */
+    @Test
+    void visibleFalseDoesNotAffectSiblings() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("description"));
+
+        RelationLayout layout = buildLayout(schema);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath descPath = new SchemaPath("items", "description");
+        sheet.setOverride(descPath, LayoutPropertyKeys.VISIBLE, false);
+
+        Style model = mockModel(schema);
+        when(model.getStylesheet()).thenReturn(sheet);
+
+        SchemaPath root = new SchemaPath("items");
+        layout.setSchemaPath(root);
+
+        ArrayNode data = buildData("Alice", "A long description text");
+        layout.measure(data, n -> n, model);
+
+        assertEquals(1, layout.getChildren().size(),
+                     "Only one visible child should remain");
+        SchemaNodeLayout visibleChild = layout.getChildren().get(0);
+        assertTrue(visibleChild.columnWidth() > 0,
+                   "Visible sibling 'name' must have positive column width");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: visible=true explicit (same as default) still includes child
+    // -----------------------------------------------------------------------
+
+    @Test
+    void visibleTrueExplicitIncludesChild() {
+        Relation schema = new Relation("items");
+        schema.addChild(new Primitive("name"));
+        schema.addChild(new Primitive("description"));
+
+        RelationLayout layout = buildLayout(schema);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        // Explicitly set visible=true (same as the default)
+        SchemaPath descPath = new SchemaPath("items", "description");
+        sheet.setOverride(descPath, LayoutPropertyKeys.VISIBLE, true);
+
+        Style model = mockModel(schema);
+        when(model.getStylesheet()).thenReturn(sheet);
+
+        SchemaPath root = new SchemaPath("items");
+        layout.setSchemaPath(root);
+
+        ArrayNode data = buildData("Alice", "A description");
+        layout.measure(data, n -> n, model);
+
+        assertEquals(2, layout.getChildren().size(),
+                     "visible=true explicit must include both children");
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-018** (Kramer-xu1): Route hide-if-empty/sort-fields through LayoutStylesheet with Relation fallback
- **RDR-018** (Kramer-9cy): `visible` property — invisible fields excluded from measure/layout
- **RDR-019** (Kramer-l6d): Array-vs-scalar bifurcation — scalar→BAR, array-of-numbers→SPARKLINE, mixed→TEXT. SparklineStats with flattened q1/q3.
- **RDR-011** (Kramer-5d9): `LayoutRenderer<T>` interface + `AbstractLayoutRenderer` tree-walk with fieldName-based child data extraction

## Test plan
- [x] 485 tests pass (23 new)

Ref: Kramer-xu1, Kramer-9cy, Kramer-l6d, Kramer-5d9