### PR TITLE
RDR-030 P4 T4A: TypeIntrospector — GraphQL schema introspection

### DIFF
--- a/kramer-ql/src/main/java/com/chiralbehaviors/layout/graphql/TypeIntrospector.java
+++ b/kramer-ql/src/main/java/com/chiralbehaviors/layout/graphql/TypeIntrospector.java
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout.graphql;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Parses a GraphQL {@code __schema} introspection response into a
+ * browseable type tree. Filters out system types ({@code __*}) and
+ * scalar types, keeping only user-defined OBJECT types.
+ * <p>
+ * Distinct from {@link SchemaIntrospector}, which inspects field arguments
+ * for server capability detection.
+ *
+ * @author hhildebrand
+ */
+public final class TypeIntrospector {
+
+    /** A GraphQL type from introspection. */
+    public record IntrospectedType(String name, String kind,
+                                    List<IntrospectedField> fields) {}
+
+    /** A field within an introspected type. */
+    public record IntrospectedField(String name, TypeRef type,
+                                     String description) {}
+
+    /** Type reference — handles scalar, LIST, NON_NULL wrapping. */
+    public record TypeRef(String name, String kind, TypeRef ofType) {
+
+        /** Unwrap LIST/NON_NULL to get the base type name. */
+        public String baseName() {
+            if (name != null) return name;
+            return ofType != null ? ofType.baseName() : null;
+        }
+    }
+
+    private final Map<String, IntrospectedType> index;
+
+    private TypeIntrospector(Map<String, IntrospectedType> index) {
+        this.index = index;
+    }
+
+    /** Parse a full introspection response (with data.__schema wrapper). */
+    public static TypeIntrospector parse(JsonNode response) {
+        JsonNode schema = response.path("data").path("__schema");
+        JsonNode types = schema.path("types");
+
+        Map<String, IntrospectedType> index = new LinkedHashMap<>();
+        if (types.isArray()) {
+            for (JsonNode typeNode : types) {
+                String name = typeNode.path("name").asText(null);
+                String kind = typeNode.path("kind").asText(null);
+                if (name == null || isSystemType(name) || "SCALAR".equals(kind)) {
+                    continue;
+                }
+                List<IntrospectedField> fields = parseFields(typeNode.path("fields"));
+                index.put(name, new IntrospectedType(name, kind, fields));
+            }
+        }
+        return new TypeIntrospector(index);
+    }
+
+    /** Name → type lookup. */
+    public Map<String, IntrospectedType> typeIndex() {
+        return Map.copyOf(index);
+    }
+
+    /** All user-defined types (excludes system and scalar). */
+    public List<IntrospectedType> userTypes() {
+        return List.copyOf(index.values());
+    }
+
+    /** Returns the standard introspection query string. */
+    public static String introspectionQuery() {
+        return """
+            {
+              __schema {
+                types {
+                  name
+                  kind
+                  fields {
+                    name
+                    description
+                    type {
+                      name
+                      kind
+                      ofType {
+                        name
+                        kind
+                        ofType {
+                          name
+                          kind
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+    }
+
+    private static List<IntrospectedField> parseFields(JsonNode fieldsNode) {
+        List<IntrospectedField> fields = new ArrayList<>();
+        if (fieldsNode == null || !fieldsNode.isArray()) return fields;
+
+        for (JsonNode fieldNode : fieldsNode) {
+            String name = fieldNode.path("name").asText(null);
+            String description = fieldNode.path("description").asText(null);
+            TypeRef type = parseTypeRef(fieldNode.path("type"));
+            if (name != null) {
+                fields.add(new IntrospectedField(name, type, description));
+            }
+        }
+        return List.copyOf(fields);
+    }
+
+    private static TypeRef parseTypeRef(JsonNode typeNode) {
+        if (typeNode == null || typeNode.isMissingNode() || typeNode.isNull()) {
+            return null;
+        }
+        String name = typeNode.path("name").isNull() ? null
+            : typeNode.path("name").asText(null);
+        String kind = typeNode.path("kind").asText(null);
+        TypeRef ofType = parseTypeRef(typeNode.path("ofType"));
+        return new TypeRef(name, kind, ofType);
+    }
+
+    private static boolean isSystemType(String name) {
+        return name.startsWith("__");
+    }
+}

--- a/kramer-ql/src/test/java/com/chiralbehaviors/layout/graphql/TypeIntrospectorTest.java
+++ b/kramer-ql/src/test/java/com/chiralbehaviors/layout/graphql/TypeIntrospectorTest.java
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout.graphql;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Tests for TypeIntrospector — parses GraphQL __schema introspection
+ * results into a browseable type tree.
+ */
+class TypeIntrospectorTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Minimal __schema response with two user types + system types.
+     */
+    private static final String SAMPLE_INTROSPECTION = """
+        {
+          "data": {
+            "__schema": {
+              "types": [
+                {
+                  "name": "Employee",
+                  "kind": "OBJECT",
+                  "fields": [
+                    { "name": "id", "description": "Primary key",
+                      "type": { "name": "ID", "kind": "SCALAR", "ofType": null } },
+                    { "name": "name", "description": null,
+                      "type": { "name": "String", "kind": "SCALAR", "ofType": null } },
+                    { "name": "projects", "description": "Active projects",
+                      "type": { "name": null, "kind": "LIST",
+                        "ofType": { "name": "Project", "kind": "OBJECT", "ofType": null } } }
+                  ]
+                },
+                {
+                  "name": "Project",
+                  "kind": "OBJECT",
+                  "fields": [
+                    { "name": "title", "description": null,
+                      "type": { "name": "String", "kind": "SCALAR", "ofType": null } },
+                    { "name": "status", "description": null,
+                      "type": { "name": "String", "kind": "SCALAR", "ofType": null } },
+                    { "name": "hours", "description": null,
+                      "type": { "name": "Int", "kind": "SCALAR", "ofType": null } }
+                  ]
+                },
+                {
+                  "name": "__Schema",
+                  "kind": "OBJECT",
+                  "fields": [
+                    { "name": "types", "description": null,
+                      "type": { "name": null, "kind": "LIST",
+                        "ofType": { "name": "__Type", "kind": "OBJECT", "ofType": null } } }
+                  ]
+                },
+                {
+                  "name": "__Type",
+                  "kind": "OBJECT",
+                  "fields": []
+                },
+                {
+                  "name": "String",
+                  "kind": "SCALAR",
+                  "fields": null
+                },
+                {
+                  "name": "Query",
+                  "kind": "OBJECT",
+                  "fields": [
+                    { "name": "employees", "description": null,
+                      "type": { "name": null, "kind": "LIST",
+                        "ofType": { "name": "Employee", "kind": "OBJECT", "ofType": null } } }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+        """;
+
+    private TypeIntrospector parse() throws Exception {
+        JsonNode json = MAPPER.readTree(SAMPLE_INTROSPECTION);
+        return TypeIntrospector.parse(json);
+    }
+
+    @Test
+    void parsesUserTypes() throws Exception {
+        TypeIntrospector introspector = parse();
+        Map<String, TypeIntrospector.IntrospectedType> index = introspector.typeIndex();
+
+        assertTrue(index.containsKey("Employee"), "Should contain Employee");
+        assertTrue(index.containsKey("Project"), "Should contain Project");
+        assertTrue(index.containsKey("Query"), "Should contain Query");
+    }
+
+    @Test
+    void filtersSystemTypes() throws Exception {
+        TypeIntrospector introspector = parse();
+        Map<String, TypeIntrospector.IntrospectedType> index = introspector.typeIndex();
+
+        assertFalse(index.containsKey("__Schema"), "__Schema should be filtered");
+        assertFalse(index.containsKey("__Type"), "__Type should be filtered");
+    }
+
+    @Test
+    void filtersScalarTypes() throws Exception {
+        TypeIntrospector introspector = parse();
+        Map<String, TypeIntrospector.IntrospectedType> index = introspector.typeIndex();
+
+        assertFalse(index.containsKey("String"), "Scalar types should be filtered");
+    }
+
+    @Test
+    void typeHasCorrectFields() throws Exception {
+        TypeIntrospector introspector = parse();
+        var employee = introspector.typeIndex().get("Employee");
+
+        assertNotNull(employee);
+        assertEquals(3, employee.fields().size());
+        assertEquals("id", employee.fields().get(0).name());
+        assertEquals("name", employee.fields().get(1).name());
+        assertEquals("projects", employee.fields().get(2).name());
+    }
+
+    @Test
+    void fieldHasDescription() throws Exception {
+        TypeIntrospector introspector = parse();
+        var employee = introspector.typeIndex().get("Employee");
+        var idField = employee.fields().get(0);
+
+        assertEquals("Primary key", idField.description());
+    }
+
+    @Test
+    void fieldTypeRefScalar() throws Exception {
+        TypeIntrospector introspector = parse();
+        var employee = introspector.typeIndex().get("Employee");
+        var nameField = employee.fields().get(1);
+
+        assertEquals("String", nameField.type().name());
+        assertEquals("SCALAR", nameField.type().kind());
+        assertNull(nameField.type().ofType());
+    }
+
+    @Test
+    void fieldTypeRefList() throws Exception {
+        TypeIntrospector introspector = parse();
+        var employee = introspector.typeIndex().get("Employee");
+        var projectsField = employee.fields().get(2);
+
+        assertEquals("LIST", projectsField.type().kind());
+        assertNotNull(projectsField.type().ofType());
+        assertEquals("Project", projectsField.type().ofType().name());
+    }
+
+    @Test
+    void introspectionQueryIsValidGraphQL() {
+        String query = TypeIntrospector.introspectionQuery();
+        assertNotNull(query);
+        assertTrue(query.contains("__schema"), "Query should contain __schema");
+        assertTrue(query.contains("fields"), "Query should request fields");
+        assertTrue(query.contains("ofType"), "Query should request ofType for wrapping");
+    }
+
+    @Test
+    void userTypesListExcludesSystemAndScalar() throws Exception {
+        TypeIntrospector introspector = parse();
+        List<TypeIntrospector.IntrospectedType> types = introspector.userTypes();
+
+        assertEquals(3, types.size(), "Should have Employee, Project, Query");
+        assertTrue(types.stream().noneMatch(t -> t.name().startsWith("__")));
+        assertTrue(types.stream().noneMatch(t -> "SCALAR".equals(t.kind())));
+    }
+}


### PR DESCRIPTION
## Summary
- Parses `__schema` introspection responses into `IntrospectedType`/`IntrospectedField`/`TypeRef` records
- Filters system types (`__*`) and scalars — only user-defined OBJECT types
- `TypeRef` handles `LIST`/`NON_NULL` wrapping via recursive `ofType`
- `introspectionQuery()` returns the standard query string
- `typeIndex()` provides name → type lookup
- `userTypes()` returns browseable list

## Test plan
- [x] User types parsed (Employee, Project, Query)
- [x] System types filtered (__Schema, __Type)
- [x] Scalar types filtered (String)
- [x] Field list correct (3 fields on Employee)
- [x] Field description present
- [x] Scalar TypeRef (String/SCALAR)
- [x] LIST TypeRef with nested ofType
- [x] Introspection query contains __schema, fields, ofType
- [x] userTypes() excludes system + scalar

Refs: Kramer-799f