### PR TITLE
RDR-019 Phase 4: HTML/SVG sparkline — completes all phases

### DIFF
--- a/docs/rdr/RDR-019-tufte-sparkline-rendering.md
+++ b/docs/rdr/RDR-019-tufte-sparkline-rendering.md
@@ -2,12 +2,11 @@
 
 ## Metadata
 - **Type**: Feature
-- **Status**: closed
+- **Status**: accepted
 - **Priority**: P2
 - **Created**: 2026-03-15
 - **Accepted**: 2026-03-16
-- **Closed**: 2026-03-16
-- **Close-reason**: implemented (Phases 1-3; Phase 4 HTML sparkline deferred to RDR-011 HtmlLayoutRenderer)
+- **Reopened**: 2026-03-16 (Phase 4 HTML sparkline SVG — prerequisite RDR-011 HtmlLayoutRenderer now complete)
 - **Reviewed-by**: self
 - **Related**: RDR-015 (Alternative Rendering Modes — defers sparkline), RDR-009 (MeasureResult), RDR-011 (Layout Protocol)
 

--- a/kramer/src/main/java/com/chiralbehaviors/layout/HtmlLayoutRenderer.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/HtmlLayoutRenderer.java
@@ -29,11 +29,77 @@ public class HtmlLayoutRenderer extends AbstractLayoutRenderer<String> {
     @Override
     protected String renderPrimitive(LayoutDecisionNode node, JsonNode data) {
         String cssClass = SchemaPath.sanitize(node.fieldName());
+        var lr = node.layoutResult();
+        var mr = node.measureResult();
+        if (lr != null && lr.primitiveMode() == PrimitiveRenderMode.SPARKLINE
+                && mr != null && mr.sparklineStats() != null
+                && data != null && data.isArray()) {
+            return renderSparklineSvg(cssClass, data, mr.sparklineStats());
+        }
         if (data != null && data.isArray()) {
             return renderArray(cssClass, data);
         }
         String text = data != null ? escapeHtml(data.asText()) : "";
         return "<span class=\"" + cssClass + "\">" + text + "</span>";
+    }
+
+    private static String renderSparklineSvg(String cssClass, JsonNode data, SparklineStats stats) {
+        int n = data.size();
+        if (n == 0) {
+            return "<svg class=\"sparkline " + cssClass + "\" width=\"100\" height=\"20\" viewBox=\"0 0 100 20\"></svg>";
+        }
+
+        double vMin = stats.seriesMin();
+        double vMax = stats.seriesMax();
+        double range = vMax - vMin;
+        // Avoid division by zero when all values are equal
+        if (range == 0.0) {
+            range = 1.0;
+        }
+
+        double viewW = 100.0;
+        double viewH = 20.0;
+
+        // Build polyline points
+        var points = new StringBuilder();
+        double lastX = 0.0, lastY = 0.0;
+        for (int i = 0; i < n; i++) {
+            double x = (n == 1) ? viewW / 2 : (i / (double) (n - 1)) * viewW;
+            double y = viewH - ((data.get(i).asDouble() - vMin) / range) * viewH;
+            if (i > 0) {
+                points.append(' ');
+            }
+            points.append(round2(x)).append(',').append(round2(y));
+            lastX = x;
+            lastY = y;
+        }
+
+        // IQR band: y coords are inverted (higher value = lower y)
+        double yQ3 = viewH - ((stats.q3() - vMin) / range) * viewH;
+        double yQ1 = viewH - ((stats.q1() - vMin) / range) * viewH;
+        // yQ1 > yQ3 because y increases downward; height = yQ1 - yQ3
+        double bandY = Math.min(yQ1, yQ3);
+        double bandH = Math.abs(yQ1 - yQ3);
+
+        return "<svg class=\"sparkline " + cssClass + "\" width=\"100\" height=\"20\" viewBox=\"0 0 100 20\">"
+             + "<rect class=\"sparkline-band\" x=\"0\" y=\"" + round2(bandY) + "\" width=\"100\" height=\"" + round2(bandH) + "\" opacity=\"0.15\"/>"
+             + "<polyline class=\"sparkline-line\" points=\"" + points + "\" fill=\"none\" stroke=\"currentColor\"/>"
+             + "<circle class=\"sparkline-end\" cx=\"" + round2(lastX) + "\" cy=\"" + round2(lastY) + "\" r=\"1.5\"/>"
+             + "</svg>";
+    }
+
+    private static String round2(double v) {
+        // Format to at most 2 decimal places, no trailing zeros
+        long rounded = Math.round(v * 100);
+        if (rounded % 100 == 0) {
+            return String.valueOf(rounded / 100);
+        } else if (rounded % 10 == 0) {
+            return (rounded / 100) + "." + ((rounded % 100) / 10);
+        } else {
+            int intPart = (int) (rounded / 100);
+            int fracPart = (int) Math.abs(rounded % 100);
+            return intPart + "." + String.format("%02d", fracPart);
+        }
     }
 
     @Override

--- a/kramer/src/test/java/com/chiralbehaviors/layout/HtmlLayoutRendererTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/HtmlLayoutRendererTest.java
@@ -230,6 +230,103 @@ class HtmlLayoutRendererTest {
         assertFalse(result.contains("<table"), "Outline mode should not produce <table> in: " + result);
     }
 
+    // --- sparkline tests ---
+
+    private static LayoutDecisionNode sparklineLeaf(String name, SparklineStats stats) {
+        var path = new SchemaPath(name);
+        var layoutResult = new LayoutResult(
+            RelationRenderMode.OUTLINE,
+            PrimitiveRenderMode.SPARKLINE,
+            false, 0.0, 0.0, 0.0,
+            List.of()
+        );
+        var measureResult = new MeasureResult(
+            0.0, 0.0, 0.0, 0.0, 0, false, 0, 0, null, List.of(),
+            null, null, null, stats
+        );
+        return new LayoutDecisionNode(path, path.leaf(), measureResult, layoutResult, null, null, null, List.of());
+    }
+
+    private static ArrayNode numericArray(double... values) {
+        ArrayNode arr = MAPPER.createArrayNode();
+        for (double v : values) {
+            arr.add(v);
+        }
+        return arr;
+    }
+
+    @Test
+    void sparklineRendersAsSvgNotSpan() {
+        var stats = new SparklineStats(0.0, 10.0, 2.5, 7.5, 5);
+        var node = sparklineLeaf("trend", stats);
+        var data = numericArray(1.0, 3.0, 5.0, 7.0, 9.0);
+
+        var result = new HtmlLayoutRenderer().render(node, data);
+
+        assertTrue(result.contains("<svg"), "Expected <svg> element, got: " + result);
+        assertFalse(result.contains("<span"), "Should not contain <span> for sparkline: " + result);
+    }
+
+    @Test
+    void sparklineSvgContainsPolyline() {
+        var stats = new SparklineStats(0.0, 10.0, 2.5, 7.5, 5);
+        var node = sparklineLeaf("trend", stats);
+        var data = numericArray(1.0, 3.0, 5.0, 7.0, 9.0);
+
+        var result = new HtmlLayoutRenderer().render(node, data);
+
+        assertTrue(result.contains("<polyline"), "Expected <polyline> in sparkline SVG: " + result);
+        assertTrue(result.contains("points="), "Expected points attribute in polyline: " + result);
+    }
+
+    @Test
+    void sparklineSvgContainsIqrBand() {
+        var stats = new SparklineStats(0.0, 10.0, 2.5, 7.5, 5);
+        var node = sparklineLeaf("trend", stats);
+        var data = numericArray(1.0, 3.0, 5.0, 7.0, 9.0);
+
+        var result = new HtmlLayoutRenderer().render(node, data);
+
+        assertTrue(result.contains("<rect"), "Expected <rect> for IQR band in sparkline SVG: " + result);
+        assertTrue(result.contains("sparkline-band"), "Expected sparkline-band class on rect: " + result);
+    }
+
+    @Test
+    void sparklineSvgContainsEndMarkerCircle() {
+        var stats = new SparklineStats(0.0, 10.0, 2.5, 7.5, 5);
+        var node = sparklineLeaf("trend", stats);
+        var data = numericArray(1.0, 3.0, 5.0, 7.0, 9.0);
+
+        var result = new HtmlLayoutRenderer().render(node, data);
+
+        assertTrue(result.contains("<circle"), "Expected <circle> end marker in sparkline SVG: " + result);
+        assertTrue(result.contains("sparkline-end"), "Expected sparkline-end class on circle: " + result);
+    }
+
+    @Test
+    void nonSparklineStillRendersAsSpan() {
+        var node = leaf("score");
+        var data = MAPPER.getNodeFactory().textNode("42");
+
+        var result = new HtmlLayoutRenderer().render(node, data);
+
+        assertTrue(result.contains("<span"), "Non-sparkline should render as <span>: " + result);
+        assertFalse(result.contains("<svg"), "Non-sparkline should not render as <svg>: " + result);
+    }
+
+    @Test
+    void sparklineNullStatsFallsBackToSpan() {
+        var node = sparklineLeaf("trend", null);
+        var data = numericArray(1.0, 2.0, 3.0);
+
+        var result = new HtmlLayoutRenderer().render(node, data);
+
+        assertTrue(result.contains("<span") || result.contains("<ul"),
+                   "Null stats sparkline should fall back to default rendering: " + result);
+        assertFalse(result.contains("<svg"),
+                    "Null stats sparkline should not produce <svg>: " + result);
+    }
+
     private static int countOccurrences(String haystack, String needle) {
         int count = 0;
         int idx = 0;


### PR DESCRIPTION
## Summary
- **RDR-019** (Kramer-dd4): HTML/SVG sparkline renderer. Inline `<svg>` with `<polyline>`, `<rect>` IQR band, `<circle>` end marker. Null stats falls back to `<span>` text. **ALL 4 PHASES COMPLETE. Zero deferred work.**

## Test plan
- [x] 593 tests pass (6 new)

Ref: Kramer-dd4