### PR TITLE
RDR-023 Phase 3b: Selective re-measure with bucket comparison

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -18,6 +18,7 @@ package com.chiralbehaviors.layout;
 
 import java.net.URL;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -629,13 +630,39 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         }
         JsonNode datum = data.get();
         try {
-            // Detect which primitive paths have changed values and clear their
-            // frozenResult so the next measure() call re-computes widths.
+            // Phase 3b: selective re-measure with bucket comparison
             if (layout != null && datum != null) {
                 Set<SchemaPath> changedPaths = detectChangedPaths(datum);
+
+                if (changedPaths.isEmpty()) {
+                    // Case (a): no data changes — just rebind and update snapshot
+                    if (control != null) {
+                        control.updateItem(datum);
+                    }
+                    if (layout != null) {
+                        dataSnapshot = DataSnapshot.buildSnapshot(layout, datum);
+                    }
+                    return;
+                }
+
                 clearFrozenResultForPaths(changedPaths);
-            }
-            if (control == null) {
+
+                // Re-measure only affected primitives and compare p90 buckets
+                Set<SchemaPath> bucketChangedPaths = remeasureChanged(changedPaths, datum);
+
+                if (bucketChangedPaths.isEmpty()) {
+                    // P90 shifted but stayed in same bucket — just rebind, no re-layout
+                    if (control != null) {
+                        control.updateItem(datum);
+                    }
+                    dataSnapshot = DataSnapshot.buildSnapshot(layout, datum);
+                    return;
+                }
+
+                // Bucket changed — need re-layout for affected subtree
+                // Phase 3c will optimize to partial re-layout; for now: full re-layout
+                Platform.runLater(() -> autoLayout(datum, getWidth()));
+            } else if (control == null) {
                 Platform.runLater(() -> autoLayout(datum, getWidth()));
             } else {
                 control.updateItem(datum);
@@ -666,31 +693,54 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
 
     /**
      * For each path in {@code paths}, locates the corresponding
-     * {@link PrimitiveLayout} via {@link Style#layout(SchemaNode)} and calls
+     * {@link PrimitiveLayout} via the layout tree and calls
      * {@link PrimitiveLayout#clearFrozenResult()}, saving the p90Width into
      * {@link #p90Snapshot} before clearing.
+     *
+     * <p><b>Convergence fast-path</b>: if the PrimitiveLayout at a given path is
+     * already converged and the new data's maximum value width does not exceed the
+     * snapshot p90, clearing is skipped entirely — the frozen result remains valid.
      *
      * <p>PrimitiveLayouts with no frozen result are silently skipped.
      */
     private void clearFrozenResultForPaths(Set<SchemaPath> paths) {
         if (paths.isEmpty() || layout == null) return;
         Map<SchemaPath, Double> newP90 = new HashMap<>(p90Snapshot);
-        clearFrozenResultInTree(layout, paths, newP90);
+        clearFrozenResultInTree(layout, paths, newP90, data.get(), model);
         p90Snapshot = Map.copyOf(newP90);
     }
 
     /**
      * Recursively walk the layout tree, clearing frozenResult on any
      * {@link PrimitiveLayout} whose path is in {@code paths}.
+     *
+     * <p><b>Convergence fast-path</b>: if the layout is converged and the new data
+     * produces a max value width {@code <= p90Snapshot[path]}, skip clearing so
+     * the frozen result stays valid.  The fast-path only fires when {@code datum}
+     * is non-null and a snapshot value exists for the path.
      */
     private static void clearFrozenResultInTree(SchemaNodeLayout snl,
                                                 Set<SchemaPath> paths,
-                                                Map<SchemaPath, Double> p90Out) {
+                                                Map<SchemaPath, Double> p90Out,
+                                                JsonNode datum,
+                                                Style model) {
         if (snl instanceof PrimitiveLayout pl) {
             SchemaPath path = pl.getSchemaPath();
             if (path != null && paths.contains(path)) {
-                // Capture p90Width before clearing
+                // Convergence fast-path: if converged and new data fits within snapshot p90, skip
                 MeasureResult mr = pl.getMeasureResult();
+                if (mr != null && mr.contentStats() != null && mr.contentStats().converged()
+                        && datum != null) {
+                    Double snapshotP90 = p90Out.get(path);
+                    if (snapshotP90 != null) {
+                        double newMaxWidth = computeMaxWidthForPath(pl, datum, model);
+                        if (newMaxWidth <= snapshotP90) {
+                            // New data fits within previous p90 — frozen result stays valid
+                            return;
+                        }
+                    }
+                }
+                // Capture p90Width before clearing
                 if (mr != null && mr.contentStats() != null) {
                     p90Out.put(path, mr.contentStats().p90Width());
                 }
@@ -698,8 +748,199 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
             }
         } else if (snl instanceof RelationLayout rl) {
             for (SchemaNodeLayout child : rl.getChildren()) {
-                clearFrozenResultInTree(child, paths, p90Out);
+                clearFrozenResultInTree(child, paths, p90Out, datum, model);
             }
         }
+    }
+
+    /**
+     * Compute the maximum rendered width for {@code pl}'s field values in
+     * {@code datum} by extracting the field from each data row.  Returns 0.0
+     * when the data is null or contains no rows with this field.
+     *
+     * <p>This is a lightweight scan used only for the convergence fast-path —
+     * it does NOT call {@code measure()} and has no side-effects on the layout.
+     */
+    private static double computeMaxWidthForPath(PrimitiveLayout pl,
+                                                  JsonNode datum,
+                                                  Style model) {
+        if (datum == null) return 0.0;
+        double max = 0.0;
+        List<JsonNode> rows = SchemaNode.asList(datum);
+        for (JsonNode row : rows) {
+            JsonNode value = pl.extractFrom(row);
+            if (value == null || value.isNull() || value.isMissingNode()) continue;
+            if (value.isArray()) {
+                for (JsonNode elem : value) {
+                    double w = pl.width(elem);
+                    if (w > max) max = w;
+                }
+            } else {
+                double w = pl.width(value);
+                if (w > max) max = w;
+            }
+        }
+        return max;
+    }
+
+    /**
+     * Re-measures only the {@link PrimitiveLayout}s whose paths are in
+     * {@code changedPaths}, then compares each new p90 against the value in
+     * {@link #p90Snapshot} using 10-unit bucket identity:
+     * {@code (int)(p90/10)}.
+     *
+     * <p><b>OUTLINE sibling expansion</b>: if a changed primitive's direct parent
+     * {@link RelationLayout} is in OUTLINE mode ({@code !useTable}), all sibling
+     * primitives are also re-measured, because OUTLINE column widths are shared
+     * across siblings.
+     *
+     * @param changedPaths paths whose frozen results have already been cleared
+     * @param datum        the new JSON data
+     * @return set of paths where the p90 bucket actually changed; empty when all
+     *         p90s stayed within the same bucket
+     */
+    private Set<SchemaPath> remeasureChanged(Set<SchemaPath> changedPaths,
+                                              JsonNode datum) {
+        return remeasureChangedImpl(changedPaths, layout, datum, model, p90Snapshot);
+    }
+
+    /**
+     * Core implementation of {@link #remeasureChanged} extracted as a static
+     * helper so tests can exercise it without a live {@link AutoLayout} instance.
+     */
+    private static Set<SchemaPath> remeasureChangedImpl(Set<SchemaPath> changedPaths,
+                                                         SchemaNodeLayout rootLayout,
+                                                         JsonNode datum,
+                                                         Style model,
+                                                         Map<SchemaPath, Double> p90Snapshot) {
+        if (changedPaths.isEmpty() || rootLayout == null || datum == null) {
+            return Set.of();
+        }
+
+        // Expand changedPaths with OUTLINE siblings, collecting (pl, parentRl) pairs
+        Set<SchemaPath> toMeasure = expandWithOutlineSiblings(changedPaths, rootLayout);
+
+        // Re-measure each primitive in toMeasure and collect bucket changes
+        Set<SchemaPath> bucketChanged = new HashSet<>();
+        remeasureInTree(rootLayout, toMeasure, changedPaths, datum, model, p90Snapshot,
+                        bucketChanged);
+        return bucketChanged;
+    }
+
+    /**
+     * Expand {@code changedPaths} to include OUTLINE siblings: for each path in
+     * {@code changedPaths}, if the parent {@link RelationLayout} is OUTLINE mode
+     * ({@code !useTable}), add all sibling primitive paths to the result set.
+     */
+    private static Set<SchemaPath> expandWithOutlineSiblings(Set<SchemaPath> changedPaths,
+                                                              SchemaNodeLayout rootLayout) {
+        Set<SchemaPath> expanded = new HashSet<>(changedPaths);
+        expandSiblingsInTree(rootLayout, changedPaths, expanded);
+        return expanded;
+    }
+
+    private static void expandSiblingsInTree(SchemaNodeLayout snl,
+                                              Set<SchemaPath> changedPaths,
+                                              Set<SchemaPath> expanded) {
+        if (snl instanceof RelationLayout rl) {
+            // Check if any child is in changedPaths AND this relation is OUTLINE mode
+            boolean anyChildChanged = false;
+            for (SchemaNodeLayout child : rl.getChildren()) {
+                if (child instanceof PrimitiveLayout pl && pl.getSchemaPath() != null
+                        && changedPaths.contains(pl.getSchemaPath())) {
+                    anyChildChanged = true;
+                    break;
+                }
+            }
+            if (anyChildChanged && !rl.isUseTable()) {
+                // OUTLINE: add all sibling primitive paths
+                for (SchemaNodeLayout child : rl.getChildren()) {
+                    if (child instanceof PrimitiveLayout pl && pl.getSchemaPath() != null) {
+                        expanded.add(pl.getSchemaPath());
+                    }
+                }
+            }
+            // Recurse into children
+            for (SchemaNodeLayout child : rl.getChildren()) {
+                expandSiblingsInTree(child, changedPaths, expanded);
+            }
+        }
+    }
+
+    /**
+     * Recursively walk the layout tree, re-measuring each {@link PrimitiveLayout}
+     * whose path is in {@code toMeasure}.  For each re-measured primitive,
+     * compare the new p90 bucket against {@code p90Snapshot}; if the bucket
+     * changed, add the path to {@code bucketChangedOut}.
+     *
+     * <p>Only paths also present in {@code originalChanged} can be added to
+     * {@code bucketChangedOut} — siblings added by OUTLINE expansion do not
+     * trigger bucket-change notifications on their own.
+     */
+    private static void remeasureInTree(SchemaNodeLayout snl,
+                                         Set<SchemaPath> toMeasure,
+                                         Set<SchemaPath> originalChanged,
+                                         JsonNode datum,
+                                         Style model,
+                                         Map<SchemaPath, Double> p90Snapshot,
+                                         Set<SchemaPath> bucketChangedOut) {
+        if (snl instanceof PrimitiveLayout pl) {
+            SchemaPath path = pl.getSchemaPath();
+            if (path != null && toMeasure.contains(path)) {
+                pl.measure(datum, n -> n, model);
+                // Only report bucket changes for originally-changed paths
+                if (originalChanged.contains(path)) {
+                    MeasureResult newMr = pl.getMeasureResult();
+                    Double oldP90 = p90Snapshot.get(path);
+                    if (newMr != null && newMr.contentStats() != null) {
+                        double newP90 = newMr.contentStats().p90Width();
+                        if (oldP90 == null || (int)(newP90 / 10) != (int)(oldP90 / 10)) {
+                            bucketChangedOut.add(path);
+                        }
+                    } else if (oldP90 == null) {
+                        // No stats available yet — treat as changed to be safe
+                        bucketChangedOut.add(path);
+                    }
+                }
+            }
+        } else if (snl instanceof RelationLayout rl) {
+            for (SchemaNodeLayout child : rl.getChildren()) {
+                remeasureInTree(child, toMeasure, originalChanged, datum, model,
+                                p90Snapshot, bucketChangedOut);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Package-private test hooks (no-JavaFX headless tests)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Test-visible entry-point for {@link #remeasureChangedImpl}.
+     * Allows headless unit tests to exercise the bucket-comparison logic without
+     * a live {@link AutoLayout} instance.
+     */
+    static Set<SchemaPath> remeasureChangedForTest(Set<SchemaPath> changedPaths,
+                                                    SchemaNodeLayout rootLayout,
+                                                    JsonNode datum,
+                                                    Style model,
+                                                    Map<SchemaPath, Double> p90Snapshot) {
+        return remeasureChangedImpl(changedPaths, rootLayout, datum, model, p90Snapshot);
+    }
+
+    /**
+     * Test-visible entry-point for the convergence fast-path in
+     * {@link #clearFrozenResultInTree}.  Drives the same logic used by
+     * {@link #clearFrozenResultForPaths} without requiring a live AutoLayout.
+     */
+    static void clearFrozenResultForPathsForTest(Set<SchemaPath> paths,
+                                                  SchemaNodeLayout rootLayout,
+                                                  JsonNode datum,
+                                                  Style model,
+                                                  Map<SchemaPath, Double> p90Snapshot) {
+        if (paths.isEmpty() || rootLayout == null) return;
+        Map<SchemaPath, Double> p90Out = new HashMap<>(p90Snapshot);
+        clearFrozenResultInTree(rootLayout, paths, p90Out, datum, model);
+        p90Snapshot.putAll(p90Out);
     }
 }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/SelectiveRemeasureTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/SelectiveRemeasureTest.java
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.LabelStyle;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Tests for Kramer-bhin Phase 3b: selective re-measure with bucket comparison.
+ *
+ * All tests are headless — no JavaFX required.
+ */
+class SelectiveRemeasureTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /** Build an array of single-field objects. */
+    private static ArrayNode buildData(String field, String... values) {
+        ArrayNode arr = JsonNodeFactory.instance.arrayNode();
+        for (String v : values) {
+            ObjectNode obj = JsonNodeFactory.instance.objectNode();
+            obj.put(field, v);
+            arr.add(obj);
+        }
+        return arr;
+    }
+
+    /** Build rows with two fields. */
+    private static ArrayNode buildData2(String f1, String[] v1s,
+                                         String f2, String[] v2s) {
+        ArrayNode arr = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < v1s.length; i++) {
+            ObjectNode obj = JsonNodeFactory.instance.objectNode();
+            obj.put(f1, v1s[i]);
+            obj.put(f2, v2s[i]);
+            arr.add(obj);
+        }
+        return arr;
+    }
+
+    /**
+     * Build a measured RelationLayout + PrimitiveLayout for a single field,
+     * with a style model whose charWidth=1.0.
+     */
+    private static RelationLayout buildAndMeasure(String rootField,
+                                                   String primField,
+                                                   JsonNode data,
+                                                   Style model) {
+        Relation rel = new Relation(rootField);
+        rel.addChild(new Primitive(primField));
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive(primField), primStyle);
+        when(model.layout(any(Primitive.class))).thenReturn(pl);
+        when(model.layout(any(com.chiralbehaviors.layout.schema.SchemaNode.class))).thenAnswer(inv -> {
+            var n = inv.getArgument(0);
+            if (n instanceof Primitive p) return model.layout(p);
+            return null;
+        });
+        RelationLayout rl = new RelationLayout(rel, TestLayouts.mockRelationStyle());
+        rl.buildPaths(new SchemaPath(rootField), model);
+        rl.measure(data, n -> n, model);
+        return rl;
+    }
+
+    private static Style mockNullStylesheetModel() {
+        Style model = mock(Style.class);
+        when(model.getStylesheet()).thenReturn(null);
+        return model;
+    }
+
+    /**
+     * Build a converged PrimitiveLayout at the given path with the specified
+     * p90Width. Uses a stylesheet that lowers min-samples so convergence is
+     * reachable quickly.
+     *
+     * The layout is measured {@code callsToConverge} times with {@code data}.
+     */
+    private static PrimitiveLayout buildConvergedPrimitive(SchemaPath path,
+                                                            JsonNode data,
+                                                            int callsToConverge) {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive(path.leaf()), primStyle);
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", callsToConverge);
+        Style styleModel = mock(Style.class);
+        when(styleModel.getStylesheet()).thenReturn(sheet);
+
+        for (int i = 0; i < callsToConverge; i++) {
+            pl.measure(data, n -> n, styleModel);
+        }
+        return pl;
+    }
+
+    // -----------------------------------------------------------------------
+    // Case (a): changed value stays in same p90 bucket → no re-layout needed
+    // -----------------------------------------------------------------------
+
+    /**
+     * When data changes but the new p90 falls in the same 10-unit bucket as
+     * the snapshot, remeasureChanged() should return an empty set.
+     */
+    @Test
+    void sameBucket_noRelayoutNeeded() {
+        SchemaPath path = new SchemaPath("root", "name");
+
+        // Build data that produces p90 = 5 (values all length 5)
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 30; i++) data.add("hello"); // len 5 → p90 bucket = (int)(5/10) = 0
+
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive("name"), primStyle);
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 3);
+        Style styleModel = mock(Style.class);
+        when(styleModel.getStylesheet()).thenReturn(sheet);
+
+        // Converge
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        assertTrue(pl.isConverged(), "Must be converged before test");
+
+        MeasureResult mr = pl.getMeasureResult();
+        assertNotNull(mr, "measureResult must be non-null after convergence");
+        assertNotNull(mr.contentStats(), "contentStats must be non-null");
+        double oldP90 = mr.contentStats().p90Width();
+
+        // Snapshot the p90
+        Map<SchemaPath, Double> p90Snapshot = new HashMap<>();
+        p90Snapshot.put(path, oldP90);
+
+        // Clear frozen and prepare new data still in same bucket
+        pl.clearFrozenResult();
+        // New data: length 7 → p90 = 7.0 still in bucket 0 (7/10 = 0 == 5/10 = 0)
+        ArrayNode newData = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 30; i++) newData.add("goodbye"); // len 7
+
+        // Pre-measure to verify same bucket (using contentStats.p90Width, not columnWidth)
+        pl.measure(newData, n -> n, styleModel);
+        MeasureResult newMr = pl.getMeasureResult();
+        double newP90 = (newMr != null && newMr.contentStats() != null)
+                        ? newMr.contentStats().p90Width() : 0.0;
+
+        int oldBucket = (int)(oldP90 / 10);
+        int newBucket = (int)(newP90 / 10);
+        assertEquals(oldBucket, newBucket,
+                "Both p90 values (%.1f and %.1f) must be in same bucket for this test to be valid"
+                        .formatted(oldP90, newP90));
+
+        // Reset to cleared state for remeasureChangedForTest to re-measure
+        pl.clearFrozenResult();
+
+        // Build a layout tree with this PrimitiveLayout
+        Relation rel = new Relation("root");
+        rel.addChild(new Primitive("name"));
+        RelationLayout rl = new RelationLayout(rel, TestLayouts.mockRelationStyle());
+        rl.children.add(pl);
+
+        // remeasureChanged with this single path should return empty (bucket unchanged)
+        Set<SchemaPath> bucketChanged = AutoLayout.remeasureChangedForTest(
+                Set.of(path), rl, newData, styleModel, p90Snapshot);
+
+        assertTrue(bucketChanged.isEmpty(),
+                "Same p90 bucket: no bucket change → remeasureChanged must be empty");
+    }
+
+    // -----------------------------------------------------------------------
+    // Case (b): changed value crosses p90 bucket → re-layout needed
+    // -----------------------------------------------------------------------
+
+    @Test
+    void differentBucket_relayoutNeeded() {
+        SchemaPath path = new SchemaPath("root", "name");
+
+        // Initial data: short values → p90 in bucket 0 (len ~5)
+        ArrayNode shortData = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 30; i++) shortData.add("hello"); // len 5
+
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive("name"), primStyle);
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 3);
+        Style styleModel = mock(Style.class);
+        when(styleModel.getStylesheet()).thenReturn(sheet);
+
+        pl.measure(shortData, n -> n, styleModel);
+        pl.measure(shortData, n -> n, styleModel);
+        pl.measure(shortData, n -> n, styleModel);
+        assertTrue(pl.isConverged());
+
+        MeasureResult mr = pl.getMeasureResult();
+        double oldP90 = mr.contentStats().p90Width(); // ~5.0 → bucket 0
+
+        Map<SchemaPath, Double> p90Snapshot = new HashMap<>();
+        p90Snapshot.put(path, oldP90);
+
+        // Clear and prepare long-value data → p90 in a higher bucket
+        pl.clearFrozenResult();
+        ArrayNode longData = JsonNodeFactory.instance.arrayNode();
+        // Use values of length 15 → contentStats.p90Width = 15.0 → bucket 1
+        for (int i = 0; i < 30; i++) longData.add("averylongvalue!"); // len 15
+
+        // Pre-measure to verify different bucket
+        pl.measure(longData, n -> n, styleModel);
+        MeasureResult newMr = pl.getMeasureResult();
+        double newP90 = (newMr != null && newMr.contentStats() != null)
+                        ? newMr.contentStats().p90Width() : 0.0;
+
+        int oldBucket = (int)(oldP90 / 10);
+        int newBucket = (int)(newP90 / 10);
+        assertNotEquals(oldBucket, newBucket,
+                "p90 values (%.1f and %.1f) must be in different buckets for this test"
+                        .formatted(oldP90, newP90));
+
+        // Reset for remeasureChangedForTest to re-measure
+        pl.clearFrozenResult();
+
+        Relation rel = new Relation("root");
+        rel.addChild(new Primitive("name"));
+        RelationLayout rl = new RelationLayout(rel, TestLayouts.mockRelationStyle());
+        rl.children.add(pl);
+
+        Set<SchemaPath> bucketChanged = AutoLayout.remeasureChangedForTest(
+                Set.of(path), rl, longData, styleModel, p90Snapshot);
+
+        assertEquals(Set.of(path), bucketChanged,
+                "Different bucket: path must appear in bucketChanged set");
+    }
+
+    // -----------------------------------------------------------------------
+    // Convergence fast-path: converged && new_value <= p90Snapshot → skip clear
+    // -----------------------------------------------------------------------
+
+    /**
+     * If a primitive is converged and the new data's value does not exceed the
+     * snapshot p90, clearFrozenResultForPaths should NOT clear frozenResult for
+     * that path (the fast-path short-circuit).
+     */
+    @Test
+    void convergenceFastPath_skipsClearWhenValueBelowSnapshot() {
+        SchemaPath path = new SchemaPath("root", "name");
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 30; i++) data.add("hello"); // len 5
+
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive("name"), primStyle);
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 3);
+        Style styleModel = mock(Style.class);
+        when(styleModel.getStylesheet()).thenReturn(sheet);
+
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        assertTrue(pl.isConverged());
+
+        double snapshotP90 = pl.getMeasureResult().contentStats().p90Width(); // ~5.0
+
+        // New data with values narrower than snapshot → p90 will be <= snapshotP90
+        ArrayNode narrower = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 30; i++) narrower.add("hi"); // len 2
+
+        // Build tree
+        Relation rel = new Relation("root");
+        rel.addChild(new Primitive("name"));
+        RelationLayout rl = new RelationLayout(rel, TestLayouts.mockRelationStyle());
+        rl.children.add(pl);
+
+        // Use the fast-path check: converged && new_value <= snapshotP90 → skip clearing
+        // We test this by calling clearFrozenResultForPathsForTest with a p90Snapshot that
+        // has a value >= the new data's max value.
+        Map<SchemaPath, Double> p90snap = new HashMap<>();
+        p90snap.put(path, snapshotP90);
+
+        // Fast-path: should NOT clear frozen result since the new value is <= snapshot p90
+        AutoLayout.clearFrozenResultForPathsForTest(Set.of(path), rl, narrower, styleModel, p90snap);
+
+        // frozenResult should still be intact (was converged, new value fits within snapshot)
+        assertTrue(pl.isConverged(),
+                "Fast-path: converged layout with new value <= p90Snapshot must NOT be cleared");
+    }
+
+    // -----------------------------------------------------------------------
+    // OUTLINE sibling expansion
+    // -----------------------------------------------------------------------
+
+    /**
+     * When a changed primitive's parent RelationLayout is in OUTLINE mode
+     * (useTable == false), all siblings should also be added to the re-measure set.
+     */
+    @Test
+    void outlineSiblingExpansion_siblingsRemeasured() {
+        SchemaPath rootPath = new SchemaPath("root");
+        SchemaPath namePath = rootPath.child("name");
+        SchemaPath agePath  = rootPath.child("age");
+
+        // Build two primitives as siblings under an OUTLINE RelationLayout
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout namePl = new PrimitiveLayout(new Primitive("name"), primStyle);
+        namePl.setSchemaPath(namePath);
+        PrimitiveLayout agePl = new PrimitiveLayout(new Primitive("age"), primStyle);
+        agePl.setSchemaPath(agePath);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(namePath, "stat-min-samples", 5);
+        sheet.setOverride(namePath, "stat-convergence-k", 3);
+        sheet.setOverride(agePath, "stat-min-samples", 5);
+        sheet.setOverride(agePath, "stat-convergence-k", 3);
+        Style styleModel = mock(Style.class);
+        when(styleModel.getStylesheet()).thenReturn(sheet);
+
+        // Measure both to get a non-null measureResult
+        ArrayNode nameData = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 30; i++) nameData.add("Alice");
+        ArrayNode ageData = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 30; i++) ageData.add("30");
+        namePl.measure(nameData, n -> n, styleModel);
+        agePl.measure(ageData, n -> n, styleModel);
+
+        Relation rel = new Relation("root");
+        rel.addChild(new Primitive("name"));
+        rel.addChild(new Primitive("age"));
+
+        // OUTLINE mode: useTable = false
+        RelationLayout rl = new RelationLayout(rel, TestLayouts.mockRelationStyle());
+        rl.children.add(namePl);
+        rl.children.add(agePl);
+        // useTable defaults to false → OUTLINE
+
+        // p90Snapshot: record old p90s
+        Map<SchemaPath, Double> p90Snapshot = new HashMap<>();
+        MeasureResult nameMr = namePl.getMeasureResult();
+        MeasureResult ageMr  = agePl.getMeasureResult();
+        if (nameMr != null && nameMr.contentStats() != null)
+            p90Snapshot.put(namePath, nameMr.contentStats().p90Width());
+        if (ageMr != null && ageMr.contentStats() != null)
+            p90Snapshot.put(agePath,  ageMr.contentStats().p90Width());
+
+        // Clear only 'name' — but expect sibling 'age' is included in re-measure
+        namePl.clearFrozenResult();
+
+        // Build combined data for re-measure (both fields)
+        ArrayNode combined = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 30; i++) {
+            ObjectNode row = JsonNodeFactory.instance.objectNode();
+            row.put("name", "A very long name that changes the bucket significantly!");
+            row.put("age", "30");
+            combined.add(row);
+        }
+
+        Set<SchemaPath> bucketChanged = AutoLayout.remeasureChangedForTest(
+                Set.of(namePath), rl, combined, styleModel, p90Snapshot);
+
+        // 'name' has a very long new value → bucket definitely changed
+        // 'age' was added as a sibling and re-measured, but its value is unchanged
+        // So bucketChanged must contain at least 'name' (which crossed a bucket)
+        assertTrue(bucketChanged.contains(namePath),
+                "name path must be in bucketChanged (bucket crossed)");
+    }
+
+    // -----------------------------------------------------------------------
+    // Empty changedPaths → no re-measure
+    // -----------------------------------------------------------------------
+
+    @Test
+    void emptyChangedPaths_noRemeasure() {
+        SchemaPath path = new SchemaPath("root", "name");
+
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive("name"), primStyle);
+        pl.setSchemaPath(path);
+
+        DefaultLayoutStylesheet sheet = new DefaultLayoutStylesheet(null);
+        sheet.setOverride(path, "stat-min-samples", 5);
+        sheet.setOverride(path, "stat-convergence-k", 3);
+        Style styleModel = mock(Style.class);
+        when(styleModel.getStylesheet()).thenReturn(sheet);
+
+        ArrayNode data = JsonNodeFactory.instance.arrayNode();
+        for (int i = 0; i < 30; i++) data.add("hello");
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        pl.measure(data, n -> n, styleModel);
+        assertTrue(pl.isConverged());
+
+        Relation rel = new Relation("root");
+        rel.addChild(new Primitive("name"));
+        RelationLayout rl = new RelationLayout(rel, TestLayouts.mockRelationStyle());
+        rl.children.add(pl);
+
+        Map<SchemaPath, Double> p90Snapshot = new HashMap<>();
+
+        // Empty changedPaths → remeasureChanged returns empty immediately
+        Set<SchemaPath> result = AutoLayout.remeasureChangedForTest(
+                Set.of(), rl, data, styleModel, p90Snapshot);
+
+        assertTrue(result.isEmpty(), "Empty changedPaths must produce empty bucketChanged");
+        assertTrue(pl.isConverged(),
+                "PrimitiveLayout must not be disturbed when changedPaths is empty");
+    }
+}


### PR DESCRIPTION
## Summary
- **Kramer-bhin**: Selective re-measure of changed primitives only. Bucket comparison `(int)(p90/10)`. Convergence fast-path. OUTLINE sibling expansion. Three-tier short-circuit: empty paths → rebind, same bucket → rebind, bucket changed → re-layout.

## Test plan
- [x] 625 tests pass (5 new)

Ref: Kramer-bhin