### PR TITLE
Wave 3 Batch 4: renderViaProtocol + sparkline integration tests

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -356,6 +356,19 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         return Optional.of(layout.snapshotDecisionTree());
     }
 
+    /**
+     * Renders the current layout decision tree via {@link JavaFxLayoutRenderer}.
+     *
+     * <p>Returns {@link Optional#empty()} if no converged layout is available
+     * (same conditions as {@link #getLayoutDecisionTree()}).
+     *
+     * @param data the JSON data node to render
+     * @return an Optional containing the rendered {@link javafx.scene.Node}, or empty
+     */
+    public Optional<javafx.scene.Node> renderViaProtocol(JsonNode data) {
+        return getLayoutDecisionTree().map(tree -> new JavaFxLayoutRenderer().render(tree, data));
+    }
+
     private void autoLayout(JsonNode zeeData, double width) {
         if (width < 10.0) {
             return;

--- a/kramer/src/test/java/com/chiralbehaviors/layout/AutoLayoutDecisionTreeTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/AutoLayoutDecisionTreeTest.java
@@ -4,6 +4,7 @@ package com.chiralbehaviors.layout;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import com.chiralbehaviors.layout.schema.Primitive;
 import com.chiralbehaviors.layout.schema.Relation;
 import com.chiralbehaviors.layout.style.PrimitiveStyle;
 import com.chiralbehaviors.layout.style.RelationStyle;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
@@ -131,6 +133,63 @@ class AutoLayoutDecisionTreeTest {
 
         assertTrue(result.isPresent());
         assertEquals("amount", result.get().fieldName());
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. renderViaProtocol() produces a non-null result when converged (Kramer-giw)
+    //
+    // Note: JavaFxLayoutRenderer requires the JavaFX toolkit (creates Label/VBox),
+    // so we validate the wiring with a toolkit-free stub renderer that returns
+    // a plain Object. The contract being tested is:
+    //   getLayoutDecisionTree() present → renderViaProtocol returns non-null
+    // -----------------------------------------------------------------------
+
+    /** Toolkit-free stub renderer for testing the rendering protocol wiring. */
+    private static class StubRenderer extends AbstractLayoutRenderer<Object> {
+        @Override
+        protected Object renderPrimitive(LayoutDecisionNode node, JsonNode data) {
+            return "primitive:" + node.fieldName();
+        }
+
+        @Override
+        protected Object renderRelation(LayoutDecisionNode node, JsonNode data,
+                                        List<Object> children) {
+            return "relation:" + node.fieldName() + "[" + children.size() + "]";
+        }
+    }
+
+    @Test
+    void renderViaProtocolProducesNonNullResultWhenConverged() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+
+        Primitive p = new Primitive("title");
+        PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+        SchemaPath path = new SchemaPath("root", "title");
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 2);
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 6; i++) {
+            data.add("item" + i);
+        }
+        for (int i = 0; i < 2; i++) {
+            pl.measure(data, n -> n, model);
+        }
+        pl.buildPaths(path, model);
+        assertTrue(pl.isConverged(), "precondition: layout must be converged");
+
+        // Simulate AutoLayout.renderViaProtocol() protocol: converged tree → render
+        Optional<LayoutDecisionNode> tree = getLayoutDecisionTree(pl);
+        assertTrue(tree.isPresent(), "precondition: decision tree must be present");
+
+        // Use stub renderer (no JavaFX toolkit required) to verify rendering wiring
+        Object result = new StubRenderer().render(tree.get(), data);
+        assertNotNull(result, "rendering a converged decision tree must produce a non-null result");
     }
 
     // -----------------------------------------------------------------------

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SparklineIntegrationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SparklineIntegrationTest.java
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.cell.LayoutCell;
+import com.chiralbehaviors.layout.cell.control.FocusTraversal;
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+
+import javafx.scene.layout.StackPane;
+
+/**
+ * Integration tests for Kramer-71q: SPARKLINE dispatch in buildControl().
+ *
+ * Verifies three scenarios from the bead specification:
+ *   1. Array-of-numbers detected as SPARKLINE and buildControl produces sparkline cell
+ *   2. Explicit render-mode=sparkline via stylesheet produces sparkline cell
+ *   3. Scalar numeric stays BAR (not SPARKLINE)
+ */
+class SparklineIntegrationTest {
+
+    // ---- 1. Array-of-numbers → SPARKLINE + buildControl produces sparkline cell ----
+
+    @Test
+    void arrayOfNumbersDetectedAsSparklineAndBuildsSparklineCell() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("series"), primStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int row = 0; row < 4; row++) {
+            ArrayNode series = JsonNodeFactory.instance.arrayNode();
+            for (int i = 1; i <= 5; i++) {
+                series.add((double) (row * 5 + i));
+            }
+            data.add(series);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+        layout.justify(200.0);
+        layout.cellHeight(1, 200.0);
+
+        assertEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                     "Array-of-numbers must be detected as SPARKLINE");
+
+        @SuppressWarnings("unchecked")
+        FocusTraversal<?> ft = mock(FocusTraversal.class);
+        LayoutCell<?> cell = layout.buildControl(ft, model);
+
+        assertNotNull(cell, "buildControl() must return a non-null cell for SPARKLINE");
+        assertInstanceOf(StackPane.class, cell.getNode(),
+                         "buildControl() for SPARKLINE must produce a StackPane (sparkline cell)");
+    }
+
+    // ---- 2. Explicit render-mode=sparkline via stylesheet produces sparkline cell ----
+
+    @Test
+    void explicitSparklineStylesheetOverrideProducesSparklineCell() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("metric"), primStyle);
+
+        SchemaPath path = new SchemaPath("metric");
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "render-mode", "sparkline");
+        layout.buildPaths(path, null);
+
+        // Plain scalar text data — would normally be TEXT, but override forces SPARKLINE
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add("alpha");
+        data.add("beta");
+        data.add("gamma");
+
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+        layout.measure(data, n -> n, model);
+        layout.justify(200.0);
+        layout.cellHeight(1, 200.0);
+
+        assertEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                     "Explicit render-mode=sparkline must force SPARKLINE mode");
+
+        @SuppressWarnings("unchecked")
+        FocusTraversal<?> ft = mock(FocusTraversal.class);
+        LayoutCell<?> cell = layout.buildControl(ft, model);
+
+        assertNotNull(cell, "buildControl() must return a non-null cell");
+        assertInstanceOf(StackPane.class, cell.getNode(),
+                         "Explicit render-mode=sparkline must produce a StackPane (sparkline cell)");
+    }
+
+    // ---- 3. Scalar numeric → BAR (not SPARKLINE) ----
+
+    @Test
+    void scalarNumericStaysBar() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("score"), primStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        data.add(10.0);
+        data.add(20.0);
+        data.add(30.0);
+        data.add(40.0);
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+
+        assertEquals(PrimitiveRenderMode.BAR, layout.getRenderMode(),
+                     "Scalar numeric values must stay BAR, not upgrade to SPARKLINE");
+        assertNotEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                        "Scalar numeric must not be SPARKLINE");
+    }
+
+    // ---- 4. SPARKLINE preempts avgCard>1 guard ----
+
+    @Test
+    void sparklinePreemptsAvgCardGuard() {
+        // Array-of-numbers has avgCard>1 by nature; SPARKLINE must preempt the guard
+        // so that buildControl() produces a sparkline cell, not a PrimitiveList.
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new Primitive("ts"), primStyle);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int row = 0; row < 3; row++) {
+            ArrayNode series = JsonNodeFactory.instance.arrayNode();
+            for (int i = 0; i < 5; i++) {
+                series.add((double) i);
+            }
+            data.add(series);
+        }
+
+        Style model = mock(Style.class);
+        layout.measure(data, n -> n, model);
+        layout.justify(200.0);
+        layout.cellHeight(1, 200.0);
+
+        assertEquals(PrimitiveRenderMode.SPARKLINE, layout.getRenderMode(),
+                     "Precondition: array-of-numbers must be SPARKLINE");
+
+        // avgCard > 1 because each value is an array; without preemption, PrimitiveList would be returned
+        MeasureResult mr = layout.getMeasureResult();
+        assertNotNull(mr);
+        assertTrue(mr.averageCardinality() > 1,
+                   "Precondition: averageCardinality must be > 1 for array-valued data");
+
+        @SuppressWarnings("unchecked")
+        FocusTraversal<?> ft = mock(FocusTraversal.class);
+        LayoutCell<?> cell = layout.buildControl(ft, model);
+
+        assertNotNull(cell);
+        assertInstanceOf(StackPane.class, cell.getNode(),
+                         "SPARKLINE must preempt avgCard>1 guard — must return StackPane, not PrimitiveList");
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-011** (Kramer-giw): `AutoLayout.renderViaProtocol(JsonNode)` — renders via `JavaFxLayoutRenderer` when `LayoutDecisionNode` available
- **RDR-019** (Kramer-71q): `SparklineIntegrationTest` — 4 end-to-end tests (array→SPARKLINE, scalar→BAR, stylesheet override, avgCard preemption). **Phase 2 COMPLETE.**

## Test plan
- [x] 509 tests pass (5 new)

Ref: Kramer-giw, Kramer-71q