### PR TITLE
Wave 3 Batch 6: HtmlLayoutRenderer table mode

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/HtmlLayoutRenderer.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/HtmlLayoutRenderer.java
@@ -8,13 +8,23 @@ import com.fasterxml.jackson.databind.JsonNode;
 /**
  * Renders a {@link LayoutDecisionNode} tree to an HTML string.
  * <p>
- * Leaf nodes become {@code <span>} elements; interior (relation) nodes become
- * {@code <div>} elements; array leaf nodes become {@code <ul>/<li>} lists.
+ * Leaf nodes become {@code <span>} elements; interior (relation) nodes in
+ * outline mode become {@code <div>} elements; relation nodes in table mode
+ * become {@code <table>/<thead>/<tbody>/<tr>/<th>/<td>} elements.
+ * Array leaf nodes become {@code <ul>/<li>} lists.
  * All text content is HTML-escaped to prevent XSS.
  * CSS class names are derived from the field name via
  * {@link SchemaPath#sanitize(String)}.
  */
 public class HtmlLayoutRenderer extends AbstractLayoutRenderer<String> {
+
+    @Override
+    public String render(LayoutDecisionNode node, JsonNode data) {
+        if (!node.childNodes().isEmpty() && isTableMode(node)) {
+            return renderTable(node, data);
+        }
+        return super.render(node, data);
+    }
 
     @Override
     protected String renderPrimitive(LayoutDecisionNode node, JsonNode data) {
@@ -30,6 +40,41 @@ public class HtmlLayoutRenderer extends AbstractLayoutRenderer<String> {
     protected String renderRelation(LayoutDecisionNode node, JsonNode data, List<String> children) {
         String cssClass = SchemaPath.sanitize(node.fieldName());
         return "<div class=\"" + cssClass + "\">" + String.join("", children) + "</div>";
+    }
+
+    private String renderTable(LayoutDecisionNode node, JsonNode data) {
+        String cssClass = SchemaPath.sanitize(node.fieldName());
+        var sb = new StringBuilder();
+        sb.append("<table class=\"").append(cssClass).append("\">");
+
+        // thead
+        sb.append("<thead><tr>");
+        for (var child : node.childNodes()) {
+            sb.append("<th>").append(escapeHtml(child.fieldName())).append("</th>");
+        }
+        sb.append("</tr></thead>");
+
+        // tbody — data is an ArrayNode of row objects
+        sb.append("<tbody>");
+        if (data != null && data.isArray()) {
+            for (JsonNode row : data) {
+                sb.append("<tr>");
+                for (var child : node.childNodes()) {
+                    JsonNode cellData = row.get(child.fieldName());
+                    sb.append("<td>").append(render(child, cellData)).append("</td>");
+                }
+                sb.append("</tr>");
+            }
+        }
+        sb.append("</tbody>");
+
+        sb.append("</table>");
+        return sb.toString();
+    }
+
+    private static boolean isTableMode(LayoutDecisionNode node) {
+        var lr = node.layoutResult();
+        return lr != null && lr.useTable();
     }
 
     private static String renderArray(String cssClass, JsonNode array) {

--- a/kramer/src/test/java/com/chiralbehaviors/layout/HtmlLayoutRendererTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/HtmlLayoutRendererTest.java
@@ -137,4 +137,106 @@ class HtmlLayoutRendererTest {
         assertTrue(result.contains("&quot;quoted&quot;"),
                    "Quotes not escaped in: " + result);
     }
+
+    // --- table mode tests ---
+
+    private static LayoutDecisionNode tableParent(String name, List<LayoutDecisionNode> children) {
+        var path = new SchemaPath(name);
+        var layoutResult = new LayoutResult(
+            RelationRenderMode.TABLE,
+            PrimitiveRenderMode.TEXT,
+            false, 0.0, 0.0, 0.0,
+            List.of()
+        );
+        return new LayoutDecisionNode(path, path.leaf(), null, layoutResult, null, null, null, children);
+    }
+
+    @Test
+    void tableModeRendersAsHtmlTable() {
+        var colA = leaf("name");
+        var colB = leaf("score");
+        var node = tableParent("results", List.of(colA, colB));
+
+        ArrayNode rows = MAPPER.createArrayNode();
+        ObjectNode row = MAPPER.createObjectNode();
+        row.put("name", "Alice");
+        row.put("score", "10");
+        rows.add(row);
+
+        var renderer = new HtmlLayoutRenderer();
+        var result = renderer.render(node, rows);
+
+        assertTrue(result.startsWith("<table"), "Expected <table> element, got: " + result);
+        assertTrue(result.contains("</table>"), "Missing </table> in: " + result);
+        assertFalse(result.contains("<div"), "Should not contain <div> in table mode: " + result);
+    }
+
+    @Test
+    void tableModeRendersColumnHeaders() {
+        var colA = leaf("name");
+        var colB = leaf("age");
+        var node = tableParent("people", List.of(colA, colB));
+
+        ArrayNode rows = MAPPER.createArrayNode();
+        rows.add(MAPPER.createObjectNode());
+
+        var renderer = new HtmlLayoutRenderer();
+        var result = renderer.render(node, rows);
+
+        assertTrue(result.contains("<th"), "Expected <th> header elements in: " + result);
+        assertTrue(result.contains(">name<"), "Expected 'name' header in: " + result);
+        assertTrue(result.contains(">age<"), "Expected 'age' header in: " + result);
+    }
+
+    @Test
+    void tableModeMultipleRowsRenderAsMultipleTr() {
+        var col = leaf("val");
+        var node = tableParent("items", List.of(col));
+
+        ArrayNode rows = MAPPER.createArrayNode();
+        ObjectNode r1 = MAPPER.createObjectNode();
+        r1.put("val", "foo");
+        rows.add(r1);
+        ObjectNode r2 = MAPPER.createObjectNode();
+        r2.put("val", "bar");
+        rows.add(r2);
+        ObjectNode r3 = MAPPER.createObjectNode();
+        r3.put("val", "baz");
+        rows.add(r3);
+
+        var renderer = new HtmlLayoutRenderer();
+        var result = renderer.render(node, rows);
+
+        int trCount = countOccurrences(result, "<tr");
+        // 1 header row + 3 data rows
+        assertEquals(4, trCount, "Expected 4 <tr> elements (1 header + 3 data), got " + trCount + " in: " + result);
+        assertTrue(result.contains(">foo<"), "Missing row value 'foo' in: " + result);
+        assertTrue(result.contains(">bar<"), "Missing row value 'bar' in: " + result);
+        assertTrue(result.contains(">baz<"), "Missing row value 'baz' in: " + result);
+    }
+
+    @Test
+    void outlineModeStillRendersAsDiv() {
+        var child = leaf("name");
+        var root = parent("person", List.of(child));
+
+        ObjectNode data = MAPPER.createObjectNode();
+        data.put("name", "Bob");
+
+        var renderer = new HtmlLayoutRenderer();
+        var result = renderer.render(root, data);
+
+        assertTrue(result.startsWith("<div"), "Outline mode should produce <div>, got: " + result);
+        assertFalse(result.contains("<table"), "Outline mode should not produce <table> in: " + result);
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) != -1) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
+    }
 }


### PR DESCRIPTION
## Summary
- **RDR-011** (Kramer-dxq): `HtmlLayoutRenderer` table mode — `useTable()=true` relations render as `<table>` with headers and data rows. Outline mode unchanged.

## Test plan
- [x] 540 tests pass (4 new)

Ref: Kramer-dxq