### PR TITLE
RDR-030 P2: FieldInspectorPanel — field properties display and editing

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldInspectorPanel.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldInspectorPanel.java
@@ -33,6 +33,7 @@ public final class FieldInspectorPanel extends VBox {
     private final Label visibleLabel = new Label();
     private final Label renderModeLabel = new Label();
     private final Label hideIfEmptyLabel = new Label();
+    private final Label frozenLabel = new Label();
 
     private final Button clearSortBtn = new Button("Clear");
     private final Button clearFilterBtn = new Button("Clear");
@@ -99,6 +100,10 @@ public final class FieldInspectorPanel extends VBox {
         row++;
         grid.add(new Label("Hide empty:"), 0, row);
         grid.add(hideIfEmptyLabel, 1, row);
+
+        row++;
+        grid.add(new Label("Frozen:"), 0, row);
+        grid.add(frozenLabel, 1, row);
 
         row++;
         grid.add(new Separator(), 0, row, 3, 1);
@@ -170,6 +175,16 @@ public final class FieldInspectorPanel extends VBox {
         return filterLabel.getText();
     }
 
+    /** Currently displayed frozen state. */
+    public String getDisplayedFrozen() {
+        return frozenLabel.getText();
+    }
+
+    /** Whether Reset All button is enabled. */
+    public boolean isResetEnabled() {
+        return !resetBtn.isDisabled();
+    }
+
     /** Clear sort on the currently inspected field. */
     public void clearSort() {
         if (currentPath != null) {
@@ -196,7 +211,10 @@ public final class FieldInspectorPanel extends VBox {
             visibleLabel.setText("");
             renderModeLabel.setText("");
             hideIfEmptyLabel.setText("");
+            frozenLabel.setText("");
             setDisableButtons(true);
+            // Reset All is global — always available
+            resetBtn.setDisable(false);
             return;
         }
 
@@ -213,18 +231,30 @@ public final class FieldInspectorPanel extends VBox {
             sortLabel.setText("ascending");
         }
 
-        filterLabel.setText(fs.filterExpression() != null ? fs.filterExpression() : "");
-        formulaLabel.setText(fs.formulaExpression() != null ? fs.formulaExpression() : "");
-        aggregateLabel.setText(fs.aggregateExpression() != null ? fs.aggregateExpression() : "");
-        visibleLabel.setText(queryState.getVisibleOrDefault(currentPath) ? "yes" : "no");
-        renderModeLabel.setText(fs.renderMode() != null ? fs.renderMode() : "auto");
-        hideIfEmptyLabel.setText(Boolean.TRUE.equals(fs.hideIfEmpty()) ? "yes" : "no");
+        // Uniform variable pattern — read each field once
+        String filter = fs.filterExpression();
+        String formula = fs.formulaExpression();
+        String aggregate = fs.aggregateExpression();
+        String renderMode = fs.renderMode();
+        Boolean frozen = fs.frozen();
 
-        setDisableButtons(false);
-        clearSortBtn.setDisable(sortFields == null || sortFields.isEmpty());
-        clearFilterBtn.setDisable(fs.filterExpression() == null);
-        clearFormulaBtn.setDisable(fs.formulaExpression() == null);
-        clearAggregateBtn.setDisable(fs.aggregateExpression() == null);
+        filterLabel.setText(filter != null ? filter : "");
+        formulaLabel.setText(formula != null ? formula : "");
+        aggregateLabel.setText(aggregate != null ? aggregate : "");
+        visibleLabel.setText(queryState.getVisibleOrDefault(currentPath) ? "yes" : "no");
+        renderModeLabel.setText(renderMode != null ? renderMode : "auto");
+        hideIfEmptyLabel.setText(Boolean.TRUE.equals(fs.hideIfEmpty()) ? "yes" : "no");
+        frozenLabel.setText(Boolean.TRUE.equals(frozen) ? "FROZEN" : "no");
+
+        boolean isFrozen = Boolean.TRUE.equals(frozen);
+        setDisableButtons(isFrozen);
+        clearSortBtn.setDisable(isFrozen || sortFields == null || sortFields.isEmpty());
+        clearFilterBtn.setDisable(isFrozen || filter == null);
+        clearFormulaBtn.setDisable(isFrozen || formula == null);
+        clearAggregateBtn.setDisable(isFrozen || aggregate == null);
+        toggleVisibleBtn.setDisable(isFrozen);
+        // Reset All is always available
+        resetBtn.setDisable(false);
     }
 
     private void setDisableButtons(boolean disabled) {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldInspectorPanel.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldInspectorPanel.java
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout.query;
+
+import com.chiralbehaviors.layout.SchemaPath;
+
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.Separator;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+
+/**
+ * Inspector panel showing all {@link FieldState} properties for a selected
+ * field. Provides inline editing via buttons that dispatch
+ * {@link LayoutInteraction} events through an {@link InteractionHandler}.
+ *
+ * @author hhildebrand
+ */
+public final class FieldInspectorPanel extends VBox {
+
+    private final InteractionHandler handler;
+    private final LayoutQueryState queryState;
+
+    private SchemaPath currentPath;
+
+    private final Label pathLabel = new Label();
+    private final Label sortLabel = new Label();
+    private final Label filterLabel = new Label();
+    private final Label formulaLabel = new Label();
+    private final Label aggregateLabel = new Label();
+    private final Label visibleLabel = new Label();
+    private final Label renderModeLabel = new Label();
+    private final Label hideIfEmptyLabel = new Label();
+
+    private final Button clearSortBtn = new Button("Clear");
+    private final Button clearFilterBtn = new Button("Clear");
+    private final Button clearFormulaBtn = new Button("Clear");
+    private final Button clearAggregateBtn = new Button("Clear");
+    private final Button toggleVisibleBtn = new Button("Toggle");
+    private final Button resetBtn = new Button("Reset All");
+
+    public FieldInspectorPanel(InteractionHandler handler,
+                                LayoutQueryState queryState) {
+        this.handler = handler;
+        this.queryState = queryState;
+        getStyleClass().add("field-inspector-panel");
+        setPadding(new Insets(8));
+        setSpacing(8);
+
+        var title = new Label("Field Inspector");
+        title.getStyleClass().add("inspector-title");
+
+        var grid = new GridPane();
+        grid.setHgap(8);
+        grid.setVgap(4);
+
+        int row = 0;
+        grid.add(new Label("Path:"), 0, row);
+        grid.add(pathLabel, 1, row);
+        GridPane.setHgrow(pathLabel, Priority.ALWAYS);
+
+        row++;
+        grid.add(new Separator(), 0, row, 3, 1);
+
+        row++;
+        grid.add(new Label("Sort:"), 0, row);
+        grid.add(sortLabel, 1, row);
+        grid.add(clearSortBtn, 2, row);
+
+        row++;
+        grid.add(new Label("Filter:"), 0, row);
+        grid.add(filterLabel, 1, row);
+        grid.add(clearFilterBtn, 2, row);
+
+        row++;
+        grid.add(new Label("Formula:"), 0, row);
+        grid.add(formulaLabel, 1, row);
+        grid.add(clearFormulaBtn, 2, row);
+
+        row++;
+        grid.add(new Label("Aggregate:"), 0, row);
+        grid.add(aggregateLabel, 1, row);
+        grid.add(clearAggregateBtn, 2, row);
+
+        row++;
+        grid.add(new Separator(), 0, row, 3, 1);
+
+        row++;
+        grid.add(new Label("Visible:"), 0, row);
+        grid.add(visibleLabel, 1, row);
+        grid.add(toggleVisibleBtn, 2, row);
+
+        row++;
+        grid.add(new Label("Render:"), 0, row);
+        grid.add(renderModeLabel, 1, row);
+
+        row++;
+        grid.add(new Label("Hide empty:"), 0, row);
+        grid.add(hideIfEmptyLabel, 1, row);
+
+        row++;
+        grid.add(new Separator(), 0, row, 3, 1);
+
+        row++;
+        grid.add(resetBtn, 0, row, 3, 1);
+
+        getChildren().addAll(title, grid);
+
+        // Button actions
+        clearSortBtn.setOnAction(e -> {
+            if (currentPath != null) {
+                handler.apply(new LayoutInteraction.ClearSort(currentPath));
+                refresh();
+            }
+        });
+        clearFilterBtn.setOnAction(e -> {
+            if (currentPath != null) {
+                handler.apply(new LayoutInteraction.ClearFilter(currentPath));
+                refresh();
+            }
+        });
+        clearFormulaBtn.setOnAction(e -> {
+            if (currentPath != null) {
+                handler.apply(new LayoutInteraction.ClearFormula(currentPath));
+                refresh();
+            }
+        });
+        clearAggregateBtn.setOnAction(e -> {
+            if (currentPath != null) {
+                handler.apply(new LayoutInteraction.ClearAggregate(currentPath));
+                refresh();
+            }
+        });
+        toggleVisibleBtn.setOnAction(e -> {
+            if (currentPath != null) {
+                handler.apply(new LayoutInteraction.ToggleVisible(currentPath));
+                refresh();
+            }
+        });
+        resetBtn.setOnAction(e -> {
+            handler.apply(new LayoutInteraction.ResetAll());
+            refresh();
+        });
+
+        inspect(null);
+    }
+
+    /**
+     * Display properties for the given field path. Pass null to clear.
+     */
+    public void inspect(SchemaPath path) {
+        this.currentPath = path;
+        refresh();
+    }
+
+    /** Currently displayed path as string, or empty. */
+    public String getDisplayedPath() {
+        return pathLabel.getText();
+    }
+
+    /** Currently displayed sort state: "ascending", "descending", or "none". */
+    public String getDisplayedSort() {
+        return sortLabel.getText();
+    }
+
+    /** Currently displayed filter expression, or empty. */
+    public String getDisplayedFilter() {
+        return filterLabel.getText();
+    }
+
+    /** Clear sort on the currently inspected field. */
+    public void clearSort() {
+        if (currentPath != null) {
+            handler.apply(new LayoutInteraction.ClearSort(currentPath));
+            refresh();
+        }
+    }
+
+    /** Clear filter on the currently inspected field. */
+    public void clearFilter() {
+        if (currentPath != null) {
+            handler.apply(new LayoutInteraction.ClearFilter(currentPath));
+            refresh();
+        }
+    }
+
+    private void refresh() {
+        if (currentPath == null) {
+            pathLabel.setText("");
+            sortLabel.setText("");
+            filterLabel.setText("");
+            formulaLabel.setText("");
+            aggregateLabel.setText("");
+            visibleLabel.setText("");
+            renderModeLabel.setText("");
+            hideIfEmptyLabel.setText("");
+            setDisableButtons(true);
+            return;
+        }
+
+        FieldState fs = queryState.getFieldState(currentPath);
+        pathLabel.setText(currentPath.toString());
+
+        // Sort
+        String sortFields = fs.sortFields();
+        if (sortFields == null || sortFields.isEmpty()) {
+            sortLabel.setText("none");
+        } else if (sortFields.startsWith("-")) {
+            sortLabel.setText("descending");
+        } else {
+            sortLabel.setText("ascending");
+        }
+
+        filterLabel.setText(fs.filterExpression() != null ? fs.filterExpression() : "");
+        formulaLabel.setText(fs.formulaExpression() != null ? fs.formulaExpression() : "");
+        aggregateLabel.setText(fs.aggregateExpression() != null ? fs.aggregateExpression() : "");
+        visibleLabel.setText(queryState.getVisibleOrDefault(currentPath) ? "yes" : "no");
+        renderModeLabel.setText(fs.renderMode() != null ? fs.renderMode() : "auto");
+        hideIfEmptyLabel.setText(Boolean.TRUE.equals(fs.hideIfEmpty()) ? "yes" : "no");
+
+        setDisableButtons(false);
+        clearSortBtn.setDisable(sortFields == null || sortFields.isEmpty());
+        clearFilterBtn.setDisable(fs.filterExpression() == null);
+        clearFormulaBtn.setDisable(fs.formulaExpression() == null);
+        clearAggregateBtn.setDisable(fs.aggregateExpression() == null);
+    }
+
+    private void setDisableButtons(boolean disabled) {
+        clearSortBtn.setDisable(disabled);
+        clearFilterBtn.setDisable(disabled);
+        clearFormulaBtn.setDisable(disabled);
+        clearAggregateBtn.setDisable(disabled);
+        toggleVisibleBtn.setDisable(disabled);
+        resetBtn.setDisable(disabled);
+    }
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldInspectorPanel.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/query/FieldInspectorPanel.java
@@ -3,7 +3,6 @@ package com.chiralbehaviors.layout.query;
 
 import com.chiralbehaviors.layout.SchemaPath;
 
-import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.Separator;
@@ -47,8 +46,6 @@ public final class FieldInspectorPanel extends VBox {
         this.handler = handler;
         this.queryState = queryState;
         getStyleClass().add("field-inspector-panel");
-        setPadding(new Insets(8));
-        setSpacing(8);
 
         var title = new Label("Field Inspector");
         title.getStyleClass().add("inspector-title");
@@ -185,6 +182,10 @@ public final class FieldInspectorPanel extends VBox {
         return !resetBtn.isDisabled();
     }
 
+    public boolean isClearSortDisabled() { return clearSortBtn.isDisabled(); }
+    public boolean isClearFilterDisabled() { return clearFilterBtn.isDisabled(); }
+    public boolean isToggleVisibleDisabled() { return toggleVisibleBtn.isDisabled(); }
+
     /** Clear sort on the currently inspected field. */
     public void clearSort() {
         if (currentPath != null) {
@@ -263,6 +264,5 @@ public final class FieldInspectorPanel extends VBox {
         clearFormulaBtn.setDisable(disabled);
         clearAggregateBtn.setDisable(disabled);
         toggleVisibleBtn.setDisable(disabled);
-        resetBtn.setDisable(disabled);
     }
 }

--- a/kramer/src/main/resources/com/chiralbehaviors/layout/default.css
+++ b/kramer/src/main/resources/com/chiralbehaviors/layout/default.css
@@ -47,6 +47,16 @@
     -fx-padding: 4;
 }
 
+.field-inspector-panel {
+    -fx-padding: 8;
+    -fx-spacing: 8;
+}
+
+.inspector-title {
+    -fx-font-weight: bold;
+    -fx-font-size: 13px;
+}
+
 .crosstab-header { /* inherits from .kramer-container */ }
 .crosstab-header-label { -fx-font-weight: bold; }
 .crosstab-row { /* inherits from .kramer-container */ }

--- a/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldInspectorPanelTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldInspectorPanelTest.java
@@ -146,6 +146,47 @@ class FieldInspectorPanelTest {
     }
 
     @Test
+    void showsDescendingSortState() {
+        var ref = new AtomicReference<String>();
+        Platform.runLater(() -> {
+            var path = new SchemaPath("employees", "name");
+            handler.apply(new LayoutInteraction.SortBy(path, true)); // descending
+
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(path);
+            ref.set(panel.getDisplayedSort());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals("descending", ref.get());
+    }
+
+    @Test
+    void frozenFieldDisablesAllMutationButtons() {
+        var ref = new AtomicReference<boolean[]>();
+        Platform.runLater(() -> {
+            var path = new SchemaPath("employees", "name");
+            queryState.setFrozen(path, true);
+            // Also set sort/filter so clear buttons would normally be enabled
+            queryState.setSortFields(path, "name");
+            queryState.setFilterExpression(path, "$x > 1");
+
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(path);
+            ref.set(new boolean[] {
+                panel.isClearSortDisabled(),
+                panel.isClearFilterDisabled(),
+                panel.isToggleVisibleDisabled()
+            });
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertTrue(ref.get()[0], "Clear sort should be disabled when frozen");
+        assertTrue(ref.get()[1], "Clear filter should be disabled when frozen");
+        assertTrue(ref.get()[2], "Toggle visible should be disabled when frozen");
+    }
+
+    @Test
     void showsFrozenState() {
         var ref = new AtomicReference<String>();
         Platform.runLater(() -> {

--- a/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldInspectorPanelTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldInspectorPanelTest.java
@@ -146,6 +146,35 @@ class FieldInspectorPanelTest {
     }
 
     @Test
+    void showsFrozenState() {
+        var ref = new AtomicReference<String>();
+        Platform.runLater(() -> {
+            var path = new SchemaPath("employees", "name");
+            queryState.setFrozen(path, true);
+
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(path);
+            ref.set(panel.getDisplayedFrozen());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals("FROZEN", ref.get());
+    }
+
+    @Test
+    void resetAllEnabledWithNoSelection() {
+        var ref = new AtomicReference<Boolean>();
+        Platform.runLater(() -> {
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(null);
+            ref.set(panel.isResetEnabled());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertTrue(ref.get(), "Reset All should be enabled even with no selection");
+    }
+
+    @Test
     void hasStyleClass() {
         var ref = new AtomicReference<Boolean>();
         Platform.runLater(() -> {

--- a/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldInspectorPanelTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/query/FieldInspectorPanelTest.java
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout.query;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+
+import com.chiralbehaviors.layout.ConfiguredMeasurementStrategy;
+import com.chiralbehaviors.layout.SchemaPath;
+import com.chiralbehaviors.layout.style.Style;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+
+/**
+ * Tests for FieldInspectorPanel (Kramer-tuiw T2A).
+ */
+@ExtendWith(ApplicationExtension.class)
+class FieldInspectorPanelTest {
+
+    private LayoutQueryState queryState;
+    private InteractionHandler handler;
+
+    @Start
+    void start(Stage stage) {
+        stage.setScene(new Scene(new Pane(), 400, 400));
+        stage.show();
+    }
+
+    @BeforeEach
+    void setUp() {
+        var style = new Style(new ConfiguredMeasurementStrategy());
+        queryState = new LayoutQueryState(style);
+        handler = new InteractionHandler(queryState);
+    }
+
+    @Test
+    void showsPathForSelectedField() {
+        var ref = new AtomicReference<String>();
+        Platform.runLater(() -> {
+            var panel = new FieldInspectorPanel(handler, queryState);
+            var path = new SchemaPath("employees", "name");
+            panel.inspect(path);
+            ref.set(panel.getDisplayedPath());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals("employees/name", ref.get());
+    }
+
+    @Test
+    void showsSortStateForSortedField() {
+        var ref = new AtomicReference<String>();
+        Platform.runLater(() -> {
+            var path = new SchemaPath("employees", "name");
+            handler.apply(new LayoutInteraction.SortBy(path, false));
+
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(path);
+            ref.set(panel.getDisplayedSort());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals("ascending", ref.get());
+    }
+
+    @Test
+    void showsFilterExpressionForFilteredField() {
+        var ref = new AtomicReference<String>();
+        Platform.runLater(() -> {
+            var path = new SchemaPath("employees", "name");
+            handler.apply(new LayoutInteraction.SetFilter(path, "$name > 'A'"));
+
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(path);
+            ref.set(panel.getDisplayedFilter());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals("$name > 'A'", ref.get());
+    }
+
+    @Test
+    void showsNoneForUnsortedField() {
+        var ref = new AtomicReference<String>();
+        Platform.runLater(() -> {
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(new SchemaPath("employees", "name"));
+            ref.set(panel.getDisplayedSort());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals("none", ref.get());
+    }
+
+    @Test
+    void clearSortViaInspectorUpdatesState() {
+        Platform.runLater(() -> {
+            var path = new SchemaPath("employees", "name");
+            handler.apply(new LayoutInteraction.SortBy(path, false));
+            assertEquals("name", queryState.getFieldState(path).sortFields());
+
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(path);
+            panel.clearSort();
+            assertNull(queryState.getFieldState(path).sortFields());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    void clearFilterViaInspectorUpdatesState() {
+        Platform.runLater(() -> {
+            var path = new SchemaPath("employees", "name");
+            handler.apply(new LayoutInteraction.SetFilter(path, "$x > 1"));
+
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(path);
+            panel.clearFilter();
+            assertNull(queryState.getFieldState(path).filterExpression());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    @Test
+    void inspectNullClearsDisplay() {
+        var ref = new AtomicReference<String>();
+        Platform.runLater(() -> {
+            var panel = new FieldInspectorPanel(handler, queryState);
+            panel.inspect(new SchemaPath("employees", "name"));
+            panel.inspect(null);
+            ref.set(panel.getDisplayedPath());
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertEquals("", ref.get());
+    }
+
+    @Test
+    void hasStyleClass() {
+        var ref = new AtomicReference<Boolean>();
+        Platform.runLater(() -> {
+            var panel = new FieldInspectorPanel(handler, queryState);
+            ref.set(panel.getStyleClass().contains("field-inspector-panel"));
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+
+        assertTrue(ref.get());
+    }
+}


### PR DESCRIPTION
## Summary
- New `FieldInspectorPanel` displays all `FieldState` properties for a selected `SchemaPath`
- Grid layout showing: path, sort, filter, formula, aggregate, visibility, render mode, hide-if-empty
- Inline Clear buttons dispatch `LayoutInteraction` events via `InteractionHandler`
- Toggle Visible and Reset All actions

## Test plan
- [x] Path display shows correct SchemaPath
- [x] Sort state: ascending, descending, none
- [x] Filter expression displayed correctly
- [x] Clear sort dispatches ClearSort and updates state
- [x] Clear filter dispatches ClearFilter and updates state
- [x] Null inspection clears display
- [x] Has field-inspector-panel style class

Refs: Kramer-tuiw