### PR TITLE
RDR-030 P1: FieldSelectorPanel state badges + selection callback

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldSelectorPanel.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldSelectorPanel.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.chiralbehaviors.layout.query;
 
+import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.function.Consumer;
 
 import com.chiralbehaviors.layout.SchemaPath;
@@ -22,6 +24,9 @@ import javafx.scene.layout.VBox;
  * A panel displaying a {@link TreeView} of the schema tree with per-field
  * visibility checkboxes, state badges (sort, filter, type), and per-Relation
  * hide-if-empty checkboxes.
+ * <p>
+ * Call {@link #dispose()} when the panel is removed from the scene to
+ * unregister the query state change listener and prevent memory leaks.
  *
  * @author hhildebrand
  */
@@ -30,6 +35,8 @@ public final class FieldSelectorPanel extends VBox {
     private final TreeView<SchemaNode> treeView;
     private final InteractionHandler handler;
     private final LayoutQueryState queryState;
+    private final Runnable changeListener;
+    private final Map<TreeItem<SchemaNode>, SchemaPath> pathCache = new IdentityHashMap<>();
     private Consumer<SchemaPath> onFieldSelected;
 
     public FieldSelectorPanel(InteractionHandler handler,
@@ -42,16 +49,21 @@ public final class FieldSelectorPanel extends VBox {
         VBox.setVgrow(treeView, Priority.ALWAYS);
         getChildren().add(treeView);
 
+        // Refresh tree cells when query state changes (sort, filter, visibility)
+        changeListener = treeView::refresh;
+        queryState.addChangeListener(changeListener);
+
         treeView.getSelectionModel().selectedItemProperty().addListener(
             (obs, old, selected) -> {
                 if (selected != null && selected.getValue() != null
                         && onFieldSelected != null) {
-                    onFieldSelected.accept(resolvePath(selected));
+                    onFieldSelected.accept(getCachedPath(selected));
                 }
             });
     }
 
     public void setRoot(SchemaNode root) {
+        pathCache.clear();
         if (root == null) {
             treeView.setRoot(null);
             return;
@@ -73,8 +85,14 @@ public final class FieldSelectorPanel extends VBox {
         treeView.refresh();
     }
 
+    /** Unregister the query state listener. Call when removing the panel. */
+    public void dispose() {
+        queryState.removeChangeListener(changeListener);
+    }
+
     private TreeItem<SchemaNode> buildTree(SchemaNode node, SchemaPath path) {
         TreeItem<SchemaNode> item = new TreeItem<>(node);
+        pathCache.put(item, path);
         item.setExpanded(true);
         if (node instanceof Relation r) {
             for (SchemaNode child : r.getChildren()) {
@@ -83,6 +101,12 @@ public final class FieldSelectorPanel extends VBox {
             }
         }
         return item;
+    }
+
+    /** Get cached SchemaPath from a TreeItem, falling back to recomputation. */
+    private SchemaPath getCachedPath(TreeItem<SchemaNode> item) {
+        SchemaPath cached = pathCache.get(item);
+        return cached != null ? cached : resolvePath(item);
     }
 
     SchemaPath resolvePath(TreeItem<SchemaNode> item) {
@@ -119,13 +143,13 @@ public final class FieldSelectorPanel extends VBox {
             visCheck.setOnAction(e -> {
                 if (getTreeItem() != null) {
                     handler.apply(new LayoutInteraction.ToggleVisible(
-                        resolvePath(getTreeItem())));
+                        getCachedPath(getTreeItem())));
                 }
             });
             hideCheck.setOnAction(e -> {
                 if (getTreeItem() != null) {
                     handler.apply(new LayoutInteraction.SetHideIfEmpty(
-                        resolvePath(getTreeItem()), hideCheck.isSelected()));
+                        getCachedPath(getTreeItem()), hideCheck.isSelected()));
                 }
             });
         }
@@ -140,7 +164,7 @@ public final class FieldSelectorPanel extends VBox {
                 return;
             }
 
-            SchemaPath path = resolvePath(getTreeItem());
+            SchemaPath path = getCachedPath(getTreeItem());
             FieldState fs = queryState.getFieldState(path);
             boolean visible = queryState.getVisibleOrDefault(path);
 

--- a/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldSelectorPanel.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldSelectorPanel.java
@@ -22,10 +22,6 @@ import javafx.scene.layout.VBox;
  * A panel displaying a {@link TreeView} of the schema tree with per-field
  * visibility checkboxes, state badges (sort, filter, type), and per-Relation
  * hide-if-empty checkboxes.
- * <p>
- * Dispatches {@link LayoutInteraction.ToggleVisible} and
- * {@link LayoutInteraction.SetHideIfEmpty} events via an
- * {@link InteractionHandler}.
  *
  * @author hhildebrand
  */
@@ -46,7 +42,6 @@ public final class FieldSelectorPanel extends VBox {
         VBox.setVgrow(treeView, Priority.ALWAYS);
         getChildren().add(treeView);
 
-        // Selection callback
         treeView.getSelectionModel().selectedItemProperty().addListener(
             (obs, old, selected) -> {
                 if (selected != null && selected.getValue() != null
@@ -56,9 +51,6 @@ public final class FieldSelectorPanel extends VBox {
             });
     }
 
-    /**
-     * Populate the tree from a schema root. Expands all nodes.
-     */
     public void setRoot(SchemaNode root) {
         if (root == null) {
             treeView.setRoot(null);
@@ -69,17 +61,14 @@ public final class FieldSelectorPanel extends VBox {
         treeView.setRoot(rootItem);
     }
 
-    /** Returns the backing TreeView for testing and layout purposes. */
     public TreeView<SchemaNode> getTreeView() {
         return treeView;
     }
 
-    /** Set a callback that fires when a field is selected in the tree. */
     public void setOnFieldSelected(Consumer<SchemaPath> callback) {
         this.onFieldSelected = callback;
     }
 
-    /** Force tree cells to re-render (picks up state changes). */
     public void refresh() {
         treeView.refresh();
     }
@@ -96,9 +85,6 @@ public final class FieldSelectorPanel extends VBox {
         return item;
     }
 
-    /**
-     * Resolve the SchemaPath for a TreeItem by walking up the tree.
-     */
     SchemaPath resolvePath(TreeItem<SchemaNode> item) {
         if (item.getParent() == null) {
             return new SchemaPath(item.getValue().getField());
@@ -107,10 +93,42 @@ public final class FieldSelectorPanel extends VBox {
     }
 
     /**
-     * Custom tree cell with visibility checkbox, state badges, type labels,
-     * and optional hide-if-empty checkbox for Relation nodes.
+     * Tree cell that allocates its node graph ONCE in the constructor.
+     * {@code updateItem} only updates text, checkbox state, and badge
+     * visibility — no new nodes are created on cell recycle.
      */
     private class FieldTreeCell extends TreeCell<SchemaNode> {
+
+        private final HBox box = new HBox(4);
+        private final CheckBox visCheck = new CheckBox();
+        private final Label fieldLabel = new Label();
+        private final Label sortBadge = new Label();
+        private final Label filterBadge = new Label();
+        private final Region spacer = new Region();
+        private final Label typeBadge = new Label();
+        private final CheckBox hideCheck = new CheckBox("hide if empty");
+
+        FieldTreeCell() {
+            sortBadge.getStyleClass().add("sort-badge");
+            filterBadge.getStyleClass().add("filter-badge");
+            typeBadge.getStyleClass().add("type-badge");
+            HBox.setHgrow(spacer, Priority.ALWAYS);
+            box.getChildren().setAll(visCheck, fieldLabel, sortBadge,
+                                      filterBadge, spacer, typeBadge, hideCheck);
+
+            visCheck.setOnAction(e -> {
+                if (getTreeItem() != null) {
+                    handler.apply(new LayoutInteraction.ToggleVisible(
+                        resolvePath(getTreeItem())));
+                }
+            });
+            hideCheck.setOnAction(e -> {
+                if (getTreeItem() != null) {
+                    handler.apply(new LayoutInteraction.SetHideIfEmpty(
+                        resolvePath(getTreeItem()), hideCheck.isSelected()));
+                }
+            });
+        }
 
         @Override
         protected void updateItem(SchemaNode node, boolean empty) {
@@ -126,30 +144,46 @@ public final class FieldSelectorPanel extends VBox {
             FieldState fs = queryState.getFieldState(path);
             boolean visible = queryState.getVisibleOrDefault(path);
 
-            var fieldLabel = new Label(node.getField());
-            var visCheck = new CheckBox();
+            fieldLabel.setText(node.getField());
             visCheck.setSelected(visible);
-            visCheck.setOnAction(e ->
-                handler.apply(new LayoutInteraction.ToggleVisible(path)));
 
-            var box = new HBox(4, visCheck, fieldLabel);
-
-            // State badges
-            addSortBadge(box, fs, path);
-            addFilterBadge(box, fs);
-            addTypeBadge(box, node);
-
-            if (node instanceof Relation) {
-                Boolean hideIfEmpty = fs.hideIfEmpty();
-                var hideCheck = new CheckBox("hide if empty");
-                hideCheck.setSelected(Boolean.TRUE.equals(hideIfEmpty));
-                hideCheck.setOnAction(e ->
-                    handler.apply(new LayoutInteraction.SetHideIfEmpty(path,
-                        hideCheck.isSelected())));
-                box.getChildren().add(hideCheck);
+            // Sort badge
+            String sortFields = fs.sortFields();
+            String fieldName = path.leaf();
+            if (sortFields != null && sortFields.equals(fieldName)) {
+                sortBadge.setText("\u25B2");
+                sortBadge.setVisible(true);
+                sortBadge.setManaged(true);
+            } else if (sortFields != null && sortFields.equals("-" + fieldName)) {
+                sortBadge.setText("\u25BC");
+                sortBadge.setVisible(true);
+                sortBadge.setManaged(true);
+            } else {
+                sortBadge.setVisible(false);
+                sortBadge.setManaged(false);
             }
 
-            // Apply field-hidden CSS class for dimmed appearance
+            // Filter badge
+            boolean hasFilter = fs.filterExpression() != null;
+            filterBadge.setText(hasFilter ? "\u25CF" : "");
+            filterBadge.setVisible(hasFilter);
+            filterBadge.setManaged(hasFilter);
+
+            // Type badge
+            if (node instanceof Relation r) {
+                typeBadge.setText("{" + r.getChildren().size() + "}");
+            } else {
+                typeBadge.setText("a");
+            }
+
+            // Hide-if-empty checkbox (Relations only)
+            boolean isRelation = node instanceof Relation;
+            hideCheck.setVisible(isRelation);
+            hideCheck.setManaged(isRelation);
+            if (isRelation) {
+                hideCheck.setSelected(Boolean.TRUE.equals(fs.hideIfEmpty()));
+            }
+
             if (!visible) {
                 if (!getStyleClass().contains("field-hidden")) {
                     getStyleClass().add("field-hidden");
@@ -160,47 +194,6 @@ public final class FieldSelectorPanel extends VBox {
 
             setText(null);
             setGraphic(box);
-        }
-
-        private void addSortBadge(HBox box, FieldState fs, SchemaPath path) {
-            String sortFields = fs.sortFields();
-            if (sortFields == null || sortFields.isEmpty()) return;
-
-            String fieldName = path.leaf();
-            Label badge = new Label();
-            badge.getStyleClass().add("sort-badge");
-            if (sortFields.equals(fieldName)) {
-                badge.setText("\u25B2"); // ▲
-            } else if (sortFields.equals("-" + fieldName)) {
-                badge.setText("\u25BC"); // ▼
-            } else {
-                return; // sorted by a different field
-            }
-            box.getChildren().add(badge);
-        }
-
-        private void addFilterBadge(HBox box, FieldState fs) {
-            if (fs.filterExpression() == null) return;
-            Label badge = new Label("\u25CF"); // ●
-            badge.getStyleClass().add("filter-badge");
-            box.getChildren().add(badge);
-        }
-
-        private void addTypeBadge(HBox box, SchemaNode node) {
-            Label badge = new Label();
-            badge.getStyleClass().add("type-badge");
-            if (node instanceof Relation r) {
-                int childCount = r.getChildren().size();
-                badge.setText("{" + childCount + "}");
-            } else if (node instanceof Primitive) {
-                badge.setText("a");
-            } else {
-                return;
-            }
-            // Push to right side
-            Region spacer = new Region();
-            HBox.setHgrow(spacer, Priority.ALWAYS);
-            box.getChildren().addAll(spacer, badge);
         }
     }
 }

--- a/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldSelectorPanel.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldSelectorPanel.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.chiralbehaviors.layout.query;
 
+import java.util.function.Consumer;
+
 import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.schema.Primitive;
 import com.chiralbehaviors.layout.schema.Relation;
@@ -13,11 +15,13 @@ import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
 /**
  * A panel displaying a {@link TreeView} of the schema tree with per-field
- * visibility checkboxes and per-Relation hide-if-empty checkboxes.
+ * visibility checkboxes, state badges (sort, filter, type), and per-Relation
+ * hide-if-empty checkboxes.
  * <p>
  * Dispatches {@link LayoutInteraction.ToggleVisible} and
  * {@link LayoutInteraction.SetHideIfEmpty} events via an
@@ -30,6 +34,7 @@ public final class FieldSelectorPanel extends VBox {
     private final TreeView<SchemaNode> treeView;
     private final InteractionHandler handler;
     private final LayoutQueryState queryState;
+    private Consumer<SchemaPath> onFieldSelected;
 
     public FieldSelectorPanel(InteractionHandler handler,
                                LayoutQueryState queryState) {
@@ -40,6 +45,15 @@ public final class FieldSelectorPanel extends VBox {
         treeView.setCellFactory(tv -> new FieldTreeCell());
         VBox.setVgrow(treeView, Priority.ALWAYS);
         getChildren().add(treeView);
+
+        // Selection callback
+        treeView.getSelectionModel().selectedItemProperty().addListener(
+            (obs, old, selected) -> {
+                if (selected != null && selected.getValue() != null
+                        && onFieldSelected != null) {
+                    onFieldSelected.accept(resolvePath(selected));
+                }
+            });
     }
 
     /**
@@ -60,6 +74,16 @@ public final class FieldSelectorPanel extends VBox {
         return treeView;
     }
 
+    /** Set a callback that fires when a field is selected in the tree. */
+    public void setOnFieldSelected(Consumer<SchemaPath> callback) {
+        this.onFieldSelected = callback;
+    }
+
+    /** Force tree cells to re-render (picks up state changes). */
+    public void refresh() {
+        treeView.refresh();
+    }
+
     private TreeItem<SchemaNode> buildTree(SchemaNode node, SchemaPath path) {
         TreeItem<SchemaNode> item = new TreeItem<>(node);
         item.setExpanded(true);
@@ -75,7 +99,7 @@ public final class FieldSelectorPanel extends VBox {
     /**
      * Resolve the SchemaPath for a TreeItem by walking up the tree.
      */
-    private SchemaPath resolvePath(TreeItem<SchemaNode> item) {
+    SchemaPath resolvePath(TreeItem<SchemaNode> item) {
         if (item.getParent() == null) {
             return new SchemaPath(item.getValue().getField());
         }
@@ -83,8 +107,8 @@ public final class FieldSelectorPanel extends VBox {
     }
 
     /**
-     * Custom tree cell with visibility checkbox and optional hide-if-empty
-     * checkbox for Relation nodes.
+     * Custom tree cell with visibility checkbox, state badges, type labels,
+     * and optional hide-if-empty checkbox for Relation nodes.
      */
     private class FieldTreeCell extends TreeCell<SchemaNode> {
 
@@ -99,18 +123,24 @@ public final class FieldSelectorPanel extends VBox {
             }
 
             SchemaPath path = resolvePath(getTreeItem());
+            FieldState fs = queryState.getFieldState(path);
             boolean visible = queryState.getVisibleOrDefault(path);
 
-            var label = new Label(node.getField());
+            var fieldLabel = new Label(node.getField());
             var visCheck = new CheckBox();
             visCheck.setSelected(visible);
             visCheck.setOnAction(e ->
                 handler.apply(new LayoutInteraction.ToggleVisible(path)));
 
-            var box = new HBox(4, visCheck, label);
+            var box = new HBox(4, visCheck, fieldLabel);
+
+            // State badges
+            addSortBadge(box, fs, path);
+            addFilterBadge(box, fs);
+            addTypeBadge(box, node);
 
             if (node instanceof Relation) {
-                Boolean hideIfEmpty = queryState.getFieldState(path).hideIfEmpty();
+                Boolean hideIfEmpty = fs.hideIfEmpty();
                 var hideCheck = new CheckBox("hide if empty");
                 hideCheck.setSelected(Boolean.TRUE.equals(hideIfEmpty));
                 hideCheck.setOnAction(e ->
@@ -130,6 +160,47 @@ public final class FieldSelectorPanel extends VBox {
 
             setText(null);
             setGraphic(box);
+        }
+
+        private void addSortBadge(HBox box, FieldState fs, SchemaPath path) {
+            String sortFields = fs.sortFields();
+            if (sortFields == null || sortFields.isEmpty()) return;
+
+            String fieldName = path.leaf();
+            Label badge = new Label();
+            badge.getStyleClass().add("sort-badge");
+            if (sortFields.equals(fieldName)) {
+                badge.setText("\u25B2"); // ▲
+            } else if (sortFields.equals("-" + fieldName)) {
+                badge.setText("\u25BC"); // ▼
+            } else {
+                return; // sorted by a different field
+            }
+            box.getChildren().add(badge);
+        }
+
+        private void addFilterBadge(HBox box, FieldState fs) {
+            if (fs.filterExpression() == null) return;
+            Label badge = new Label("\u25CF"); // ●
+            badge.getStyleClass().add("filter-badge");
+            box.getChildren().add(badge);
+        }
+
+        private void addTypeBadge(HBox box, SchemaNode node) {
+            Label badge = new Label();
+            badge.getStyleClass().add("type-badge");
+            if (node instanceof Relation r) {
+                int childCount = r.getChildren().size();
+                badge.setText("{" + childCount + "}");
+            } else if (node instanceof Primitive) {
+                badge.setText("a");
+            } else {
+                return;
+            }
+            // Push to right side
+            Region spacer = new Region();
+            HBox.setHgrow(spacer, Priority.ALWAYS);
+            box.getChildren().addAll(spacer, badge);
         }
     }
 }

--- a/kramer/src/main/resources/com/chiralbehaviors/layout/default.css
+++ b/kramer/src/main/resources/com/chiralbehaviors/layout/default.css
@@ -40,7 +40,6 @@
 
 .field-hidden {
     -fx-opacity: 0.4;
-    -fx-strikethrough: true;
 }
 
 .field-selector-panel {

--- a/kramer/src/main/resources/com/chiralbehaviors/layout/default.css
+++ b/kramer/src/main/resources/com/chiralbehaviors/layout/default.css
@@ -47,6 +47,24 @@
     -fx-padding: 4;
 }
 
+.sort-badge {
+    -fx-font-size: 9px;
+    -fx-text-fill: #2196F3;
+    -fx-padding: 0 2 0 2;
+}
+
+.filter-badge {
+    -fx-font-size: 8px;
+    -fx-text-fill: #FF9800;
+    -fx-padding: 0 2 0 2;
+}
+
+.type-badge {
+    -fx-font-size: 9px;
+    -fx-text-fill: #999;
+    -fx-padding: 0 4 0 4;
+}
+
 .crosstab-header { /* inherits from .kramer-container */ }
 .crosstab-header-label { -fx-font-weight: bold; }
 .crosstab-row { /* inherits from .kramer-container */ }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldSelectorPanelTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldSelectorPanelTest.java
@@ -280,4 +280,56 @@ class FieldSelectorPanelTest {
         assertEquals("records/details/value", ref.get().toString(),
             "Path should be fully qualified");
     }
+
+    // -------------------------------------------------------------------
+    // CSS class verification
+    // -------------------------------------------------------------------
+
+    @Test
+    void hiddenFieldGetsDimmedCssClass() {
+        var ref = new AtomicReference<Boolean>();
+        Platform.runLater(() -> {
+            var path = new SchemaPath("records", "name");
+            handler.apply(new LayoutInteraction.ToggleVisible(path)); // hide
+
+            var panel = createAndAttach(buildSchema());
+            // The change listener auto-refreshes; check for field-hidden nodes
+            var cells = findNodesByClass(panel, "field-hidden");
+            ref.set(!cells.isEmpty());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertTrue(ref.get(), "Hidden field cell should have field-hidden CSS class");
+    }
+
+    @Test
+    void visibleFieldDoesNotHaveDimmedCssClass() {
+        var ref = new AtomicReference<Boolean>();
+        Platform.runLater(() -> {
+            // All fields visible by default
+            var panel = createAndAttach(buildSchema());
+            var cells = findNodesByClass(panel, "field-hidden");
+            ref.set(cells.isEmpty());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertTrue(ref.get(), "Visible fields should not have field-hidden CSS class");
+    }
+
+    private List<Node> findNodesByClass(Node root, String cssClass) {
+        List<Node> result = new java.util.ArrayList<>();
+        findNodesByClassRec(root, cssClass, result);
+        return result;
+    }
+
+    private void findNodesByClassRec(Node node, String cssClass, List<Node> out) {
+        if (node.getStyleClass().contains(cssClass)) {
+            out.add(node);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                findNodesByClassRec(child, cssClass, out);
+            }
+        }
+    }
 }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldSelectorPanelTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldSelectorPanelTest.java
@@ -91,7 +91,8 @@ class FieldSelectorPanelTest {
     }
 
     private void findLabelsByClassRec(Node node, String cssClass, List<Label> out) {
-        if (node instanceof Label label && label.getStyleClass().contains(cssClass)) {
+        if (node instanceof Label label && label.getStyleClass().contains(cssClass)
+                && label.isVisible()) {
             out.add(label);
         }
         if (node instanceof Parent parent) {
@@ -220,20 +221,26 @@ class FieldSelectorPanelTest {
         });
         WaitForAsyncUtils.waitForFxEvents();
 
-        assertFalse(ref.get().isEmpty(), "Relation nodes should have type badge");
+        assertFalse(ref.get().isEmpty(), "Type badges should appear");
+        assertTrue(ref.get().stream().anyMatch(l -> l.getText().startsWith("{")),
+            "Relation type badge should show {N} format");
+        assertTrue(ref.get().stream().anyMatch(l -> "a".equals(l.getText())),
+            "Primitive type badge should show 'a'");
     }
 
     @Test
     void noBadgesWhenNoStateOverrides() {
-        var ref = new AtomicReference<List<Label>>();
+        var sortRef = new AtomicReference<List<Label>>();
+        var filterRef = new AtomicReference<List<Label>>();
         Platform.runLater(() -> {
-            // No state changes — no badges expected
             var panel = createAndAttach(buildSchema());
-            ref.set(findLabelsByClass(panel, "sort-badge"));
+            sortRef.set(findLabelsByClass(panel, "sort-badge"));
+            filterRef.set(findLabelsByClass(panel, "filter-badge"));
         });
         WaitForAsyncUtils.waitForFxEvents();
 
-        assertTrue(ref.get().isEmpty(), "No sort badges when no fields are sorted");
+        assertTrue(sortRef.get().isEmpty(), "No sort badges when no fields are sorted");
+        assertTrue(filterRef.get().isEmpty(), "No filter badges when no fields are filtered");
     }
 
     // -------------------------------------------------------------------
@@ -246,8 +253,9 @@ class FieldSelectorPanelTest {
         Platform.runLater(() -> {
             var panel = createAndAttach(buildSchema());
             panel.setOnFieldSelected(ref::set);
-            // Select "name" (index 2: root=0, id=1, name=2)
-            panel.getTreeView().getSelectionModel().select(2);
+            // Select "name" via tree model (not fragile index)
+            TreeItem<SchemaNode> nameItem = panel.getTreeView().getRoot().getChildren().get(1);
+            panel.getTreeView().getSelectionModel().select(nameItem);
         });
         WaitForAsyncUtils.waitForFxEvents();
 
@@ -261,8 +269,10 @@ class FieldSelectorPanelTest {
         Platform.runLater(() -> {
             var panel = createAndAttach(buildSchema());
             panel.setOnFieldSelected(ref::set);
-            // Select "value" inside "details" (deeper path)
-            panel.getTreeView().getSelectionModel().select(4); // root=0,id=1,name=2,details=3,value=4
+            // Select "value" inside "details" via tree model
+            TreeItem<SchemaNode> details = panel.getTreeView().getRoot().getChildren().get(2);
+            TreeItem<SchemaNode> value = details.getChildren().get(0);
+            panel.getTreeView().getSelectionModel().select(value);
         });
         WaitForAsyncUtils.waitForFxEvents();
 

--- a/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldSelectorPanelTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldSelectorPanelTest.java
@@ -3,6 +3,8 @@ package com.chiralbehaviors.layout.query;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -16,16 +18,21 @@ import com.chiralbehaviors.layout.ConfiguredMeasurementStrategy;
 import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.schema.Primitive;
 import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.schema.SchemaNode;
 import com.chiralbehaviors.layout.style.Style;
 
 import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Parent;
 import javafx.scene.Scene;
+import javafx.scene.control.Label;
 import javafx.scene.control.TreeItem;
 import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 
 /**
- * Tests for FieldSelectorPanel (Kramer-6u5t T3.1).
+ * Tests for FieldSelectorPanel: visibility checkboxes, state badges,
+ * type labels, and selection callback.
  */
 @ExtendWith(ApplicationExtension.class)
 class FieldSelectorPanelTest {
@@ -33,10 +40,12 @@ class FieldSelectorPanelTest {
     private Style style;
     private LayoutQueryState queryState;
     private InteractionHandler handler;
+    private Stage testStage;
 
     @Start
     void start(Stage stage) {
-        stage.setScene(new Scene(new Pane(), 400, 300));
+        this.testStage = stage;
+        stage.setScene(new Scene(new Pane(), 400, 400));
         stage.show();
     }
 
@@ -57,17 +66,53 @@ class FieldSelectorPanelTest {
         return root;
     }
 
+    /**
+     * Attach panel to scene and force layout so TreeView materializes cells.
+     */
+    private FieldSelectorPanel createAndAttach(Relation schema) {
+        var panel = new FieldSelectorPanel(handler, queryState);
+        panel.setRoot(schema);
+        panel.setMinSize(300, 300);
+        panel.setPrefSize(300, 300);
+        Pane root = (Pane) testStage.getScene().getRoot();
+        root.getChildren().setAll(panel);
+        root.applyCss();
+        root.layout();
+        return panel;
+    }
+
+    /**
+     * Collect all Labels with a given CSS class from the panel's scene graph.
+     */
+    private List<Label> findLabelsByClass(Node root, String cssClass) {
+        List<Label> result = new ArrayList<>();
+        findLabelsByClassRec(root, cssClass, result);
+        return result;
+    }
+
+    private void findLabelsByClassRec(Node node, String cssClass, List<Label> out) {
+        if (node instanceof Label label && label.getStyleClass().contains(cssClass)) {
+            out.add(label);
+        }
+        if (node instanceof Parent parent) {
+            for (Node child : parent.getChildrenUnmodifiable()) {
+                findLabelsByClassRec(child, cssClass, out);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Existing tests (tree structure, visibility, hide-if-empty)
+    // -------------------------------------------------------------------
+
     @Test
     void setRootPopulatesTree() {
         var ref = new AtomicReference<Integer>();
         Platform.runLater(() -> {
-            var panel = new FieldSelectorPanel(handler, queryState);
-            panel.setRoot(buildSchema());
-            // Root (records) has 3 children: id, name, details
+            var panel = createAndAttach(buildSchema());
             ref.set(panel.getTreeView().getRoot().getChildren().size());
         });
         WaitForAsyncUtils.waitForFxEvents();
-
         assertEquals(3, ref.get(), "Root should have 3 children");
     }
 
@@ -75,13 +120,11 @@ class FieldSelectorPanelTest {
     void nestedRelationPopulatesRecursively() {
         var ref = new AtomicReference<Integer>();
         Platform.runLater(() -> {
-            var panel = new FieldSelectorPanel(handler, queryState);
-            panel.setRoot(buildSchema());
+            var panel = createAndAttach(buildSchema());
             TreeItem<?> details = panel.getTreeView().getRoot().getChildren().get(2);
             ref.set(details.getChildren().size());
         });
         WaitForAsyncUtils.waitForFxEvents();
-
         assertEquals(1, ref.get(), "'details' Relation should have 1 child (value)");
     }
 
@@ -89,13 +132,11 @@ class FieldSelectorPanelTest {
     void toggleVisibleDispatchesEvent() {
         Platform.runLater(() -> {
             var path = new SchemaPath("records", "name");
-            assertTrue(queryState.getVisibleOrDefault(path), "default visible");
-
+            assertTrue(queryState.getVisibleOrDefault(path));
             handler.apply(new LayoutInteraction.ToggleVisible(path));
-            assertFalse(queryState.getVisibleOrDefault(path), "should be hidden after toggle");
-
+            assertFalse(queryState.getVisibleOrDefault(path));
             handler.apply(new LayoutInteraction.ToggleVisible(path));
-            assertTrue(queryState.getVisibleOrDefault(path), "should be visible after second toggle");
+            assertTrue(queryState.getVisibleOrDefault(path));
         });
         WaitForAsyncUtils.waitForFxEvents();
     }
@@ -104,13 +145,10 @@ class FieldSelectorPanelTest {
     void setHideIfEmptyDispatchesEvent() {
         Platform.runLater(() -> {
             var path = new SchemaPath("records", "details");
-
             handler.apply(new LayoutInteraction.SetHideIfEmpty(path, true));
             assertEquals(Boolean.TRUE, queryState.getFieldState(path).hideIfEmpty());
-
             handler.apply(new LayoutInteraction.SetHideIfEmpty(path, false));
-            assertNull(queryState.getFieldState(path).hideIfEmpty(),
-                       "Setting hideIfEmpty to false should clear it (null)");
+            assertNull(queryState.getFieldState(path).hideIfEmpty());
         });
         WaitForAsyncUtils.waitForFxEvents();
     }
@@ -118,10 +156,8 @@ class FieldSelectorPanelTest {
     @Test
     void setRootWithNullClearsTree() {
         Platform.runLater(() -> {
-            var panel = new FieldSelectorPanel(handler, queryState);
-            panel.setRoot(buildSchema());
+            var panel = createAndAttach(buildSchema());
             assertNotNull(panel.getTreeView().getRoot());
-
             panel.setRoot(null);
             assertNull(panel.getTreeView().getRoot());
         });
@@ -132,11 +168,106 @@ class FieldSelectorPanelTest {
     void panelHasStyleClass() {
         var ref = new AtomicReference<Boolean>();
         Platform.runLater(() -> {
-            var panel = new FieldSelectorPanel(handler, queryState);
+            var panel = createAndAttach(buildSchema());
             ref.set(panel.getStyleClass().contains("field-selector-panel"));
         });
         WaitForAsyncUtils.waitForFxEvents();
+        assertTrue(ref.get());
+    }
 
-        assertTrue(ref.get(), "Panel should have field-selector-panel style class");
+    // -------------------------------------------------------------------
+    // T1A: State badges
+    // -------------------------------------------------------------------
+
+    @Test
+    void sortBadgeAppearsOnSortedField() {
+        var ref = new AtomicReference<List<Label>>();
+        Platform.runLater(() -> {
+            var path = new SchemaPath("records", "name");
+            handler.apply(new LayoutInteraction.SortBy(path, false));
+
+            var panel = createAndAttach(buildSchema());
+            ref.set(findLabelsByClass(panel, "sort-badge"));
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertFalse(ref.get().isEmpty(), "Sort badge should appear on sorted field");
+        assertTrue(ref.get().stream().anyMatch(l -> "▲".equals(l.getText())),
+            "Ascending sort badge should show ▲");
+    }
+
+    @Test
+    void filterBadgeAppearsOnFilteredField() {
+        var ref = new AtomicReference<List<Label>>();
+        Platform.runLater(() -> {
+            var path = new SchemaPath("records", "name");
+            handler.apply(new LayoutInteraction.SetFilter(path, "$name > 'A'"));
+
+            var panel = createAndAttach(buildSchema());
+            ref.set(findLabelsByClass(panel, "filter-badge"));
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertFalse(ref.get().isEmpty(), "Filter badge should appear on filtered field");
+    }
+
+    @Test
+    void typeBadgeAppearsOnRelationNodes() {
+        var ref = new AtomicReference<List<Label>>();
+        Platform.runLater(() -> {
+            var panel = createAndAttach(buildSchema());
+            ref.set(findLabelsByClass(panel, "type-badge"));
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertFalse(ref.get().isEmpty(), "Relation nodes should have type badge");
+    }
+
+    @Test
+    void noBadgesWhenNoStateOverrides() {
+        var ref = new AtomicReference<List<Label>>();
+        Platform.runLater(() -> {
+            // No state changes — no badges expected
+            var panel = createAndAttach(buildSchema());
+            ref.set(findLabelsByClass(panel, "sort-badge"));
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertTrue(ref.get().isEmpty(), "No sort badges when no fields are sorted");
+    }
+
+    // -------------------------------------------------------------------
+    // T1B: Selection callback
+    // -------------------------------------------------------------------
+
+    @Test
+    void selectionCallbackFiresOnTreeSelection() {
+        var ref = new AtomicReference<SchemaPath>();
+        Platform.runLater(() -> {
+            var panel = createAndAttach(buildSchema());
+            panel.setOnFieldSelected(ref::set);
+            // Select "name" (index 2: root=0, id=1, name=2)
+            panel.getTreeView().getSelectionModel().select(2);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertNotNull(ref.get(), "Selection callback should fire");
+        assertEquals("name", ref.get().leaf(), "Should select 'name' field");
+    }
+
+    @Test
+    void selectionCallbackReceivesCorrectPath() {
+        var ref = new AtomicReference<SchemaPath>();
+        Platform.runLater(() -> {
+            var panel = createAndAttach(buildSchema());
+            panel.setOnFieldSelected(ref::set);
+            // Select "value" inside "details" (deeper path)
+            panel.getTreeView().getSelectionModel().select(4); // root=0,id=1,name=2,details=3,value=4
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertNotNull(ref.get(), "Selection callback should fire for nested field");
+        assertEquals("records/details/value", ref.get().toString(),
+            "Path should be fully qualified");
     }
 }


### PR DESCRIPTION
## Summary
- State badges on tree nodes: sort arrow (▲/▼), filter indicator (●), type badge ({n}/a)
- Selection callback: `setOnFieldSelected(Consumer<SchemaPath>)` for click-to-scroll integration
- `refresh()` method for tree cell re-render after state changes
- CSS classes: `.sort-badge`, `.filter-badge`, `.type-badge`

## Test plan
- [x] Sort badge appears on sorted field, shows correct arrow direction
- [x] Filter badge appears when filter expression is set
- [x] Type badge shows child count for Relations, "a" for Primitives
- [x] No badges when no state overrides
- [x] Selection callback fires with correct SchemaPath
- [x] Nested selection reports fully-qualified path

Refs: Kramer-ac5w, Kramer-b56f