### PR TITLE
Wave 3 Batch 3: cache version, SparklineStyle, JavaFxLayoutRenderer

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -375,7 +375,8 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         int dataCardinality = zeeData != null ? zeeData.size() : 0;
         SchemaPath rootPath = layout.getSchemaPath();
         if (allConverged() && rootPath != null && layout instanceof RelationLayout) {
-            LayoutDecisionKey key = LayoutDecisionKey.of(rootPath, width, dataCardinality);
+            LayoutDecisionKey key = LayoutDecisionKey.of(rootPath, width, dataCardinality,
+                                                         model.getStylesheet().getVersion());
             if (decisionCache.containsKey(key)) {
                 buildAndInstallControl(zeeData, width);
                 return;
@@ -413,7 +414,8 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         // Cache the layout decision for this width bucket.
         // Use snapshotLayoutResult() to read existing state without re-running layout().
         if (rootPath != null) {
-            LayoutDecisionKey key = LayoutDecisionKey.of(rootPath, width, dataCardinality);
+            LayoutDecisionKey key = LayoutDecisionKey.of(rootPath, width, dataCardinality,
+                                                         model.getStylesheet().getVersion());
             if (!decisionCache.containsKey(key) && layout instanceof RelationLayout rl) {
                 decisionCache.put(key, rl.snapshotLayoutResult());
             }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/JavaFxLayoutRenderer.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/JavaFxLayoutRenderer.java
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+
+import com.chiralbehaviors.layout.schema.SchemaNode;
+
+/**
+ * Proof-of-concept {@link LayoutRenderer} that produces a JavaFX {@link Node}
+ * tree from a {@link LayoutDecisionNode}.
+ * <p>
+ * Leaf nodes are rendered as a {@link Label} whose text is the scalar value of
+ * {@code data}. Interior nodes are rendered as a {@link VBox} that contains the
+ * rendered children in order. Both node types receive a CSS style class derived
+ * from the sanitized {@code fieldName}.
+ * <p>
+ * This renderer demonstrates the {@link AbstractLayoutRenderer} protocol and is
+ * intentionally simple. The production rendering path continues to use
+ * {@code buildControl()} via the existing layout engine.
+ */
+public class JavaFxLayoutRenderer extends AbstractLayoutRenderer<Node> {
+
+    @Override
+    protected Node renderPrimitive(LayoutDecisionNode node, JsonNode data) {
+        var label = new Label(data != null ? SchemaNode.asText(data) : "");
+        label.getStyleClass().add(SchemaPath.sanitize(node.fieldName()));
+        return label;
+    }
+
+    @Override
+    protected Node renderRelation(LayoutDecisionNode node, JsonNode data, List<Node> children) {
+        var container = new VBox();
+        container.getStyleClass().add(SchemaPath.sanitize(node.fieldName()));
+        container.getChildren().addAll(children);
+        return container;
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutDecisionKey.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutDecisionKey.java
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.chiralbehaviors.layout;
 
-/**
- * Cache key for the layout decision cache in {@link AutoLayout}.
- * Bucketing width to the nearest 10px prevents thrashing on sub-pixel resize
- * events while still producing distinct keys across meaningful width changes.
- *
- * <p>The record's generated {@code equals} and {@code hashCode} make it safe
- * to use directly as a {@link java.util.HashMap} key.
- */
-public record LayoutDecisionKey(SchemaPath path, int widthBucket, int dataCardinality) {
+public record LayoutDecisionKey(SchemaPath path, int widthBucket, int dataCardinality, long stylesheetVersion) {
 
     /**
-     * Creates a key from a schema path, a raw pixel width, and an item count.
+     * Creates a key from a schema path, a raw pixel width, an item count, and a stylesheet version.
      * Width is bucketed by truncating {@code width / 10} to an integer.
      */
-    public static LayoutDecisionKey of(SchemaPath path, double width, int itemCount) {
+    public static LayoutDecisionKey of(SchemaPath path, double width, int itemCount, long stylesheetVersion) {
         assert width >= 0 : "width must be non-negative";
-        return new LayoutDecisionKey(path, (int) (width / 10), itemCount);
+        return new LayoutDecisionKey(path, (int) (width / 10), itemCount, stylesheetVersion);
+    }
+
+    /**
+     * Convenience overload that uses stylesheet version 0 (no stylesheet discrimination).
+     * Preserved for callers that pre-date stylesheet versioning.
+     */
+    public static LayoutDecisionKey of(SchemaPath path, double width, int itemCount) {
+        return of(path, width, itemCount, 0L);
     }
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -32,6 +32,7 @@ import com.chiralbehaviors.layout.schema.Primitive;
 import com.chiralbehaviors.layout.style.PrimitiveStyle;
 import com.chiralbehaviors.layout.style.PrimitiveStyle.PrimitiveBarStyle;
 import com.chiralbehaviors.layout.style.PrimitiveStyle.PrimitiveBadgeStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle.PrimitiveSparklineStyle;
 import com.chiralbehaviors.layout.style.Style;
 import com.chiralbehaviors.layout.table.ColumnHeader;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -60,8 +61,9 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     private List<String>           badgeValues               = null;
 
     // Cached style instances — re-used across buildControl() calls to avoid per-call allocation
-    private PrimitiveBarStyle      cachedBarStyle;
-    private PrimitiveBadgeStyle    cachedBadgeStyle;
+    private PrimitiveBarStyle        cachedBarStyle;
+    private PrimitiveBadgeStyle      cachedBadgeStyle;
+    private PrimitiveSparklineStyle  cachedSparklineStyle;
 
     // Convergence detection state (Kramer-16k)
     private MeasureResult          frozenResult;
@@ -102,6 +104,15 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     @Override
     public LayoutCell<? extends Region> buildControl(FocusTraversal<?> parentTraversal,
                                                      Style model) {
+        // SPARKLINE must preempt avgCard>1 guard: array-valued data has avgCard>1 by nature
+        if (renderMode == PrimitiveRenderMode.SPARKLINE) {
+            if (cachedSparklineStyle == null) {
+                cachedSparklineStyle = new PrimitiveSparklineStyle(style.getLabelStyle(),
+                                                                    javafx.geometry.Insets.EMPTY,
+                                                                    style.getLabelStyle());
+            }
+            return cachedSparklineStyle.build(parentTraversal, this);
+        }
         int avgCard = measureResult != null ? measureResult.averageCardinality() : averageCardinality;
         if (avgCard > 1) {
             return new PrimitiveList(this, parentTraversal);
@@ -638,6 +649,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         // Invalidate cached style objects so they are rebuilt after a layout cycle.
         cachedBarStyle = null;
         cachedBadgeStyle = null;
+        cachedSparklineStyle = null;
     }
 
     protected double width(JsonNode row) {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
@@ -22,6 +22,7 @@ import static com.chiralbehaviors.layout.cell.control.SelectionEvent.TRIPLE_SELE
 
 import com.chiralbehaviors.layout.MeasureResult;
 import com.chiralbehaviors.layout.NumericStats;
+import com.chiralbehaviors.layout.SparklineStats;
 import com.chiralbehaviors.layout.PrimitiveLayout;
 import com.chiralbehaviors.layout.cell.LayoutCell;
 import com.chiralbehaviors.layout.cell.control.FocusTraversal;
@@ -38,6 +39,8 @@ import javafx.scene.control.Label;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Polyline;
 import javafx.scene.shape.Rectangle;
 import javafx.util.Duration;
 
@@ -321,6 +324,134 @@ abstract public class PrimitiveStyle extends NodeStyle {
                    + primitiveStyle.getHorizontalInset();
         }
 
+    }
+
+    public static class PrimitiveSparklineStyle extends PrimitiveStyle {
+
+        public static final String PRIMITIVE_SPARKLINE_CLASS = "primitive-sparkline";
+
+        private final LabelStyle primitiveStyle;
+
+        public PrimitiveSparklineStyle(LabelStyle labelStyle, Insets listInsets,
+                                       LabelStyle primitiveStyle) {
+            super(labelStyle, listInsets);
+            this.primitiveStyle = primitiveStyle;
+        }
+
+        @Override
+        public LayoutCell<?> build(FocusTraversal<?> pt, PrimitiveLayout p) {
+            StackPane pane = new StackPane();
+            pane.setMinSize(p.getJustifiedWidth(), p.getCellHeight());
+            pane.setPrefSize(p.getJustifiedWidth(), p.getCellHeight());
+            pane.setMaxSize(p.getJustifiedWidth(), p.getCellHeight());
+
+            Polyline line = new Polyline();
+            line.getStyleClass().add("sparkline-line");
+
+            Rectangle band = new Rectangle(0, 0, 0, 0);
+            band.getStyleClass().add("sparkline-band");
+
+            Circle endMarker = new Circle(3);
+            endMarker.getStyleClass().add("sparkline-end-marker");
+
+            pane.getChildren().addAll(band, line, endMarker);
+
+            return new PrimitiveLayoutCell<Region>(p, PRIMITIVE_SPARKLINE_CLASS, pt) {
+                @Override
+                public StackPane getNode() {
+                    return pane;
+                }
+
+                @Override
+                public boolean isReusable() {
+                    return true;
+                }
+
+                @Override
+                public void updateItem(JsonNode item) {
+                    super.updateItem(item);
+                    line.getPoints().clear();
+                    band.setWidth(0);
+                    band.setHeight(0);
+                    endMarker.setVisible(false);
+
+                    if (item == null || item.isNull() || !item.isArray() || item.size() == 0) {
+                        // Fallback: show nothing (or could render text)
+                        return;
+                    }
+
+                    int n = item.size();
+                    double[] values = new double[n];
+                    for (int i = 0; i < n; i++) {
+                        values[i] = item.get(i).asDouble();
+                    }
+
+                    MeasureResult mr = p.getMeasureResult();
+                    SparklineStats stats = (mr != null) ? mr.sparklineStats() : null;
+
+                    double sMin = (stats != null) ? stats.seriesMin() : values[0];
+                    double sMax = (stats != null) ? stats.seriesMax() : values[0];
+                    double q1   = (stats != null) ? stats.q1()        : sMin;
+                    double q3   = (stats != null) ? stats.q3()        : sMax;
+
+                    // Recalculate bounds from cell if no stats
+                    if (stats == null) {
+                        for (double v : values) {
+                            if (v < sMin) sMin = v;
+                            if (v > sMax) sMax = v;
+                        }
+                        q1 = sMin;
+                        q3 = sMax;
+                    }
+
+                    double cellW = p.getJustifiedWidth();
+                    double cellH = p.getCellHeight();
+                    double range = sMax - sMin;
+
+                    // Build polyline points
+                    double[] pts = new double[n * 2];
+                    for (int i = 0; i < n; i++) {
+                        double x = (n == 1) ? cellW / 2.0 : (cellW * i / (n - 1));
+                        double yFrac = (range == 0.0) ? 0.5 : (values[i] - sMin) / range;
+                        double y = cellH - (yFrac * cellH); // invert: high value → low y
+                        pts[i * 2]     = x;
+                        pts[i * 2 + 1] = y;
+                    }
+                    for (double pt2 : pts) {
+                        line.getPoints().add(pt2);
+                    }
+
+                    // IQR band
+                    double q1Frac = (range == 0.0) ? 0.5 : (q1 - sMin) / range;
+                    double q3Frac = (range == 0.0) ? 0.5 : (q3 - sMin) / range;
+                    double bandTop = cellH - (q3Frac * cellH);
+                    double bandBot = cellH - (q1Frac * cellH);
+                    band.setX(0);
+                    band.setY(bandTop);
+                    band.setWidth(cellW);
+                    band.setHeight(Math.max(0, bandBot - bandTop));
+
+                    // End marker at last value
+                    double lastValue = values[n - 1];
+                    double lastFrac  = (range == 0.0) ? 0.5 : (lastValue - sMin) / range;
+                    double markerX   = (n == 1) ? cellW / 2.0 : cellW;
+                    double markerY   = cellH - (lastFrac * cellH);
+                    endMarker.setCenterX(markerX);
+                    endMarker.setCenterY(markerY);
+                    endMarker.setVisible(true);
+                }
+            };
+        }
+
+        @Override
+        public double getHeight(double maxWidth, double justified) {
+            return primitiveStyle.getHeight(1);
+        }
+
+        @Override
+        public double width(JsonNode value) {
+            return 0.0;
+        }
     }
 
     private final Insets listInsets;

--- a/kramer/src/test/java/com/chiralbehaviors/layout/JavaFxLayoutRendererTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/JavaFxLayoutRendererTest.java
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+class JavaFxLayoutRendererTest extends ApplicationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public void start(Stage stage) {
+        // No UI setup needed; we just need the toolkit initialized.
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static LayoutDecisionNode leaf(String name) {
+        var path = new SchemaPath(name);
+        return new LayoutDecisionNode(path, path.leaf(), null, null, null, null, null, null);
+    }
+
+    private static LayoutDecisionNode parent(String name, List<LayoutDecisionNode> children) {
+        var path = new SchemaPath(name);
+        return new LayoutDecisionNode(path, path.leaf(), null, null, null, null, null, children);
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void leafNodeRendersAsLabel() {
+        var renderer = new JavaFxLayoutRenderer();
+        var node = leaf("score");
+        var data = MAPPER.getNodeFactory().textNode("42");
+
+        var result = renderer.render(node, data);
+
+        assertInstanceOf(Label.class, result, "leaf must render as Label");
+        assertEquals("42", ((Label) result).getText());
+    }
+
+    @Test
+    void leafNodeHasFieldNameStyleClass() {
+        var renderer = new JavaFxLayoutRenderer();
+        var node = leaf("score");
+        var data = MAPPER.getNodeFactory().textNode("99");
+
+        var result = (Label) renderer.render(node, data);
+
+        assertTrue(result.getStyleClass().contains("score"),
+                   "Label must carry the sanitized field name as a style class");
+    }
+
+    @Test
+    void relationNodeRendersAsVBox() {
+        var child = leaf("name");
+        var root = parent("person", List.of(child));
+
+        ObjectNode data = MAPPER.createObjectNode();
+        data.put("name", "Alice");
+
+        var renderer = new JavaFxLayoutRenderer();
+        var result = renderer.render(root, data);
+
+        assertInstanceOf(VBox.class, result, "relation must render as VBox");
+        var vbox = (VBox) result;
+        assertEquals(1, vbox.getChildren().size());
+        assertInstanceOf(Label.class, vbox.getChildren().get(0));
+    }
+
+    @Test
+    void relationNodeHasFieldNameStyleClass() {
+        var child = leaf("x");
+        var root = parent("container", List.of(child));
+
+        var renderer = new JavaFxLayoutRenderer();
+        var result = (VBox) renderer.render(root, MAPPER.createObjectNode());
+
+        assertTrue(result.getStyleClass().contains("container"),
+                   "VBox must carry the sanitized field name as a style class");
+    }
+
+    @Test
+    void childDataExtractedViaFieldName() {
+        var child = leaf("status");
+        var root = parent("item", List.of(child));
+
+        ObjectNode data = MAPPER.createObjectNode();
+        data.put("status", "active");
+        data.put("other", "ignored");
+
+        var renderer = new JavaFxLayoutRenderer();
+        var vbox = (VBox) renderer.render(root, data);
+        var label = (Label) vbox.getChildren().get(0);
+
+        assertEquals("active", label.getText(), "child must receive value of 'status' field");
+    }
+
+    @Test
+    void nullDataProducesEmptyLabel() {
+        var renderer = new JavaFxLayoutRenderer();
+        var node = leaf("value");
+
+        var result = (Label) renderer.render(node, null);
+
+        assertEquals("", result.getText(), "null data must produce empty Label text");
+    }
+
+    @Test
+    void multipleChildrenAddedToVBox() {
+        var child1 = leaf("first");
+        var child2 = leaf("second");
+        var root = parent("row", List.of(child1, child2));
+
+        ObjectNode data = MAPPER.createObjectNode();
+        data.put("first", "A");
+        data.put("second", "B");
+
+        var renderer = new JavaFxLayoutRenderer();
+        var vbox = (VBox) renderer.render(root, data);
+
+        assertEquals(2, vbox.getChildren().size());
+        assertEquals("A", ((Label) vbox.getChildren().get(0)).getText());
+        assertEquals("B", ((Label) vbox.getChildren().get(1)).getText());
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionCacheTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/LayoutDecisionCacheTest.java
@@ -121,6 +121,30 @@ class LayoutDecisionCacheTest {
                    "A key with different cardinality must not hit the old cache entry");
     }
 
+    // ---- stylesheetVersion discrimination ----
+
+    @Test
+    void differentStylesheetVersionProducesDifferentKey() {
+        var path = new SchemaPath("root").child("items");
+        var k1 = LayoutDecisionKey.of(path, 250.0, 5, 1L);
+        var k2 = LayoutDecisionKey.of(path, 250.0, 5, 2L);
+        assertNotEquals(k1, k2, "Different stylesheet versions must produce different keys");
+    }
+
+    @Test
+    void cacheMissWhenStylesheetVersionChanges() {
+        Map<LayoutDecisionKey, LayoutResult> cache = new HashMap<>();
+
+        var path = new SchemaPath("root");
+        var result = new LayoutResult(RelationRenderMode.TABLE, PrimitiveRenderMode.TEXT, false, 120.0, 0.0, 100.0, List.of());
+
+        cache.put(LayoutDecisionKey.of(path, 300.0, 4, 1L), result);
+
+        // Same path/width/cardinality but incremented stylesheet version → miss
+        var newKey = LayoutDecisionKey.of(path, 300.0, 4, 2L);
+        assertNull(cache.get(newKey), "Incremented stylesheet version must miss the old cache entry");
+    }
+
     // ---- widthBucket boundary conditions ----
 
     @Test

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SparklineStyleTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SparklineStyleTest.java
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.cell.LayoutCell;
+import com.chiralbehaviors.layout.cell.control.FocusTraversal;
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.LabelStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle.PrimitiveSparklineStyle;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+import javafx.geometry.Insets;
+import javafx.scene.layout.StackPane;
+
+/**
+ * Tests for Kramer-t92: PrimitiveSparklineStyle and SparklineCell.
+ */
+class SparklineStyleTest {
+
+    // ---- class structure ----
+
+    @Test
+    void primitiveSparklineStyleExistsAsStaticInnerClass() {
+        Class<?> enclosing = PrimitiveSparklineStyle.class.getEnclosingClass();
+        assertNotNull(enclosing, "PrimitiveSparklineStyle must be an inner class");
+        assertEquals(PrimitiveStyle.class, enclosing,
+                     "PrimitiveSparklineStyle must be enclosed in PrimitiveStyle");
+        assertTrue(java.lang.reflect.Modifier.isStatic(PrimitiveSparklineStyle.class.getModifiers()),
+                   "PrimitiveSparklineStyle must be a static inner class");
+        assertTrue(java.lang.reflect.Modifier.isPublic(PrimitiveSparklineStyle.class.getModifiers()),
+                   "PrimitiveSparklineStyle must be public");
+    }
+
+    @Test
+    void primitiveSparklineStyleExtendsPrimitiveStyle() {
+        assertTrue(PrimitiveStyle.class.isAssignableFrom(PrimitiveSparklineStyle.class),
+                   "PrimitiveSparklineStyle must extend PrimitiveStyle");
+    }
+
+    // ---- width() returns 0.0 ----
+
+    @Test
+    void widthReturnsZero() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight(anyDouble())).thenReturn(20.0);
+
+        PrimitiveSparklineStyle sparklineStyle = new PrimitiveSparklineStyle(labelStyle,
+                                                                              Insets.EMPTY,
+                                                                              labelStyle);
+        double w = sparklineStyle.width(JsonNodeFactory.instance.arrayNode());
+        assertEquals(0.0, w, 1e-9, "PrimitiveSparklineStyle.width() must return 0.0");
+    }
+
+    @Test
+    void widthReturnsZeroForNull() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight(anyDouble())).thenReturn(20.0);
+
+        PrimitiveSparklineStyle sparklineStyle = new PrimitiveSparklineStyle(labelStyle,
+                                                                              Insets.EMPTY,
+                                                                              labelStyle);
+        double w = sparklineStyle.width(JsonNodeFactory.instance.nullNode());
+        assertEquals(0.0, w, 1e-9, "PrimitiveSparklineStyle.width() must return 0.0 for null node");
+    }
+
+    // ---- getHeight returns single-line height ----
+
+    @Test
+    void getHeightReturnsSingleLineHeight() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight(anyDouble())).thenReturn(20.0);
+
+        PrimitiveSparklineStyle sparklineStyle = new PrimitiveSparklineStyle(labelStyle,
+                                                                              Insets.EMPTY,
+                                                                              labelStyle);
+        double height = sparklineStyle.getHeight(1000.0, 200.0);
+        assertEquals(20.0, height, 1e-9,
+                     "SPARKLINE height must be single line (primitiveStyle.getHeight(1))");
+    }
+
+    @Test
+    void getHeightIgnoresMaxAndJustifiedArguments() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight(anyDouble())).thenReturn(15.0);
+
+        PrimitiveSparklineStyle sparklineStyle = new PrimitiveSparklineStyle(labelStyle,
+                                                                              Insets.EMPTY,
+                                                                              labelStyle);
+        double h1 = sparklineStyle.getHeight(100.0, 50.0);
+        double h2 = sparklineStyle.getHeight(9999.0, 1.0);
+        assertEquals(h1, h2, 1e-9,
+                     "SPARKLINE height must not depend on maxWidth or justified arguments");
+    }
+
+    // ---- build() returns a LayoutCell with StackPane root ----
+
+    @Test
+    void buildReturnsLayoutCellWithStackPaneRoot() {
+        LabelStyle labelStyle = mock(LabelStyle.class);
+        when(labelStyle.getHeight(anyDouble())).thenReturn(20.0);
+        when(labelStyle.getHeight()).thenReturn(20.0);
+
+        PrimitiveSparklineStyle sparklineStyle = new PrimitiveSparklineStyle(labelStyle,
+                                                                              Insets.EMPTY,
+                                                                              labelStyle);
+
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("values"), primStyle);
+
+        // Measure with array-of-numbers data to set sparklineStats + renderMode
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ArrayNode series = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 5; i++) {
+            series.add((double) i);
+        }
+        data.add(series);
+
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        layout.measure(data, n -> n, model);
+        layout.justify(200.0);
+        layout.cellHeight(1, 200.0);
+
+        @SuppressWarnings("unchecked")
+        FocusTraversal<?> ft = mock(FocusTraversal.class);
+
+        LayoutCell<?> cell = sparklineStyle.build(ft, layout);
+        assertNotNull(cell, "build() must return a non-null LayoutCell");
+        assertNotNull(cell.getNode(), "cell.getNode() must not be null");
+        assertInstanceOf(StackPane.class, cell.getNode(),
+                         "cell root must be a StackPane");
+    }
+
+    // ---- buildControl() dispatches to SparklineStyle when renderMode == SPARKLINE ----
+
+    @Test
+    void buildControlDispatchesToSparklineStyleWhenRenderModeSPARKLINE() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("values"), primStyle);
+
+        // Build array-of-numbers data to trigger SPARKLINE detection
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int row = 0; row < 5; row++) {
+            ArrayNode series = JsonNodeFactory.instance.arrayNode();
+            for (int i = 1; i <= 5; i++) {
+                series.add((double) (row * 5 + i));
+            }
+            data.add(series);
+        }
+
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                     "Precondition: renderMode must be SPARKLINE for array-of-numbers data");
+    }
+
+    @Test
+    void buildControlDispatchesToSparklineBeforeAvgCardGuard() {
+        // This verifies the SPARKLINE preempts avgCard>1 guard (audit finding C1).
+        // If SPARKLINE did NOT preempt the guard, avgCard>1 would redirect to PrimitiveList
+        // for array-valued data — the returned cell would not be a StackPane.
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("series"), primStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int row = 0; row < 3; row++) {
+            ArrayNode series = JsonNodeFactory.instance.arrayNode();
+            for (int i = 1; i <= 4; i++) {
+                series.add((double) i);
+            }
+            data.add(series);
+        }
+
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        layout.measure(data, n -> n, model);
+        layout.justify(200.0);
+        layout.cellHeight(1, 200.0);
+
+        assertEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                     "Precondition: renderMode must be SPARKLINE");
+
+        @SuppressWarnings("unchecked")
+        FocusTraversal<?> ft = mock(FocusTraversal.class);
+        LayoutCell<?> cell = layout.buildControl(ft, model);
+
+        assertNotNull(cell, "buildControl() must return non-null cell for SPARKLINE");
+        assertInstanceOf(StackPane.class, cell.getNode(),
+                         "buildControl() for SPARKLINE must return StackPane — not PrimitiveList (avgCard>1 must not preempt SPARKLINE)");
+    }
+
+    // ---- cachedSparklineStyle is reset in clear() via layout() ----
+
+    @Test
+    void cachedSparklineStyleIsResetAfterLayout() {
+        // Calling layout() invokes clear() which must null cachedSparklineStyle.
+        // We verify indirectly: two buildControl() calls around a layout() cycle
+        // both succeed (no stale state exception).
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("ts"), primStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        ArrayNode series = JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 3; i++) {
+            series.add((double) i);
+        }
+        data.add(series);
+
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        layout.measure(data, n -> n, model);
+        layout.justify(100.0);
+        layout.cellHeight(1, 100.0);
+
+        @SuppressWarnings("unchecked")
+        FocusTraversal<?> ft = mock(FocusTraversal.class);
+
+        // First build
+        LayoutCell<?> cell1 = layout.buildControl(ft, model);
+        assertInstanceOf(StackPane.class, cell1.getNode(), "First call must produce StackPane");
+
+        // layout() → clear() → cachedSparklineStyle = null
+        layout.layout(100.0);
+        layout.measure(data, n -> n, model);
+        layout.justify(100.0);
+        layout.cellHeight(1, 100.0);
+
+        // Second build after reset — must still work
+        LayoutCell<?> cell2 = layout.buildControl(ft, model);
+        assertInstanceOf(StackPane.class, cell2.getNode(), "Second call after clear() must produce StackPane");
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-018** (Kramer-0cp): `LayoutDecisionKey` includes `stylesheetVersion`. **Phase 1 COMPLETE.**
- **RDR-019** (Kramer-t92): `PrimitiveSparklineStyle` — Polyline+Rectangle band+Circle end marker. SPARKLINE preempts avgCard>1 guard. cachedSparklineStyle with clear() reset.
- **RDR-011** (Kramer-gde): `JavaFxLayoutRenderer` — Label for primitives, VBox for relations. Proof-of-concept protocol renderer.

## Test plan
- [x] 504 tests pass (19 new)

Ref: Kramer-0cp, Kramer-t92, Kramer-gde