### PR TITLE
Kramer-bnf4: Fix outline label rotation + first item test

### DIFF
--- a/kramer/src/main/java/com/chiralbehaviors/layout/outline/OutlineElement.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/outline/OutlineElement.java
@@ -80,14 +80,20 @@ public class OutlineElement extends HorizontalCell<OutlineElement>
             .setPrefHeight(elementHeight);
         cell.getNode()
             .setMaxHeight(elementHeight);
-        // Check if the label should rotate vertical to avoid truncation.
-        // Same heuristic as table column headers (verticalHeaderThreshold=1.5):
-        // rotate when label text is wider than allocated width AND there is
-        // enough vertical space to show the rotated text.
+        // Rotate label vertical when there is enough vertical space.
+        // For relation labels (structural), always prefer vertical — they
+        // are less important than data and vertical rendering frees
+        // horizontal space. For primitive labels, only rotate when the
+        // text would truncate (textWidth > labelWidth).
         double textWidth = layout.labelWidth(layout.getLabel());
         double labelH = layout.getLabelHeight();
-        boolean rotateVertical = textWidth > labelWidth
-                                 && elementHeight >= textWidth;
+        boolean isRelation = layout instanceof com.chiralbehaviors.layout.RelationLayout;
+        // Relations: always rotate when room (saves horizontal space).
+        // Primitives: rotate when text nearly fills the label allocation
+        // (>95% consumed — insets/rounding will truncate with "...").
+        boolean wouldTruncate = textWidth > labelWidth * 0.95;
+        boolean rotateVertical = elementHeight >= textWidth
+                                 && (isRelation || wouldTruncate);
 
         String bulletText = style.getBulletText();
         if (!bulletText.isEmpty() && style.getBulletWidth() > 0) {

--- a/kramer/src/test/java/com/chiralbehaviors/layout/AutoLayoutResizeAdaptationTest.java
+++ b/kramer/src/test/java/com/chiralbehaviors/layout/AutoLayoutResizeAdaptationTest.java
@@ -476,19 +476,19 @@ class AutoLayoutResizeAdaptationTest {
     @Test
     void outlineRendersDataValues() throws Exception {
         runOnFx(() -> {
-            // Test at narrow width matching user's window (~600px)
+            // Test at narrow width matching user's window (~500px)
             Style style = new Style();
             AutoLayout al = new AutoLayout(null, style);
             var root = new javafx.scene.layout.BorderPane();
             root.setCenter(al);
-            new javafx.scene.Scene(root, 600, 800);
+            new javafx.scene.Scene(root, 500, 1200);
             root.applyCss();
             root.layout();
 
             al.setRoot(threeLevelSchema());
             al.measure(threeLevelData());
             al.updateItem(threeLevelData());
-            al.resize(1200, 800);
+            al.resize(500, 1200);
 
             root.applyCss();
             root.layout();
@@ -598,12 +598,23 @@ class AutoLayoutResizeAdaptationTest {
                         + " width=" + parentWidth);
                 }
             }
-            // NOW assert data is present
+            // Assert data is present
             assertTrue(hasCS || hasMath,
                 "Rendered text should include department names (CS or Math). " +
                 "Found: " + allText);
             assertEquals(0, invisible,
                 "All data values must be in regions wide enough to display them");
+
+            // Bug check: first section item must not be dropped.
+            // The data has section A(45) as first item for CS101.
+            // A VirtualFlow off-by-one would show B,C but skip A.
+            boolean hasA = allText.contains("A");
+            boolean has45 = allText.contains("45");
+            System.out.println("[FIRST-ITEM] hasA=" + hasA + " has45=" + has45);
+            assertTrue(hasA && has45,
+                "First section item (A, 45) must be present. " +
+                "Missing first item indicates VirtualFlow off-by-one. " +
+                "Found: " + allText);
         });
     }
 


### PR DESCRIPTION
## Summary
- Fix rotation heuristic: relation labels always rotate when vertical space allows (saves horizontal space for data)
- Primitive labels rotate when text fills >95% of allocation (prevents truncation from insets/rounding)
- Previous condition `textWidth > labelWidth` never fired because labelWidth = max(sibling widths)
- Test verifies first section item A(45) is present (VirtualFlow off-by-one guard)

## Test plan
- [x] 1014 kramer + 20 explorer tests pass
- [x] Rotation test: "courses" rotates at 400px
- [ ] Manual: "sections" and "building" labels render vertically in demo