### PR TITLE
Kramer-49hy: Extract LayoutView interface from RelationLayout

### DIFF
--- a/docs/plans/2026-03-22-render-context-interface-design.md
+++ b/docs/plans/2026-03-22-render-context-interface-design.md
@@ -1,0 +1,64 @@
+---
+title: "Render-Context Interface (LayoutView) Design"
+status: approved
+created: 2026-03-22
+rdr: RDR-032
+---
+
+# Render-Context Interface Design
+
+## Goal
+
+Extract a `LayoutView` interface from `RelationLayout` that captures all state
+renderers need. This decouples the compute pipeline from rendering, enabling
+pluggable renderers (React, DOM, etc.) for the JS port (RDR-032).
+
+## Approach: Interface Extraction (Approach B)
+
+1. Define `LayoutView` interface with read-only accessors for all fields that
+   `buildControl()`, `buildOutline()`, `buildNestedTable()`, and
+   `buildColumnHeader()` read from `RelationLayout`.
+
+2. `RelationLayout` implements `LayoutView` — zero behavior change for existing
+   Java renderers.
+
+3. Refactor renderer constructors (`NestedTable`, `Outline`, `OutlineCell`,
+   `TableHeader`) to accept `LayoutView` instead of `RelationLayout`.
+
+4. The `LayoutView` interface becomes the TypeScript type definition for the
+   JS port's render protocol.
+
+## Interface Definition
+
+```java
+public interface LayoutView {
+    boolean isUseTable();
+    boolean isCrosstab();
+    double getJustifiedWidth();
+    double getCellHeight();
+    double getLabelWidth();
+    int getResolvedCardinality();
+    double getColumnHeaderHeight();
+    List<ColumnSet> getColumnSets();
+    List<SchemaNodeLayout> getChildren();
+    RelationStyle getStyle();
+    JsonNode extractFrom(JsonNode datum);
+    String getLabel();
+    String getCssClass();
+    SchemaPath getSchemaPath();
+}
+```
+
+## Files Changed
+
+- NEW: `LayoutView.java` — interface definition
+- MODIFY: `RelationLayout.java` — `implements LayoutView`
+- MODIFY: `NestedTable.java` — constructor takes `LayoutView`
+- MODIFY: `Outline.java` — constructor takes `LayoutView`
+- MODIFY: `OutlineCell.java` — constructor takes `LayoutView`
+- MODIFY: `TableHeader.java` — constructor takes `LayoutView`
+
+## Validation
+
+- All 1140 existing tests pass unchanged (RelationLayout implements the interface)
+- New test: verify LayoutView captures all fields needed by renderers

--- a/kramer/src/main/java/com/chiralbehaviors/layout/LayoutView.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/LayoutView.java
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.chiralbehaviors.layout;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import com.chiralbehaviors.layout.cell.LayoutCell;
+import com.chiralbehaviors.layout.cell.control.FocusTraversal;
+import com.chiralbehaviors.layout.schema.Relation;
+import com.chiralbehaviors.layout.style.RelationStyle;
+import com.chiralbehaviors.layout.style.Style;
+import com.chiralbehaviors.layout.table.TableHeader;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import javafx.scene.control.Label;
+import javafx.scene.layout.Region;
+
+/**
+ * Read-only view of a relation's post-compute layout state.
+ * Captures everything renderers ({@link com.chiralbehaviors.layout.table.NestedTable},
+ * {@link com.chiralbehaviors.layout.outline.Outline}, etc.) need to build
+ * the control tree.
+ *
+ * <p>{@link RelationLayout} implements this interface. The JS port (RDR-032)
+ * will implement it from a portable render-context record, enabling pluggable
+ * renderers without depending on the Java layout engine.
+ */
+public interface LayoutView {
+
+    // --- Mode decisions ---
+    boolean isUseTable();
+    boolean isCrosstab();
+
+    // --- Geometry ---
+    double getJustifiedWidth();
+    double getJustifiedTableColumnWidth();
+    double getCellHeight();
+    double getHeight();
+    double getLabelWidth();
+    double columnHeaderHeight();
+    double baseRowCellHeight(double extended);
+
+    // --- Structure ---
+    int getResolvedCardinality();
+    Collection<ColumnSet> getColumnSets();
+    List<SchemaNodeLayout> getChildren();
+    void forEach(Consumer<? super SchemaNodeLayout> action);
+
+    // --- Schema identity ---
+    Relation getNode();
+    String getField();
+    String getLabel();
+    String getCssClass();
+    SchemaPath getSchemaPath();
+
+    // --- Style ---
+    RelationStyle getStyle();
+
+    // --- Data extraction ---
+    JsonNode extractFrom(JsonNode datum);
+
+    // --- Aggregate ---
+    String getAggregatePosition();
+    Map<String, Object> getAggregateResults();
+
+    // --- Label ---
+    double getLabelHeight();
+    Label label(double width, double height);
+    double labelWidth(String text);
+
+    // --- Rendering ---
+    TableHeader buildColumnHeader();
+    LayoutCell<? extends Region> buildControl(FocusTraversal<?> parentTraversal,
+                                               Style model);
+}

