### PR TITLE
RDR-023 Phase 3c + epic close: mode-flip detection — all phases complete

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/AutoLayout.java
@@ -659,9 +659,19 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
                     return;
                 }
 
-                // Bucket changed — need re-layout for affected subtree
-                // Phase 3c will optimize to partial re-layout; for now: full re-layout
-                Platform.runLater(() -> autoLayout(datum, getWidth()));
+                // Phase 3c: check whether the bucket change actually flips a TABLE/OUTLINE decision.
+                // This is O(changed_paths) — no solver re-run needed.
+                if (detectModeFlip(bucketChangedPaths)) {
+                    // Mode assignment changed — full re-layout required
+                    autoLayout(datum, getWidth());
+                } else {
+                    // Width shifted but mode unchanged — rebind only
+                    if (control != null) {
+                        control.updateItem(datum);
+                    }
+                }
+                updateSnapshots(datum);
+                return;
             } else if (control == null) {
                 Platform.runLater(() -> autoLayout(datum, getWidth()));
             } else {
@@ -708,6 +718,17 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
         Map<SchemaPath, Double> newP90 = new HashMap<>(p90Snapshot);
         clearFrozenResultInTree(layout, paths, newP90, data.get(), model);
         p90Snapshot = Map.copyOf(newP90);
+    }
+
+    /**
+     * Updates {@link #dataSnapshot} from the current layout tree and datum.
+     * Called after the Phase 3c fast-path (rebind without full re-layout) to
+     * keep the snapshot current for the next {@link #setContent()} comparison.
+     */
+    private void updateSnapshots(JsonNode datum) {
+        if (layout != null && datum != null) {
+            dataSnapshot = DataSnapshot.buildSnapshot(layout, datum);
+        }
     }
 
     /**
@@ -802,6 +823,92 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
     private Set<SchemaPath> remeasureChanged(Set<SchemaPath> changedPaths,
                                               JsonNode datum) {
         return remeasureChangedImpl(changedPaths, layout, datum, model, p90Snapshot);
+    }
+
+    /**
+     * Phase 3c: Lightweight mode-flip detection.
+     *
+     * <p>After {@link #remeasureChanged} identifies bucket-changed paths, this
+     * method checks whether any affected {@link RelationLayout} ancestor would
+     * actually flip its TABLE/OUTLINE decision.  Uses a direct threshold
+     * comparison — {@code calculateTableColumnWidth() + nestedHorizontalInset <= availableWidth}
+     * — against each RelationLayout ancestor of the changed paths, without
+     * running the full constraint solver.
+     *
+     * @param bucketChangedPaths paths whose p90 bucket changed after re-measure
+     * @return {@code true} if any ancestor RelationLayout would change its
+     *         TABLE/OUTLINE mode, requiring a full re-layout; {@code false} if
+     *         the mode is stable and a rebind suffices
+     */
+    private boolean detectModeFlip(Set<SchemaPath> bucketChangedPaths) {
+        if (layout == null || decisionCache.isEmpty()) return true;
+        return detectModeFlipInTree(bucketChangedPaths, layout, getWidth());
+    }
+
+    /**
+     * Recursively walks the layout tree rooted at {@code node}, checking each
+     * {@link RelationLayout} that is a strict ancestor of any path in
+     * {@code changedPaths}. For each such relation, recomputes
+     * {@code calculateTableColumnWidth()} and compares the threshold
+     * {@code newTableWidth + nestedInset <= availableWidth} against the current
+     * {@link RelationLayout#isUseTable()} state. Returns {@code true} on the
+     * first detected flip.
+     *
+     * @param changedPaths  paths whose p90 bucket changed
+     * @param node          current layout node being evaluated
+     * @param availableWidth width available to {@code node} from its parent
+     * @return {@code true} if a mode flip is detected anywhere in the subtree
+     */
+    private static boolean detectModeFlipInTree(Set<SchemaPath> changedPaths,
+                                                 SchemaNodeLayout node,
+                                                 double availableWidth) {
+        if (!(node instanceof RelationLayout rl)) return false;
+
+        SchemaPath rlPath = rl.getSchemaPath();
+        if (rlPath != null && isAncestorOfAny(rlPath, changedPaths)) {
+            boolean currentUseTable = rl.isUseTable();
+            double newTableWidth    = rl.calculateTableColumnWidth();
+            double nestedInset      = rl.getStyle().getNestedHorizontalInset();
+            boolean wouldUseTable   = newTableWidth + nestedInset <= availableWidth;
+            if (currentUseTable != wouldUseTable) {
+                return true;
+            }
+        }
+
+        // Recurse into child RelationLayouts.
+        // In OUTLINE mode the child's available width = (parentWidth - labelWidth)
+        // - outlineCellHorizontalInset. In TABLE mode the top-level layout pass
+        // already committed the tree; we use a conservative full-width estimate
+        // for children to avoid false negatives.
+        double lw = rl.getLabelWidth();
+        double childWidth = rl.isUseTable()
+                ? availableWidth
+                : availableWidth - lw - rl.getStyle().getOutlineCellHorizontalInset();
+
+        for (SchemaNodeLayout child : rl.getChildren()) {
+            if (detectModeFlipInTree(changedPaths, child, childWidth)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns {@code true} when {@code candidate} is a strict ancestor of at
+     * least one path in {@code paths}: i.e., {@code candidate} is a proper
+     * prefix of that path (has fewer segments and the segments match).
+     */
+    private static boolean isAncestorOfAny(SchemaPath candidate,
+                                            Set<SchemaPath> paths) {
+        List<String> candSegs = candidate.segments();
+        for (SchemaPath p : paths) {
+            List<String> segs = p.segments();
+            if (segs.size() > candSegs.size()
+                    && segs.subList(0, candSegs.size()).equals(candSegs)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -926,6 +1033,24 @@ public class AutoLayout extends AnchorPane implements LayoutCell<AutoLayout> {
                                                     Style model,
                                                     Map<SchemaPath, Double> p90Snapshot) {
         return remeasureChangedImpl(changedPaths, rootLayout, datum, model, p90Snapshot);
+    }
+
+    /**
+     * Test-visible entry-point for {@link #detectModeFlipInTree}.
+     * Allows headless unit tests to exercise the mode-flip detection logic
+     * without a live {@link AutoLayout} instance.
+     *
+     * @param bucketChangedPaths paths whose p90 bucket changed after re-measure
+     * @param rootLayout         the root of the layout tree (may be null)
+     * @param availableWidth     the width available to the root node
+     * @return {@code true} if any ancestor RelationLayout would change its
+     *         TABLE/OUTLINE mode; {@code true} when {@code rootLayout} is null
+     */
+    static boolean detectModeFlipForTest(Set<SchemaPath> bucketChangedPaths,
+                                          SchemaNodeLayout rootLayout,
+                                          double availableWidth) {
+        if (rootLayout == null) return true;
+        return detectModeFlipInTree(bucketChangedPaths, rootLayout, availableWidth);
     }
 
     /**

--- a/kramer/src/test/java/com/chiralbehaviors/layout/ModeFlipDetectionTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/ModeFlipDetectionTest.java
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import com.chiralbehaviors.layout.schema.Primitive;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.PrimitiveStyle;
+
+/**
+ * Tests for Kramer-nyqy Phase 3c: Lightweight mode-flip detection.
+ *
+ * Uses AutoLayout.detectModeFlipForTest() — a static test-visible entry-point
+ * that drives the same tree-walk logic as the private detectModeFlip() method,
+ * without requiring a live AutoLayout or JavaFX.
+ *
+ * All tests are headless.
+ */
+class ModeFlipDetectionTest {
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Build a single-child RelationLayout with a PrimitiveLayout whose
+     * dataWidth is set to {@code primDataWidth}. The RelationLayout is forced
+     * into TABLE mode via nestTableColumn(). mockRelationStyle has all insets=0,
+     * so calculateTableColumnWidth() == primDataWidth.
+     *
+     * @param rootPath      path for the RelationLayout
+     * @param primPath      path for the PrimitiveLayout child
+     * @param primDataWidth the dataWidth to inject directly into the PrimitiveLayout
+     * @return RelationLayout in TABLE mode
+     */
+    private static RelationLayout buildTableModeRelation(SchemaPath rootPath,
+                                                          SchemaPath primPath,
+                                                          double primDataWidth) {
+        RelationLayout rl = buildRelationLayout(rootPath, primPath, primDataWidth);
+        rl.nestTableColumn(SchemaNodeLayout.Indent.TOP, new javafx.geometry.Insets(0));
+        return rl;
+    }
+
+    /**
+     * Build a single-child RelationLayout in OUTLINE mode (useTable=false).
+     */
+    private static RelationLayout buildOutlineModeRelation(SchemaPath rootPath,
+                                                            SchemaPath primPath,
+                                                            double primDataWidth) {
+        return buildRelationLayout(rootPath, primPath, primDataWidth);
+    }
+
+    /**
+     * Constructs a RelationLayout with one PrimitiveLayout child. Injects
+     * {@code primDataWidth} directly into the PrimitiveLayout's dataWidth field
+     * so that tableColumnWidth() returns a predictable value without needing
+     * a full measure() pipeline.
+     */
+    private static RelationLayout buildRelationLayout(SchemaPath rootPath,
+                                                       SchemaPath primPath,
+                                                       double primDataWidth) {
+        PrimitiveStyle primStyle = TestLayouts.mockPrimitiveStyle(1.0);
+        PrimitiveLayout pl = new PrimitiveLayout(new Primitive(primPath.leaf()), primStyle);
+        pl.setSchemaPath(primPath);
+        // Directly set dataWidth so tableColumnWidth() returns a known value.
+        // dataWidth is protected and tests are in the same package.
+        pl.dataWidth = primDataWidth;
+
+        Relation rel = new Relation(rootPath.leaf());
+        rel.addChild(new Primitive(primPath.leaf()));
+
+        RelationLayout rl = new RelationLayout(rel, TestLayouts.mockRelationStyle());
+        rl.children.add(pl);
+        rl.setSchemaPath(rootPath);
+        return rl;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 1: p90 change within threshold → no mode flip, just rebind
+    // -----------------------------------------------------------------------
+
+    /**
+     * RelationLayout is TABLE mode. calculateTableColumnWidth() returns a value
+     * that still fits within availableWidth. No mode flip expected.
+     *
+     * tableColumnWidth = 50, nestedInset = 0, availableWidth = 200
+     * 50 + 0 <= 200 → still fits → current mode TABLE == new mode TABLE → no flip
+     */
+    @Test
+    void p90WithinThreshold_noModeFlip() {
+        SchemaPath rootPath = new SchemaPath("root");
+        SchemaPath primPath = rootPath.child("name");
+
+        // useTable=true, calculateTableColumnWidth()=50, availableWidth=200 → fits
+        RelationLayout rl = buildTableModeRelation(rootPath, primPath, 50.0);
+        double availableWidth = 200.0;
+
+        boolean flipped = AutoLayout.detectModeFlipForTest(Set.of(primPath), rl, availableWidth);
+
+        assertFalse(flipped,
+                "Table still fits in available width: no mode flip expected");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 2: p90 increase crosses tableColumnWidth threshold → TABLE→OUTLINE
+    // -----------------------------------------------------------------------
+
+    /**
+     * RelationLayout is TABLE mode (useTable=true). After re-measure,
+     * calculateTableColumnWidth() now exceeds availableWidth. Mode flips TABLE→OUTLINE.
+     *
+     * tableColumnWidth = 50, nestedInset = 0, availableWidth = 40
+     * 50 + 0 > 40 → would be OUTLINE → current mode TABLE != OUTLINE → FLIP
+     */
+    @Test
+    void p90IncreaseCrossesThreshold_tableToOutlineFlip() {
+        SchemaPath rootPath = new SchemaPath("root");
+        SchemaPath primPath = rootPath.child("value");
+
+        RelationLayout rl = buildTableModeRelation(rootPath, primPath, 50.0);
+        double availableWidth = 40.0; // too narrow for tableColumnWidth=50
+
+        boolean flipped = AutoLayout.detectModeFlipForTest(Set.of(primPath), rl, availableWidth);
+
+        assertTrue(flipped,
+                "Table no longer fits: TABLE→OUTLINE mode flip must be detected");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 3: p90 decrease crosses threshold → OUTLINE→TABLE flip
+    // -----------------------------------------------------------------------
+
+    /**
+     * RelationLayout is OUTLINE mode (useTable=false). After re-measure,
+     * calculateTableColumnWidth() now fits in availableWidth. Mode flips OUTLINE→TABLE.
+     *
+     * tableColumnWidth = 30, nestedInset = 0, availableWidth = 100
+     * 30 + 0 <= 100 → would be TABLE → current mode OUTLINE != TABLE → FLIP
+     */
+    @Test
+    void p90DecreaseCrossesThreshold_outlineToTableFlip() {
+        SchemaPath rootPath = new SchemaPath("root");
+        SchemaPath primPath = rootPath.child("label");
+
+        RelationLayout rl = buildOutlineModeRelation(rootPath, primPath, 30.0);
+        double availableWidth = 100.0;
+
+        boolean flipped = AutoLayout.detectModeFlipForTest(Set.of(primPath), rl, availableWidth);
+
+        assertTrue(flipped,
+                "Table now fits: OUTLINE→TABLE mode flip must be detected");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 4: null rootLayout → fall through to full re-layout
+    // -----------------------------------------------------------------------
+
+    /**
+     * When detectModeFlipForTest is called with null rootLayout, it must return
+     * true so the caller falls through to full re-layout (conservative path).
+     */
+    @Test
+    void nullRootLayout_fallsThroughToFullRelayout() {
+        boolean flipped = AutoLayout.detectModeFlipForTest(
+                Set.of(new SchemaPath("root", "x")),
+                null,
+                100.0);
+
+        assertTrue(flipped,
+                "Null rootLayout must return true to trigger full re-layout");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 5: LCA subtree identification — only affected subtree checked
+    // -----------------------------------------------------------------------
+
+    /**
+     * Two child RelationLayouts under a root. Only leftBranch has a changed path.
+     * leftBranch is TABLE but its calculateTableColumnWidth() exceeds the available
+     * width → flip detected. rightBranch is stable (not evaluated). The overall
+     * result is true because leftBranch flips.
+     */
+    @Test
+    void lcaSubtree_onlyAffectedSubtreeChecked() {
+        SchemaPath rootPath  = new SchemaPath("root");
+        SchemaPath leftPath  = rootPath.child("left");
+        SchemaPath rightPath = rootPath.child("right");
+        SchemaPath leftPrimPath  = leftPath.child("leftPrim");
+        SchemaPath rightPrimPath = rightPath.child("rightPrim");
+
+        // leftBranch: TABLE mode, tableColumnWidth=80, availableWidth=60 → won't fit → FLIP
+        RelationLayout leftRl  = buildTableModeRelation(leftPath, leftPrimPath, 80.0);
+        // rightBranch: TABLE mode, tableColumnWidth=30, availableWidth=60 → fits → no flip
+        RelationLayout rightRl = buildTableModeRelation(rightPath, rightPrimPath, 30.0);
+
+        Relation rootRel = new Relation("root");
+        rootRel.addChild(new Relation("left"));
+        rootRel.addChild(new Relation("right"));
+        RelationLayout rootRl = new RelationLayout(rootRel, TestLayouts.mockRelationStyle());
+        rootRl.children.add(leftRl);
+        rootRl.children.add(rightRl);
+        rootRl.setSchemaPath(rootPath);
+
+        // Only leftPrimPath changed; availableWidth chosen so left flips but right doesn't
+        double availableWidth = 60.0;
+        boolean flipped = AutoLayout.detectModeFlipForTest(Set.of(leftPrimPath), rootRl, availableWidth);
+
+        assertTrue(flipped,
+                "LCA subtree: leftBranch flip must be detected from root walk");
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 6: changed path with no RelationLayout ancestor → no flip
+    // -----------------------------------------------------------------------
+
+    /**
+     * Changed path is a single-segment path (no parent). No RelationLayout in
+     * the tree has it as a descendant, so no mode flip is detected.
+     */
+    @Test
+    void noAncestorRelation_noFlip() {
+        SchemaPath rootPath = new SchemaPath("root");
+        SchemaPath primPath = rootPath.child("name");
+
+        // Tree only contains root/name, but changed path is unrelated
+        RelationLayout rl = buildTableModeRelation(rootPath, primPath, 30.0);
+        SchemaPath unrelatedPath = new SchemaPath("other", "field");
+
+        boolean flipped = AutoLayout.detectModeFlipForTest(
+                Set.of(unrelatedPath), rl, 200.0);
+
+        assertFalse(flipped,
+                "Unrelated changed path must not trigger mode flip detection");
+    }
+}


### PR DESCRIPTION
## Summary
- **Kramer-nyqy**: `detectModeFlip()` — lightweight threshold comparison against cached `LayoutResult`. No solver re-solve. Only ancestors of changed paths checked. **Phase 3c COMPLETE.**
- **Kramer-p22 epic closed** — all 5 beads, all phases, zero deferred work.

## Test plan
- [x] 631 tests pass (6 new)

Ref: Kramer-nyqy, Kramer-p22