### PR TITLE
RDR-023 Phase 3a: Data snapshot + frozenResult invalidation

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -70,6 +71,11 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
     private final SimpleObjectProperty<SchemaNode>        root         = new SimpleObjectProperty<>();
     private final String                                  stylesheet;
 
+    // Data snapshot state (Kramer-eyr): tracks primitive values across setContent() calls
+    // to invalidate frozenResult on PrimitiveLayouts whose data has changed.
+    private Map<SchemaPath, List<String>>                 dataSnapshot = DataSnapshot.EMPTY;
+    private Map<SchemaPath, Double>                       p90Snapshot  = Map.of();
+
     // Search
     private SearchBar                                     searchBar;
     private LayoutSearch                                  layoutSearch;
@@ -94,6 +100,8 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
             measureResult = null;
             decisionCache.clear();
             control = null;
+            dataSnapshot = DataSnapshot.EMPTY;
+            p90Snapshot  = Map.of();
         });
         data.addListener((o, p, c) -> setContent());
         controller = new FocusController<>(this);
@@ -621,14 +629,77 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         }
         JsonNode datum = data.get();
         try {
+            // Detect which primitive paths have changed values and clear their
+            // frozenResult so the next measure() call re-computes widths.
+            if (layout != null && datum != null) {
+                Set<SchemaPath> changedPaths = detectChangedPaths(datum);
+                clearFrozenResultForPaths(changedPaths);
+            }
             if (control == null) {
                 Platform.runLater(() -> autoLayout(datum, getWidth()));
             } else {
                 control.updateItem(datum);
             }
             layout();
+            // Update snapshot after successful pipeline
+            if (layout != null && datum != null) {
+                dataSnapshot = DataSnapshot.buildSnapshot(layout, datum);
+            }
         } catch (Throwable e) {
             log.log(Level.SEVERE, "cannot set content", e);
+            // Exception during pipeline: clear both snapshots so the next call starts fresh
+            dataSnapshot = DataSnapshot.EMPTY;
+            p90Snapshot  = Map.of();
+        }
+    }
+
+    /**
+     * Compares {@code data} against the last captured {@link #dataSnapshot} and
+     * returns the set of {@link SchemaPath}s whose primitive values have changed.
+     *
+     * <p>On cold start (empty snapshot) or row-count change, all known paths are
+     * returned. On an identical repeat, an empty set is returned.
+     */
+    private Set<SchemaPath> detectChangedPaths(JsonNode data) {
+        return DataSnapshot.detectChangedPaths(layout, data, dataSnapshot);
+    }
+
+    /**
+     * For each path in {@code paths}, locates the corresponding
+     * {@link PrimitiveLayout} via {@link Style#layout(SchemaNode)} and calls
+     * {@link PrimitiveLayout#clearFrozenResult()}, saving the p90Width into
+     * {@link #p90Snapshot} before clearing.
+     *
+     * <p>PrimitiveLayouts with no frozen result are silently skipped.
+     */
+    private void clearFrozenResultForPaths(Set<SchemaPath> paths) {
+        if (paths.isEmpty() || layout == null) return;
+        Map<SchemaPath, Double> newP90 = new HashMap<>(p90Snapshot);
+        clearFrozenResultInTree(layout, paths, newP90);
+        p90Snapshot = Map.copyOf(newP90);
+    }
+
+    /**
+     * Recursively walk the layout tree, clearing frozenResult on any
+     * {@link PrimitiveLayout} whose path is in {@code paths}.
+     */
+    private static void clearFrozenResultInTree(SchemaNodeLayout snl,
+                                                Set<SchemaPath> paths,
+                                                Map<SchemaPath, Double> p90Out) {
+        if (snl instanceof PrimitiveLayout pl) {
+            SchemaPath path = pl.getSchemaPath();
+            if (path != null && paths.contains(path)) {
+                // Capture p90Width before clearing
+                MeasureResult mr = pl.getMeasureResult();
+                if (mr != null && mr.contentStats() != null) {
+                    p90Out.put(path, mr.contentStats().p90Width());
+                }
+                pl.clearFrozenResult();
+            }
+        } else if (snl instanceof RelationLayout rl) {
+            for (SchemaNodeLayout child : rl.getChildren()) {
+                clearFrozenResultInTree(child, paths, p90Out);
+            }
         }
     }
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/DataSnapshot.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/DataSnapshot.java
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.chiralbehaviors.layout.schema.SchemaNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+/**
+ * Captures a snapshot of primitive field values from a JSON data tree against
+ * the schema layout tree, and computes which paths changed between snapshots.
+ *
+ * <p>Snapshot entries map each {@link SchemaPath} (of a primitive leaf) to the
+ * ordered list of text values seen at that path across all data rows. A path is
+ * considered changed when:
+ * <ul>
+ *   <li>it is absent from the prior snapshot (cold start), or</li>
+ *   <li>its value list differs (different length or any element differs).</li>
+ * </ul>
+ *
+ * <p>Row-count changes (i.e. the top-level array size changed) are a special
+ * case: the method returns ALL known paths so that every {@link PrimitiveLayout}
+ * is invalidated for a full rebuild.
+ *
+ * <p><b>Traversal semantics</b>: the root layout's rows ARE the data rows —
+ * the root relation's field name is not a key in the data.  Nested relation
+ * fields ARE keys in their parent rows and are extracted normally.
+ */
+final class DataSnapshot {
+
+    /** Sentinel empty snapshot used on cold start. */
+    static final Map<SchemaPath, List<String>> EMPTY = Map.of();
+
+    private DataSnapshot() {}
+
+    /**
+     * Detect which primitive paths have changed values between {@code prior} and
+     * the new {@code data}, walking the schema tree rooted at {@code rootLayout}.
+     *
+     * <p>If {@code prior} is empty (cold start) all paths are returned.
+     * If the top-level row count changed, all paths are returned.
+     *
+     * @param rootLayout the measured layout tree root (RelationLayout or PrimitiveLayout)
+     * @param data       the new JSON data (array of rows or single object)
+     * @param prior      the previously captured snapshot, or {@link #EMPTY}
+     * @return set of changed paths; never null, may be empty if nothing changed
+     */
+    static Set<SchemaPath> detectChangedPaths(SchemaNodeLayout rootLayout,
+                                              JsonNode data,
+                                              Map<SchemaPath, List<String>> prior) {
+        if (prior.isEmpty()) {
+            // Cold start: everything is "changed"
+            Set<SchemaPath> allPaths = new HashSet<>();
+            collectPaths(rootLayout, allPaths);
+            return allPaths;
+        }
+
+        // Row-count change: full rebuild
+        int newRowCount = (data != null && data.isArray()) ? data.size() : 1;
+        int priorRowCount = priorRowCount(prior);
+        if (priorRowCount >= 0 && newRowCount != priorRowCount) {
+            Set<SchemaPath> allPaths = new HashSet<>();
+            collectPaths(rootLayout, allPaths);
+            return allPaths;
+        }
+
+        // Element-level comparison
+        Map<SchemaPath, List<String>> current = buildSnapshot(rootLayout, data);
+        Set<SchemaPath> changed = new HashSet<>();
+        for (Map.Entry<SchemaPath, List<String>> entry : current.entrySet()) {
+            SchemaPath path = entry.getKey();
+            List<String> newValues = entry.getValue();
+            List<String> oldValues = prior.get(path);
+            if (oldValues == null || !oldValues.equals(newValues)) {
+                changed.add(path);
+            }
+        }
+        // Also mark paths that were in prior but are no longer present
+        for (SchemaPath path : prior.keySet()) {
+            if (!current.containsKey(path)) {
+                changed.add(path);
+            }
+        }
+        return changed;
+    }
+
+    /**
+     * Build a fresh snapshot by walking the layout tree and extracting all
+     * primitive field values from {@code data}.
+     *
+     * <p>The root layout's rows are the top-level data rows (the root relation's
+     * field is not a key in the data).  Nested relations extract their field
+     * from parent rows.
+     *
+     * @param rootLayout the measured layout tree root
+     * @param data       the JSON data (array of rows or single object)
+     * @return map of SchemaPath to ordered list of text values; never null
+     */
+    static Map<SchemaPath, List<String>> buildSnapshot(SchemaNodeLayout rootLayout,
+                                                       JsonNode data) {
+        Map<SchemaPath, List<String>> snapshot = new HashMap<>();
+        if (rootLayout == null || data == null) {
+            return snapshot;
+        }
+        List<JsonNode> rows = SchemaNode.asList(data);
+        if (rootLayout instanceof PrimitiveLayout pl) {
+            // Single-primitive root: rows are the values directly
+            collectPrimitiveValues(pl, rows, snapshot);
+        } else if (rootLayout instanceof RelationLayout rl) {
+            // Root relation: rows ARE the data rows; recurse children with same rows
+            collectRelationChildren(rl, rows, snapshot);
+        }
+        return snapshot;
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Collect all SchemaPath keys reachable from {@code snl} into {@code out}.
+     */
+    private static void collectPaths(SchemaNodeLayout snl, Set<SchemaPath> out) {
+        if (snl instanceof PrimitiveLayout pl) {
+            SchemaPath p = pl.getSchemaPath();
+            if (p != null) out.add(p);
+        } else if (snl instanceof RelationLayout rl) {
+            for (SchemaNodeLayout child : rl.getChildren()) {
+                collectPaths(child, out);
+            }
+        }
+    }
+
+    /**
+     * Recursively collect values for {@code snl} given that {@code rows} are the
+     * parent rows from which {@code snl}'s field should be extracted.
+     *
+     * <p>For a nested {@link RelationLayout}, the field is extracted from each
+     * parent row (possibly returning an array) and flattened before recursing.
+     * For a {@link PrimitiveLayout}, the field is extracted from each parent row
+     * and the text value is stored.
+     */
+    private static void collectValues(SchemaNodeLayout snl,
+                                      List<JsonNode> parentRows,
+                                      Map<SchemaPath, List<String>> snapshot) {
+        if (snl instanceof PrimitiveLayout pl) {
+            collectPrimitiveValues(pl, parentRows, snapshot);
+        } else if (snl instanceof RelationLayout rl) {
+            // Extract this relation's field from each parent row, flatten, recurse
+            List<JsonNode> childRows = extractField(parentRows, rl.getField());
+            collectRelationChildren(rl, childRows, snapshot);
+        }
+    }
+
+    /**
+     * Collect values for {@code pl} by extracting its field from each parent row.
+     */
+    private static void collectPrimitiveValues(PrimitiveLayout pl,
+                                               List<JsonNode> parentRows,
+                                               Map<SchemaPath, List<String>> snapshot) {
+        SchemaPath path = pl.getSchemaPath();
+        if (path == null) return;
+        List<String> values = new ArrayList<>(parentRows.size());
+        for (JsonNode row : parentRows) {
+            if (row == null) {
+                values.add("");
+            } else {
+                JsonNode extracted = pl.extractFrom(row);
+                values.add(SchemaNode.asText(extracted));
+            }
+        }
+        snapshot.put(path, values);
+    }
+
+    /**
+     * Recurse into the children of {@code rl}, passing {@code rows} as the
+     * parent rows for each child.
+     */
+    private static void collectRelationChildren(RelationLayout rl,
+                                                List<JsonNode> rows,
+                                                Map<SchemaPath, List<String>> snapshot) {
+        for (SchemaNodeLayout child : rl.getChildren()) {
+            collectValues(child, rows, snapshot);
+        }
+    }
+
+    /**
+     * Extract {@code field} from each row and flatten into a single list.
+     * Arrays are expanded; missing/null values are skipped.
+     */
+    private static List<JsonNode> extractField(List<JsonNode> rows, String field) {
+        List<JsonNode> result = new ArrayList<>();
+        for (JsonNode row : rows) {
+            if (row == null) continue;
+            JsonNode extracted = row.get(field);
+            if (extracted == null || extracted.isNull() || extracted.isMissingNode()) continue;
+            if (extracted.isArray()) {
+                for (JsonNode child : (ArrayNode) extracted) {
+                    result.add(child);
+                }
+            } else {
+                result.add(extracted);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Infer the prior row count from the snapshot. Returns the length of any
+     * value list (all should be equal for top-level rows), or -1 if empty.
+     */
+    private static int priorRowCount(Map<SchemaPath, List<String>> prior) {
+        for (List<String> values : prior.values()) {
+            return values.size();
+        }
+        return -1;
+    }
+
+    /** Returns the number of top-level rows in data. */
+    static int rowCount(JsonNode data) {
+        if (data == null) return 0;
+        return data.isArray() ? data.size() : 1;
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/PrimitiveLayout.java
@@ -545,6 +545,20 @@ public final class PrimitiveLayout extends SchemaNodeLayout {
         return frozenResult != null;
     }
 
+    /**
+     * Clears the frozen (converged) result and resets all convergence tracking
+     * state so that the next {@link #measure} call performs a full re-measurement.
+     *
+     * <p>Called by {@link AutoLayout} when data changes are detected at this
+     * primitive's path so that new data content is reflected in width calculations.
+     */
+    public void clearFrozenResult() {
+        frozenResult = null;
+        frozenStylesheetVersion = -1;
+        lastP90Width = Double.NaN;
+        consecutiveStableCount = 0;
+    }
+
     public LayoutResult computeLayout(double width) {
         clear();
         return new LayoutResult(

--- a/kramer/src/test/java/com/chiralbehaviors/layout/DataSnapshotTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/DataSnapshotTest.java
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Tests for Kramer-eyr: data snapshot + frozenResult invalidation.
+ *
+ * All tests are headless — no JavaFX required.
+ */
+class DataSnapshotTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a Relation schema with the given child primitive field names,
+     * create the RelationLayout via mocked Style, build paths, and measure.
+     *
+     * <p>The Style mock uses {@code charWidth=1.0} PrimitiveStyle mocks and
+     * returns null for the stylesheet so no CSS is consulted.
+     */
+    private static RelationLayout buildAndMeasure(String field, JsonNode data,
+                                                   String... childFields) {
+        Relation rel = new Relation(field);
+        for (String cf : childFields) {
+            rel.addChild(new Primitive(cf));
+        }
+
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        Style model = mockStyleModel(rel, primStyle);
+
+        RelationLayout rl = new RelationLayout(rel, TestLayouts.mockRelationStyle());
+        rl.buildPaths(new SchemaPath(field), model);
+        rl.measure(data, n -> n, model);
+        return rl;
+    }
+
+    /** Build a Style mock that creates PrimitiveLayouts with the given primStyle. */
+    private static Style mockStyleModel(Relation schema, PrimitiveStyle primStyle) {
+        Style model = mock(Style.class);
+        for (var child : schema.getChildren()) {
+            if (child instanceof Primitive p) {
+                PrimitiveLayout pl = new PrimitiveLayout(p, primStyle);
+                when(model.layout(p)).thenReturn(pl);
+            }
+        }
+        when(model.layout((com.chiralbehaviors.layout.schema.SchemaNode) any())).thenAnswer(inv -> {
+            var n = inv.getArgument(0);
+            if (n instanceof Primitive p) return model.layout(p);
+            return null;
+        });
+        when(model.getStylesheet()).thenReturn(null);
+        return model;
+    }
+
+    /** Build an array of single-field objects. */
+    private static ArrayNode buildData(String field, String... values) {
+        ArrayNode arr = JsonNodeFactory.instance.arrayNode();
+        for (String v : values) {
+            ObjectNode obj = JsonNodeFactory.instance.objectNode();
+            obj.put(field, v);
+            arr.add(obj);
+        }
+        return arr;
+    }
+
+    /** Build rows with two fields. */
+    private static ArrayNode buildData2(String f1, String[] v1s, String f2, String[] v2s) {
+        ArrayNode arr = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < v1s.length; i++) {
+            ObjectNode obj = JsonNodeFactory.instance.objectNode();
+            obj.put(f1, v1s[i]);
+            obj.put(f2, v2s[i]);
+            arr.add(obj);
+        }
+        return arr;
+    }
+
+    // -----------------------------------------------------------------------
+    // PrimitiveLayout.clearFrozenResult()
+    // -----------------------------------------------------------------------
+
+    @Test
+    void clearFrozenResultResetsConvergenceState() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive("text"), style);
+        SchemaPath path = new SchemaPath("text");
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 3);
+        Style styleModel = mock(Style.class);
+        when(styleModel.getStylesheet()).thenReturn(sheet);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 4; i++) data.add("x");
+        data.add("x".repeat(20));
+
+        // 3 stable calls → converged
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        assertTrue(pl.isConverged(), "Should be converged before clearFrozenResult()");
+
+        pl.clearFrozenResult();
+
+        assertFalse(pl.isConverged(), "clearFrozenResult() must clear convergence");
+    }
+
+    @Test
+    void clearFrozenResultAllowsRemeasure() {
+        PrimitiveStyle style = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive("text"), style);
+        SchemaPath path = new SchemaPath("text");
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 3);
+        Style styleModel = mock(Style.class);
+        when(styleModel.getStylesheet()).thenReturn(sheet);
+
+        // Narrow data — converge
+        ArrayNode narrow = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 4; i++) narrow.add("x");
+        narrow.add("x".repeat(20));
+        pl.measure(narrow, n -> n, styleModel);
+        pl.measure(narrow, n -> n, styleModel);
+        pl.measure(narrow, n -> n, styleModel);
+        assertTrue(pl.isConverged());
+        double frozenWidth = pl.columnWidth();
+
+        pl.clearFrozenResult();
+
+        // Measure wider data — must NOT return old frozen width
+        ArrayNode wide = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 4; i++) wide.add("x");
+        wide.add("x".repeat(100));
+        double newWidth = pl.measure(wide, n -> n, styleModel);
+
+        assertNotEquals(frozenWidth, newWidth, 0.1,
+                "After clearFrozenResult(), measure() must use new data");
+    }
+
+    // -----------------------------------------------------------------------
+    // DataSnapshot.buildSnapshot()
+    // -----------------------------------------------------------------------
+
+    @Test
+    void buildSnapshotCapturesPrimitiveValues() {
+        ArrayNode data = buildData("name", "Alice", "Bob", "Carol");
+        RelationLayout rl = buildAndMeasure("root", data, "name");
+
+        Map<SchemaPath, List<String>> snapshot = DataSnapshot.buildSnapshot(rl, data);
+
+        assertFalse(snapshot.isEmpty(), "Snapshot must not be empty");
+        SchemaPath namePath = new SchemaPath("root", "name");
+        assertTrue(snapshot.containsKey(namePath), "Snapshot must contain root/name");
+        assertEquals(List.of("Alice", "Bob", "Carol"), snapshot.get(namePath));
+    }
+
+    @Test
+    void buildSnapshotCapturesMultiplePrimitives() {
+        ArrayNode data = buildData2("name", new String[]{"Alice", "Bob"},
+                                    "age",  new String[]{"30", "25"});
+        RelationLayout rl = buildAndMeasure("root", data, "name", "age");
+
+        Map<SchemaPath, List<String>> snapshot = DataSnapshot.buildSnapshot(rl, data);
+
+        assertEquals(List.of("Alice", "Bob"), snapshot.get(new SchemaPath("root", "name")));
+        assertEquals(List.of("30", "25"),     snapshot.get(new SchemaPath("root", "age")));
+    }
+
+    @Test
+    void buildSnapshotEmptyDataProducesEmptyLists() {
+        // Measure with real data so children are populated
+        ArrayNode initData = buildData("name", "Alice");
+        RelationLayout rl = buildAndMeasure("root", initData, "name");
+
+        ArrayNode empty = JsonNodeFactory.instance.arrayNode();
+        Map<SchemaPath, List<String>> snapshot = DataSnapshot.buildSnapshot(rl, empty);
+
+        SchemaPath namePath = new SchemaPath("root", "name");
+        assertTrue(snapshot.containsKey(namePath), "Snapshot key must exist even for empty data");
+        assertEquals(List.of(), snapshot.get(namePath));
+    }
+
+    // -----------------------------------------------------------------------
+    // DataSnapshot.detectChangedPaths() — cold start
+    // -----------------------------------------------------------------------
+
+    @Test
+    void coldStartReturnsAllPaths() {
+        ArrayNode data = buildData2("name", new String[]{"Alice"},
+                                    "age",  new String[]{"30"});
+        RelationLayout rl = buildAndMeasure("root", data, "name", "age");
+
+        // Cold start: prior snapshot is EMPTY
+        Set<SchemaPath> changed = DataSnapshot.detectChangedPaths(rl, data, DataSnapshot.EMPTY);
+
+        assertEquals(2, changed.size(), "Cold start must return all 2 primitive paths");
+        assertTrue(changed.contains(new SchemaPath("root", "name")));
+        assertTrue(changed.contains(new SchemaPath("root", "age")));
+    }
+
+    // -----------------------------------------------------------------------
+    // DataSnapshot.detectChangedPaths() — same data → no changes
+    // -----------------------------------------------------------------------
+
+    @Test
+    void sameDataProducesNoChangedPaths() {
+        ArrayNode data = buildData("name", "Alice", "Bob");
+        RelationLayout rl = buildAndMeasure("root", data, "name");
+
+        Map<SchemaPath, List<String>> snapshot = DataSnapshot.buildSnapshot(rl, data);
+
+        // Same data again → nothing changed
+        Set<SchemaPath> changed = DataSnapshot.detectChangedPaths(rl, data, snapshot);
+        assertTrue(changed.isEmpty(), "Identical data must produce no changed paths");
+    }
+
+    // -----------------------------------------------------------------------
+    // DataSnapshot.detectChangedPaths() — changed value
+    // -----------------------------------------------------------------------
+
+    @Test
+    void changedValueDetected() {
+        ArrayNode data1 = buildData2("name", new String[]{"Alice", "Bob"},
+                                     "age",  new String[]{"30", "25"});
+        RelationLayout rl = buildAndMeasure("root", data1, "name", "age");
+
+        Map<SchemaPath, List<String>> snapshot = DataSnapshot.buildSnapshot(rl, data1);
+
+        // Change 'name' only; 'age' stays the same
+        ArrayNode data2 = buildData2("name", new String[]{"Alice", "Charlie"},
+                                     "age",  new String[]{"30", "25"});
+        Set<SchemaPath> changed = DataSnapshot.detectChangedPaths(rl, data2, snapshot);
+
+        assertEquals(1, changed.size(), "Only 'name' changed");
+        assertTrue(changed.contains(new SchemaPath("root", "name")));
+        assertFalse(changed.contains(new SchemaPath("root", "age")));
+    }
+
+    // -----------------------------------------------------------------------
+    // DataSnapshot.detectChangedPaths() — row count change → full rebuild
+    // -----------------------------------------------------------------------
+
+    @Test
+    void rowCountChangeReturnsAllPaths() {
+        ArrayNode data1 = buildData2("name", new String[]{"Alice"},
+                                     "age",  new String[]{"30"});
+        RelationLayout rl = buildAndMeasure("root", data1, "name", "age");
+
+        Map<SchemaPath, List<String>> snapshot = DataSnapshot.buildSnapshot(rl, data1);
+
+        // Two rows now
+        ArrayNode data2 = buildData2("name", new String[]{"Alice", "Bob"},
+                                     "age",  new String[]{"30", "25"});
+        Set<SchemaPath> changed = DataSnapshot.detectChangedPaths(rl, data2, snapshot);
+
+        assertEquals(2, changed.size(), "Row count change must return all paths");
+        assertTrue(changed.contains(new SchemaPath("root", "name")));
+        assertTrue(changed.contains(new SchemaPath("root", "age")));
+    }
+
+    // -----------------------------------------------------------------------
+    // clearFrozenResultForPaths integration via tree walk
+    // -----------------------------------------------------------------------
+
+    @Test
+    void clearFrozenResultForPathsInvalidatesAffectedLayouts() {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive("name"), primStyle);
+        SchemaPath path = new SchemaPath("root", "name");
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 3);
+        Style styleModel = mock(Style.class);
+        when(styleModel.getStylesheet()).thenReturn(sheet);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 4; i++) data.add("x");
+        data.add("x".repeat(20));
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        assertTrue(pl.isConverged());
+
+        // Simulate clearFrozenResultForPaths — path in changed set
+        pl.clearFrozenResult();
+        assertFalse(pl.isConverged(), "Affected PrimitiveLayout must lose convergence");
+    }
+
+    // -----------------------------------------------------------------------
+    // Schema root change: EMPTY snapshot triggers full rebuild
+    // -----------------------------------------------------------------------
+
+    @Test
+    void schemaRootChangeInvalidatesAllState() {
+        ArrayNode data = buildData2("x", new String[]{"1", "2"},
+                                    "y", new String[]{"a", "b"});
+        RelationLayout rl = buildAndMeasure("v2root", data, "x", "y");
+
+        // After schema root change, prior snapshot is reset to EMPTY → all paths changed
+        Set<SchemaPath> changed = DataSnapshot.detectChangedPaths(rl, data, DataSnapshot.EMPTY);
+        assertEquals(2, changed.size(), "EMPTY prior snapshot must return all primitive paths");
+    }
+}


### PR DESCRIPTION
## Summary
- **Kramer-eyr**: `DataSnapshot` utility + `PrimitiveLayout.clearFrozenResult()` + `AutoLayout` snapshot state management. Detects changed data paths, clears convergence for affected primitives, try/finally exception safety.

## Test plan
- [x] 620 tests pass (11 new)

Ref: Kramer-eyr