--- a/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/RelationLayout.java
@@ -18,6 +18,7 @@ package com.chiralbehaviors.layout;
 
 import static com.chiralbehaviors.layout.style.Style.*;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -61,7 +62,7 @@ import javafx.scene.layout.Region;
  * @author halhildebrand
  *
  */
-public final class RelationLayout extends SchemaNodeLayout {
+public final class RelationLayout extends SchemaNodeLayout implements LayoutView {
 
     public static ArrayNode flatten(Relation fold, JsonNode datum) {
         ArrayNode flattened = JsonNodeFactory.instance.arrayNode();
@@ -636,6 +637,21 @@ public final class RelationLayout extends SchemaNodeLayout {
 
     public boolean isUseTable() {
         return useTable;
+    }
+
+    @Override
+    public double getJustifiedWidth() {
+        return justifiedWidth;
+    }
+
+    @Override
+    public int getResolvedCardinality() {
+        return resolvedCardinality;
+    }
+
+    @Override
+    public Collection<ColumnSet> getColumnSets() {
+        return columnSets;
     }
 
     /**

--- a/kramer/src/main/java/com/chiralbehaviors/layout/outline/Outline.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/outline/Outline.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.OptionalInt;
 
 import com.chiralbehaviors.layout.ColumnSet;
-import com.chiralbehaviors.layout.RelationLayout;
+import com.chiralbehaviors.layout.LayoutView;
 import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.cell.control.FocusTraversal;
 import com.chiralbehaviors.layout.flowless.VirtualFlow;
@@ -44,7 +44,7 @@ public class Outline extends VirtualFlow<OutlineCell> {
 
     public Outline(double width, double cellHeight,
                    Collection<ColumnSet> columnSets, int averageCardinality,
-                   RelationLayout layout, FocusTraversal<?> parentTraversal,
+                   LayoutView layout, FocusTraversal<?> parentTraversal,
                    Style model, RelationStyle style, double labelWidth) {
         super(STYLE_SHEET, width + style.getOutlineCellHorizontalInset(),
               cellHeight + style.getOutlineCellVerticalInset(),

--- a/kramer/src/main/java/com/chiralbehaviors/layout/outline/OutlineCell.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/outline/OutlineCell.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.chiralbehaviors.layout.ColumnSet;
-import com.chiralbehaviors.layout.RelationLayout;
+import com.chiralbehaviors.layout.LayoutView;
 import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.cell.Hit;
 import com.chiralbehaviors.layout.cell.LayoutContainer;
@@ -53,7 +53,7 @@ public class OutlineCell extends VerticalCell<OutlineCell>
     private List<Span>                                  spans                 = new ArrayList<>();
 
     public OutlineCell(Collection<ColumnSet> columnSets, int childCardinality,
-                       RelationLayout layout, FocusTraversal<OutlineCell> pt,
+                       LayoutView layout, FocusTraversal<OutlineCell> pt,
                        Style model, RelationStyle style, double labelWidth) {
         this(layout.getCssClass(), pt);
         columnSets.forEach(cs -> {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/outline/Span.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/outline/Span.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import java.util.List;
 
 import com.chiralbehaviors.layout.ColumnSet;
-import com.chiralbehaviors.layout.RelationLayout;
+import com.chiralbehaviors.layout.LayoutView;
 import com.chiralbehaviors.layout.cell.Hit;
 import com.chiralbehaviors.layout.cell.HorizontalCell;
 import com.chiralbehaviors.layout.cell.LayoutContainer;
@@ -50,7 +50,7 @@ public class Span extends HorizontalCell<Span>
     private final MouseHandler                                   mouseModel;
     private final MultipleCellSelection<JsonNode, OutlineColumn> selectionModel;
 
-    public Span(int cardinality, RelationLayout layout, double labelWidth,
+    public Span(int cardinality, LayoutView layout, double labelWidth,
                 ColumnSet columnSet, FocusTraversal<Span> parentTraversal,
                 Style model, RelationStyle style) {
         this(layout.getField(), parentTraversal);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/ColumnHeader.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/ColumnHeader.java
@@ -19,8 +19,8 @@ package com.chiralbehaviors.layout.table;
 import java.util.List;
 import java.util.function.Function;
 
+import com.chiralbehaviors.layout.LayoutView;
 import com.chiralbehaviors.layout.PrimitiveLayout;
-import com.chiralbehaviors.layout.RelationLayout;
 import com.chiralbehaviors.layout.style.Style;
 
 import javafx.geometry.Pos;
@@ -96,7 +96,7 @@ public class ColumnHeader extends VBox {
         }
     }
 
-    public ColumnHeader(double width, double height, RelationLayout layout,
+    public ColumnHeader(double width, double height, LayoutView layout,
                         List<Function<Double, ColumnHeader>> nestedHeaders) {
         this();
         setMinHeight(height);

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedCell.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedCell.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
-import com.chiralbehaviors.layout.RelationLayout;
+import com.chiralbehaviors.layout.LayoutView;
 import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.cell.Hit;
 import com.chiralbehaviors.layout.cell.HorizontalCell;
@@ -54,7 +54,7 @@ public class NestedCell extends HorizontalCell<NestedCell> implements
     private final MouseHandler                                                  mouseModel;
     private final MultipleCellSelection<JsonNode, LayoutCell<? extends Region>> selectionModel;
 
-    public NestedCell(RelationLayout layout,
+    public NestedCell(LayoutView layout,
                       FocusTraversal<NestedCell> parentTraversal, Style model) {
         this(layout.getCssClass(), parentTraversal);
         layout.forEach(child -> {

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedRow.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedRow.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.OptionalInt;
 
-import com.chiralbehaviors.layout.RelationLayout;
+import com.chiralbehaviors.layout.LayoutView;
 import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.cell.control.FocusTraversal;
 import com.chiralbehaviors.layout.flowless.VirtualFlow;
@@ -40,14 +40,14 @@ public class NestedRow extends VirtualFlow<NestedCell> {
     private static final String STYLE_SHEET           = "nested-row.css";
     private int                 index;
 
-    public NestedRow(double rendered, RelationLayout layout,
+    public NestedRow(double rendered, LayoutView layout,
                      int childCardinality, FocusTraversal<?> parentTraversal,
                      Style model, RelationStyle style, boolean rootLevel) {
         this(rendered, layout.getCellHeight(), layout, childCardinality,
              parentTraversal, model, style, rootLevel);
     }
 
-    public NestedRow(double rendered, double rowHeight, RelationLayout layout,
+    public NestedRow(double rendered, double rowHeight, LayoutView layout,
                      int childCardinality, FocusTraversal<?> parentTraversal,
                      Style model, RelationStyle style, boolean rootLevel) {
         super(STYLE_SHEET, layout.getJustifiedTableColumnWidth(), rowHeight,

--- a/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedTable.java
+++ b/kramer/src/main/java/com/chiralbehaviors/layout/table/NestedTable.java
@@ -19,7 +19,7 @@ package com.chiralbehaviors.layout.table;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.chiralbehaviors.layout.RelationLayout;
+import com.chiralbehaviors.layout.LayoutView;
 import com.chiralbehaviors.layout.SchemaPath;
 import com.chiralbehaviors.layout.cell.VerticalCell;
 import com.chiralbehaviors.layout.cell.control.FocusTraversal;
@@ -54,7 +54,7 @@ public class NestedTable extends VerticalCell<NestedTable> {
 
     private final VirtualFlow<NestedCell> rows;
 
-    public NestedTable(int childCardinality, RelationLayout layout,
+    public NestedTable(int childCardinality, LayoutView layout,
                        FocusTraversal<?> parentTraversal, Style model,
                        RelationStyle style, boolean rootLevel) {
         super(STYLE_SHEET);
@@ -113,7 +113,7 @@ public class NestedTable extends VerticalCell<NestedTable> {
         if (rows != null) rows.setFocus();
     }
 
-    private static HBox buildAggregateFooter(RelationLayout layout,
+    private static HBox buildAggregateFooter(LayoutView layout,
                                                 java.util.Map<String, Object> aggResults) {
         HBox footer = new HBox();
         footer.getStyleClass().add("aggregate-footer");


### PR DESCRIPTION
## Summary
- Extract `LayoutView` interface capturing all 19 methods renderers call on `RelationLayout`
- `RelationLayout implements LayoutView` — zero behavior change
- New accessors: `getJustifiedWidth()`, `getResolvedCardinality()`, `getColumnSets()`
- Architectural prerequisite for JS port (RDR-032)

## Test plan
- [x] 1014 kramer + 20 explorer tests pass unchanged
- [x] Interface compiles with all methods satisfied

Phase 1 of 2. Phase 2 (refactor renderer constructors) follows.