### PR TITLE
Wave 3 Batch 5: HtmlLayoutRenderer + sparkline stylesheet properties

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/HtmlLayoutRenderer.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/HtmlLayoutRenderer.java
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Renders a {@link LayoutDecisionNode} tree to an HTML string.
+ * <p>
+ * Leaf nodes become {@code <span>} elements; interior (relation) nodes become
+ * {@code <div>} elements; array leaf nodes become {@code <ul>/<li>} lists.
+ * All text content is HTML-escaped to prevent XSS.
+ * CSS class names are derived from the field name via
+ * {@link SchemaPath#sanitize(String)}.
+ */
+public class HtmlLayoutRenderer extends AbstractLayoutRenderer<String> {
+
+    @Override
+    protected String renderPrimitive(LayoutDecisionNode node, JsonNode data) {
+        String cssClass = SchemaPath.sanitize(node.fieldName());
+        if (data != null && data.isArray()) {
+            return renderArray(cssClass, data);
+        }
+        String text = data != null ? escapeHtml(data.asText()) : "";
+        return "<span class=\"" + cssClass + "\">" + text + "</span>";
+    }
+
+    @Override
+    protected String renderRelation(LayoutDecisionNode node, JsonNode data, List<String> children) {
+        String cssClass = SchemaPath.sanitize(node.fieldName());
+        return "<div class=\"" + cssClass + "\">" + String.join("", children) + "</div>";
+    }
+
+    private static String renderArray(String cssClass, JsonNode array) {
+        var sb = new StringBuilder();
+        sb.append("<ul class=\"").append(cssClass).append("\">");
+        for (JsonNode item : array) {
+            sb.append("<li>").append(escapeHtml(item.asText())).append("</li>");
+        }
+        sb.append("</ul>");
+        return sb.toString();
+    }
+
+    private static String escapeHtml(String text) {
+        return text.replace("&", "&amp;")
+                   .replace("<", "&lt;")
+                   .replace(">", "&gt;")
+                   .replace("\"", "&quot;");
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutPropertyKeys.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutPropertyKeys.java
@@ -17,5 +17,13 @@ public final class LayoutPropertyKeys {
     public static final String HIDE_IF_EMPTY = "hide-if-empty";
     public static final String SORT_FIELDS  = "sort-fields";
 
+    // Sparkline rendering properties
+    public static final String SPARKLINE_BAND_VISIBLE    = "sparkline-band-visible";
+    public static final String SPARKLINE_END_MARKER      = "sparkline-end-marker";
+    public static final String SPARKLINE_MIN_MAX_MARKERS = "sparkline-min-max-markers";
+    public static final String SPARKLINE_LINE_WIDTH      = "sparkline-line-width";
+    public static final String SPARKLINE_BAND_OPACITY    = "sparkline-band-opacity";
+    public static final String SPARKLINE_MIN_WIDTH       = "sparkline-min-width";
+
     private LayoutPropertyKeys() {}
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -72,6 +72,9 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     private double                 lastP90Width              = Double.NaN;
     private int                    consecutiveStableCount    = 0;
 
+    // Last stylesheet seen during buildControl — used by cell renderers (Kramer-7c4)
+    private LayoutStylesheet       currentStylesheet;
+
     public PrimitiveLayout(Primitive p, PrimitiveStyle style) {
         super(p, style.getLabelStyle());
         this.style = style;
@@ -104,6 +107,7 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
     @Override
     public LayoutCell<? extends Region> buildControl(FocusTraversal<?> parentTraversal,
                                                      Style model) {
+        currentStylesheet = (model != null) ? model.getStylesheet() : null;
         // SPARKLINE must preempt avgCard>1 guard: array-valued data has avgCard>1 by nature
         if (renderMode == PrimitiveRenderMode.SPARKLINE) {
             if (cachedSparklineStyle == null) {
@@ -500,6 +504,15 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
 
     public MeasureResult getMeasureResult() {
         return measureResult;
+    }
+
+    /**
+     * Returns the {@link LayoutStylesheet} last captured during {@link #buildControl}.
+     * May be {@code null} if {@code buildControl} has not yet been called or was called
+     * with a {@code null} model.
+     */
+    public LayoutStylesheet getStylesheet() {
+        return currentStylesheet;
     }
 
     public PrimitiveRenderMode getRenderMode() {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/style/PrimitiveStyle.java
@@ -20,8 +20,11 @@ import static com.chiralbehaviors.layout.cell.control.SelectionEvent.DOUBLE_SELE
 import static com.chiralbehaviors.layout.cell.control.SelectionEvent.SINGLE_SELECT;
 import static com.chiralbehaviors.layout.cell.control.SelectionEvent.TRIPLE_SELECT;
 
+import com.chiralbehaviors.layout.LayoutPropertyKeys;
+import com.chiralbehaviors.layout.LayoutStylesheet;
 import com.chiralbehaviors.layout.MeasureResult;
 import com.chiralbehaviors.layout.NumericStats;
+import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.SparklineStats;
 import com.chiralbehaviors.layout.PrimitiveLayout;
 import com.chiralbehaviors.layout.cell.LayoutCell;
@@ -370,9 +373,29 @@ abstract public class PrimitiveStyle extends NodeStyle {
                 @Override
                 public void updateItem(JsonNode item) {
                     super.updateItem(item);
+                    // Read stylesheet properties (Kramer-7c4)
+                    LayoutStylesheet ss = p.getStylesheet();
+                    SchemaPath path = p.getSchemaPath();
+                    boolean bandVisible = (ss != null && path != null)
+                        ? ss.getBoolean(path, LayoutPropertyKeys.SPARKLINE_BAND_VISIBLE, true)
+                        : true;
+                    boolean endMarkerVisible = (ss != null && path != null)
+                        ? ss.getBoolean(path, LayoutPropertyKeys.SPARKLINE_END_MARKER, true)
+                        : true;
+                    double lineWidth = (ss != null && path != null)
+                        ? ss.getDouble(path, LayoutPropertyKeys.SPARKLINE_LINE_WIDTH, 1.0)
+                        : 1.0;
+                    double bandOpacity = (ss != null && path != null)
+                        ? ss.getDouble(path, LayoutPropertyKeys.SPARKLINE_BAND_OPACITY, 0.15)
+                        : 0.15;
+
+                    line.setStrokeWidth(lineWidth);
+                    band.setOpacity(bandOpacity);
+
                     line.getPoints().clear();
                     band.setWidth(0);
                     band.setHeight(0);
+                    band.setVisible(bandVisible);
                     endMarker.setVisible(false);
 
                     if (item == null || item.isNull() || !item.isArray() || item.size() == 0) {
@@ -438,7 +461,7 @@ abstract public class PrimitiveStyle extends NodeStyle {
                     double markerY   = cellH - (lastFrac * cellH);
                     endMarker.setCenterX(markerX);
                     endMarker.setCenterY(markerY);
-                    endMarker.setVisible(true);
+                    endMarker.setVisible(endMarkerVisible);
                 }
             };
         }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/HtmlLayoutRendererTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/HtmlLayoutRendererTest.java
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+class HtmlLayoutRendererTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static LayoutDecisionNode leaf(String name) {
+        var path = new SchemaPath(name);
+        return new LayoutDecisionNode(path, path.leaf(), null, null, null, null, null, null);
+    }
+
+    private static LayoutDecisionNode parent(String name, List<LayoutDecisionNode> children) {
+        var path = new SchemaPath(name);
+        return new LayoutDecisionNode(path, path.leaf(), null, null, null, null, null, children);
+    }
+
+    @Test
+    void leafNodeRendersAsSpan() {
+        var renderer = new HtmlLayoutRenderer();
+        var node = leaf("score");
+        JsonNode data = MAPPER.getNodeFactory().textNode("42");
+
+        var result = renderer.render(node, data);
+
+        assertEquals("<span class=\"score\">42</span>", result);
+    }
+
+    @Test
+    void relationNodeRendersAsDiv() {
+        var child = leaf("name");
+        var root = parent("person", List.of(child));
+
+        ObjectNode data = MAPPER.createObjectNode();
+        data.put("name", "Alice");
+
+        var renderer = new HtmlLayoutRenderer();
+        var result = renderer.render(root, data);
+
+        assertEquals("<div class=\"person\"><span class=\"name\">Alice</span></div>", result);
+    }
+
+    @Test
+    void nestedTreeProducesCorrectStructure() {
+        var grandchild = leaf("value");
+        var child = parent("nested", List.of(grandchild));
+        var root = parent("top", List.of(child));
+
+        ObjectNode innerData = MAPPER.createObjectNode();
+        innerData.put("value", "deep");
+        ObjectNode outerData = MAPPER.createObjectNode();
+        outerData.set("nested", innerData);
+
+        var renderer = new HtmlLayoutRenderer();
+        var result = renderer.render(root, outerData);
+
+        assertEquals(
+            "<div class=\"top\"><div class=\"nested\"><span class=\"value\">deep</span></div></div>",
+            result);
+    }
+
+    @Test
+    void nullDataRendersEmptySpan() {
+        var renderer = new HtmlLayoutRenderer();
+        var node = leaf("title");
+
+        var result = renderer.render(node, null);
+
+        assertEquals("<span class=\"title\"></span>", result);
+    }
+
+    @Test
+    void cssClassUsesSanitizedFieldName() {
+        var renderer = new HtmlLayoutRenderer();
+        var node = leaf("my field");
+        JsonNode data = MAPPER.getNodeFactory().textNode("x");
+
+        var result = renderer.render(node, data);
+
+        // "my field" sanitizes to "my_field"
+        assertTrue(result.contains("class=\"my_field\""),
+                   "Expected sanitized CSS class in: " + result);
+    }
+
+    @Test
+    void numericLeadingCharacterSanitized() {
+        var renderer = new HtmlLayoutRenderer();
+        var node = leaf("1value");
+        JsonNode data = MAPPER.getNodeFactory().textNode("ok");
+
+        var result = renderer.render(node, data);
+
+        // "1value" sanitizes to "_1value"
+        assertTrue(result.contains("class=\"_1value\""),
+                   "Expected leading-digit sanitization in: " + result);
+    }
+
+    @Test
+    void arrayDataRendersEachItemAsListItem() {
+        var renderer = new HtmlLayoutRenderer();
+        var node = leaf("tags");
+        ArrayNode arr = MAPPER.createArrayNode();
+        arr.add("alpha");
+        arr.add("beta");
+
+        var result = renderer.render(node, arr);
+
+        assertTrue(result.contains("<li>alpha</li>"), "Missing first list item in: " + result);
+        assertTrue(result.contains("<li>beta</li>"), "Missing second list item in: " + result);
+        assertTrue(result.startsWith("<ul class=\"tags\">"), "Missing ul wrapper in: " + result);
+        assertTrue(result.endsWith("</ul>"), "Missing closing ul in: " + result);
+    }
+
+    @Test
+    void htmlSpecialCharactersAreEscaped() {
+        var renderer = new HtmlLayoutRenderer();
+        var node = leaf("content");
+        JsonNode data = MAPPER.getNodeFactory().textNode("<b>bold</b> & \"quoted\"");
+
+        var result = renderer.render(node, data);
+
+        assertTrue(result.contains("&lt;b&gt;bold&lt;/b&gt;"),
+                   "Angle brackets not escaped in: " + result);
+        assertTrue(result.contains("&amp;"),
+                   "Ampersand not escaped in: " + result);
+        assertTrue(result.contains("&quot;quoted&quot;"),
+                   "Quotes not escaped in: " + result);
+    }
+}

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SparklinePropertiesTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SparklinePropertiesTest.java
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.DefaultLayoutStylesheet;
+import com.chiralbehaviors.layout.LayoutPropertyKeys;
+import com.chiralbehaviors.layout.LayoutStylesheet;
+import com.chiralbehaviors.layout.SchemaPath;
+
+/**
+ * Tests for Kramer-7c4: sparkline-specific LayoutStylesheet property constants.
+ */
+class SparklinePropertiesTest {
+
+    // ---- constant values ----
+
+    @Test
+    void sparklineBandVisibleKeyHasCorrectValue() {
+        assertEquals("sparkline-band-visible", LayoutPropertyKeys.SPARKLINE_BAND_VISIBLE);
+    }
+
+    @Test
+    void sparklineEndMarkerKeyHasCorrectValue() {
+        assertEquals("sparkline-end-marker", LayoutPropertyKeys.SPARKLINE_END_MARKER);
+    }
+
+    @Test
+    void sparklineMinMaxMarkersKeyHasCorrectValue() {
+        assertEquals("sparkline-min-max-markers", LayoutPropertyKeys.SPARKLINE_MIN_MAX_MARKERS);
+    }
+
+    @Test
+    void sparklineLineWidthKeyHasCorrectValue() {
+        assertEquals("sparkline-line-width", LayoutPropertyKeys.SPARKLINE_LINE_WIDTH);
+    }
+
+    @Test
+    void sparklineBandOpacityKeyHasCorrectValue() {
+        assertEquals("sparkline-band-opacity", LayoutPropertyKeys.SPARKLINE_BAND_OPACITY);
+    }
+
+    @Test
+    void sparklineMinWidthKeyHasCorrectValue() {
+        assertEquals("sparkline-min-width", LayoutPropertyKeys.SPARKLINE_MIN_WIDTH);
+    }
+
+    // ---- modifier checks ----
+
+    @Test
+    void sparklineConstantsArePublicStaticFinalString() throws NoSuchFieldException {
+        for (String name : new String[]{
+            "SPARKLINE_BAND_VISIBLE",
+            "SPARKLINE_END_MARKER",
+            "SPARKLINE_MIN_MAX_MARKERS",
+            "SPARKLINE_LINE_WIDTH",
+            "SPARKLINE_BAND_OPACITY",
+            "SPARKLINE_MIN_WIDTH"
+        }) {
+            Field f = LayoutPropertyKeys.class.getDeclaredField(name);
+            int mods = f.getModifiers();
+            assertTrue(Modifier.isPublic(mods), name + " must be public");
+            assertTrue(Modifier.isStatic(mods), name + " must be static");
+            assertTrue(Modifier.isFinal(mods), name + " must be final");
+            assertEquals(String.class, f.getType(), name + " must be String");
+        }
+    }
+
+    // ---- default values via DefaultLayoutStylesheet ----
+
+    @Test
+    void sparklineBandVisibleDefaultTrue() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        assertTrue(sheet.getBoolean(path, LayoutPropertyKeys.SPARKLINE_BAND_VISIBLE, true),
+                   "sparkline-band-visible default must be true");
+    }
+
+    @Test
+    void sparklineEndMarkerDefaultTrue() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        assertTrue(sheet.getBoolean(path, LayoutPropertyKeys.SPARKLINE_END_MARKER, true),
+                   "sparkline-end-marker default must be true");
+    }
+
+    @Test
+    void sparklineMinMaxMarkersDefaultFalse() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        assertFalse(sheet.getBoolean(path, LayoutPropertyKeys.SPARKLINE_MIN_MAX_MARKERS, false),
+                    "sparkline-min-max-markers default must be false");
+    }
+
+    @Test
+    void sparklineLineWidthDefaultOne() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        assertEquals(1.0, sheet.getDouble(path, LayoutPropertyKeys.SPARKLINE_LINE_WIDTH, 1.0),
+                     1e-9, "sparkline-line-width default must be 1.0");
+    }
+
+    @Test
+    void sparklineBandOpacityDefaultPointFifteen() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        assertEquals(0.15, sheet.getDouble(path, LayoutPropertyKeys.SPARKLINE_BAND_OPACITY, 0.15),
+                     1e-9, "sparkline-band-opacity default must be 0.15");
+    }
+
+    // ---- stylesheet override honored ----
+
+    @Test
+    void sparklineBandVisibleOverrideFalse() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        sheet.setOverride(path, LayoutPropertyKeys.SPARKLINE_BAND_VISIBLE, false);
+        assertFalse(sheet.getBoolean(path, LayoutPropertyKeys.SPARKLINE_BAND_VISIBLE, true),
+                    "Override false for sparkline-band-visible must be honored");
+    }
+
+    @Test
+    void sparklineEndMarkerOverrideFalse() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        sheet.setOverride(path, LayoutPropertyKeys.SPARKLINE_END_MARKER, false);
+        assertFalse(sheet.getBoolean(path, LayoutPropertyKeys.SPARKLINE_END_MARKER, true),
+                    "Override false for sparkline-end-marker must be honored");
+    }
+
+    @Test
+    void sparklineMinMaxMarkersOverrideTrue() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        sheet.setOverride(path, LayoutPropertyKeys.SPARKLINE_MIN_MAX_MARKERS, true);
+        assertTrue(sheet.getBoolean(path, LayoutPropertyKeys.SPARKLINE_MIN_MAX_MARKERS, false),
+                   "Override true for sparkline-min-max-markers must be honored");
+    }
+
+    @Test
+    void sparklineLineWidthOverride() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        sheet.setOverride(path, LayoutPropertyKeys.SPARKLINE_LINE_WIDTH, 2.5);
+        assertEquals(2.5, sheet.getDouble(path, LayoutPropertyKeys.SPARKLINE_LINE_WIDTH, 1.0),
+                     1e-9, "Override 2.5 for sparkline-line-width must be honored");
+    }
+
+    @Test
+    void sparklineBandOpacityOverride() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath path = new SchemaPath("values");
+        sheet.setOverride(path, LayoutPropertyKeys.SPARKLINE_BAND_OPACITY, 0.5);
+        assertEquals(0.5, sheet.getDouble(path, LayoutPropertyKeys.SPARKLINE_BAND_OPACITY, 0.15),
+                     1e-9, "Override 0.5 for sparkline-band-opacity must be honored");
+    }
+
+    @Test
+    void overrideOnOnePathDoesNotAffectAnother() {
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        SchemaPath pathA = new SchemaPath("values");
+        SchemaPath pathB = new SchemaPath("other");
+        sheet.setOverride(pathA, LayoutPropertyKeys.SPARKLINE_BAND_VISIBLE, false);
+        // pathB must still see the default
+        assertTrue(sheet.getBoolean(pathB, LayoutPropertyKeys.SPARKLINE_BAND_VISIBLE, true),
+                   "Override on pathA must not affect pathB");
+    }
+
+    // ---- PrimitiveLayout.getStylesheet() wires through ----
+
+    @Test
+    void primitiveLayoutGetStylesheetReturnsStylesheetFromBuildControl() {
+        com.chiralbehaviors.layout.style.PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(7.0);
+        PrimitiveLayout layout = new PrimitiveLayout(new com.chiralbehaviors.layout.schema.Primitive("v"), primStyle);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        com.chiralbehaviors.layout.style.Style model = mock(com.chiralbehaviors.layout.style.Style.class);
+        when(model.getStylesheet()).thenReturn(sheet);
+
+        // Before buildControl: should be null or a no-op default
+        // After buildControl: getStylesheet() returns what model.getStylesheet() returned
+
+        // Trigger buildControl to wire the stylesheet
+        com.chiralbehaviors.layout.cell.control.FocusTraversal<?> ft =
+            mock(com.chiralbehaviors.layout.cell.control.FocusTraversal.class);
+
+        // measure + shape to make buildControl work without NPE
+        com.fasterxml.jackson.databind.node.ArrayNode data =
+            com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.arrayNode();
+        com.fasterxml.jackson.databind.node.ArrayNode series =
+            com.fasterxml.jackson.databind.node.JsonNodeFactory.instance.arrayNode();
+        for (int i = 1; i <= 3; i++) series.add((double) i);
+        data.add(series);
+
+        layout.measure(data, n -> n, model);
+        layout.justify(100.0);
+        layout.cellHeight(1, 100.0);
+        layout.buildControl(ft, model);
+
+        assertSame(sheet, layout.getStylesheet(),
+                   "PrimitiveLayout.getStylesheet() must return the stylesheet from the last buildControl call");
+    }
+}


### PR DESCRIPTION
## Summary
- **RDR-011** (Kramer-agd): `HtmlLayoutRenderer` — HTML string output from `LayoutDecisionNode`. XSS-safe. Array data as `<ul>/<li>`.
- **RDR-019** (Kramer-7c4): 6 sparkline LayoutStylesheet properties wired into `PrimitiveSparklineStyle`. **Phase 3 COMPLETE.**

## Test plan
- [x] 536 tests pass (27 new)

Ref: Kramer-agd, Kramer-7c4