### PR TITLE
Kramer-46cv: @kramer/graphql — query parsing, AST expansion, introspection

### DIFF
--- a/js/packages/graphql/package.json
+++ b/js/packages/graphql/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "main": "./src/index.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/index.js"
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   },
   "scripts": {
@@ -14,12 +15,12 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@kramer/core": "workspace:*"
+    "@kramer/core": "workspace:*",
+    "graphql": "^16.13.0"
   },
   "devDependencies": {
-    "graphql": "^16.0.0",
     "tsup": "^8.0.0",
-    "vitest": "^3.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/js/packages/graphql/src/expander.ts
+++ b/js/packages/graphql/src/expander.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * QueryExpander — add/remove fields from a GraphQL AST.
+ * Port of Java QueryExpander using graphql-js visit() + print().
+ */
+
+import {
+  parse, print, visit, Kind,
+  type DocumentNode, type FieldNode, type SelectionSetNode,
+} from 'graphql';
+
+/**
+ * Add a field to the selection set at the given path.
+ * Returns a new Document (immutable).
+ */
+export function addField(
+  doc: DocumentNode,
+  parentPath: string[],
+  fieldName: string,
+): DocumentNode {
+  return visit(doc, {
+    SelectionSet: {
+      enter(node, _key, parent) {
+        // Check if this selection set is at the target path
+        if (!isAtPath(node, parent, parentPath, doc)) return undefined;
+
+        // Check if field already exists (idempotent)
+        const exists = node.selections.some(
+          s => s.kind === Kind.FIELD && s.name.value === fieldName
+        );
+        if (exists) return undefined;
+
+        // Add new field
+        const newField: FieldNode = {
+          kind: Kind.FIELD,
+          name: { kind: Kind.NAME, value: fieldName },
+        };
+
+        return {
+          ...node,
+          selections: [...node.selections, newField],
+        };
+      },
+    },
+  });
+}
+
+/**
+ * Remove a field from its parent's selection set.
+ * The last segment of fieldPath is the field to remove.
+ */
+export function removeField(
+  doc: DocumentNode,
+  fieldPath: string[],
+): DocumentNode {
+  if (fieldPath.length === 0) return doc;
+  const fieldName = fieldPath[fieldPath.length - 1];
+  const parentPath = fieldPath.slice(0, -1);
+
+  return visit(doc, {
+    SelectionSet: {
+      enter(node, _key, parent) {
+        if (!isAtPath(node, parent, parentPath, doc)) return undefined;
+
+        const filtered = node.selections.filter(
+          s => !(s.kind === Kind.FIELD && s.name.value === fieldName)
+        );
+        if (filtered.length === node.selections.length) return undefined;
+
+        return { ...node, selections: filtered };
+      },
+    },
+  });
+}
+
+/**
+ * Serialize a Document back to a query string.
+ */
+export function serialize(doc: DocumentNode): string {
+  return print(doc);
+}
+
+// --- Path matching ---
+
+function isAtPath(
+  _node: SelectionSetNode,
+  parent: any,
+  path: string[],
+  _doc: DocumentNode,
+): boolean {
+  // Simple heuristic: match by walking up the parent chain
+  // For the top-level operation, path is empty
+  if (path.length === 0) {
+    return parent?.kind === Kind.OPERATION_DEFINITION;
+  }
+
+  // For nested paths, check if the parent field name matches the last segment
+  if (parent?.kind === Kind.FIELD) {
+    const fieldName = (parent as FieldNode).name.value;
+    return fieldName === path[path.length - 1];
+  }
+
+  return false;
+}

--- a/js/packages/graphql/src/index.ts
+++ b/js/packages/graphql/src/index.ts
@@ -1,3 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// @kramer/graphql — placeholder
-export const VERSION = '0.0.1';
+// @kramer/graphql — GraphQL integration for Kramer
+
+export { buildSchema, parseQuery } from './util.js';
+export { addField, removeField, serialize } from './expander.js';
+export {
+  parseIntrospection, baseName, INTROSPECTION_QUERY,
+  type IntrospectedType, type IntrospectedField, type TypeRef,
+  type TypeIntrospectorResult,
+} from './introspector.js';

--- a/js/packages/graphql/src/introspector.ts
+++ b/js/packages/graphql/src/introspector.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * TypeIntrospector — parse GraphQL __schema introspection results.
+ * Port of Java TypeIntrospector.
+ */
+
+export interface IntrospectedType {
+  readonly name: string;
+  readonly kind: string;
+  readonly fields: IntrospectedField[];
+}
+
+export interface IntrospectedField {
+  readonly name: string;
+  readonly type: TypeRef;
+  readonly description: string | null;
+}
+
+export interface TypeRef {
+  readonly name: string | null;
+  readonly kind: string;
+  readonly ofType: TypeRef | null;
+}
+
+export interface TypeIntrospectorResult {
+  readonly typeIndex: Map<string, IntrospectedType>;
+  readonly userTypes: IntrospectedType[];
+}
+
+/**
+ * Parse a GraphQL __schema introspection response into a type index.
+ */
+export function parseIntrospection(json: unknown): TypeIntrospectorResult {
+  const data = (json as any)?.data?.__schema?.types;
+  if (!Array.isArray(data)) {
+    throw new Error('Invalid introspection response: expected data.__schema.types array');
+  }
+
+  const typeIndex = new Map<string, IntrospectedType>();
+  const userTypes: IntrospectedType[] = [];
+
+  for (const raw of data) {
+    if (isSystemType(raw.name) || raw.kind === 'SCALAR') continue;
+
+    const fields: IntrospectedField[] = (raw.fields ?? []).map((f: any) => ({
+      name: f.name,
+      type: parseTypeRef(f.type),
+      description: f.description ?? null,
+    }));
+
+    const type: IntrospectedType = {
+      name: raw.name,
+      kind: raw.kind,
+      fields,
+    };
+
+    typeIndex.set(raw.name, type);
+    userTypes.push(type);
+  }
+
+  return { typeIndex, userTypes };
+}
+
+function parseTypeRef(raw: any): TypeRef {
+  if (!raw) return { name: null, kind: 'SCALAR', ofType: null };
+  return {
+    name: raw.name ?? null,
+    kind: raw.kind ?? 'SCALAR',
+    ofType: raw.ofType ? parseTypeRef(raw.ofType) : null,
+  };
+}
+
+function isSystemType(name: string): boolean {
+  return name.startsWith('__');
+}
+
+/**
+ * Get the base type name, unwrapping LIST/NON_NULL wrappers.
+ */
+export function baseName(ref: TypeRef): string | null {
+  if (ref.name != null) return ref.name;
+  return ref.ofType ? baseName(ref.ofType) : null;
+}
+
+/**
+ * The standard introspection query.
+ */
+export const INTROSPECTION_QUERY = `{
+  __schema {
+    types {
+      name
+      kind
+      fields {
+        name
+        description
+        type {
+          name
+          kind
+          ofType {
+            name
+            kind
+            ofType {
+              name
+              kind
+            }
+          }
+        }
+      }
+    }
+  }
+}`;

--- a/js/packages/graphql/src/util.ts
+++ b/js/packages/graphql/src/util.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * GraphQL query → Kramer schema tree.
+ * Port of Java GraphQlUtil.buildContext().
+ */
+
+import { parse, type DocumentNode, type FieldNode, type SelectionSetNode, Kind } from 'graphql';
+import { relation, primitive, type Relation, type SchemaNode } from '@kramer/core';
+
+/**
+ * Parse a GraphQL query string into a Kramer Relation schema tree.
+ */
+export function buildSchema(query: string, source?: string): Relation {
+  const doc = parse(query);
+  const opDef = doc.definitions.find(d => d.kind === Kind.OPERATION_DEFINITION);
+  if (!opDef || opDef.kind !== Kind.OPERATION_DEFINITION) {
+    throw new Error('No operation definition found in query');
+  }
+
+  const selections = opDef.selectionSet.selections.filter(
+    (s): s is FieldNode => s.kind === Kind.FIELD
+  );
+
+  if (source) {
+    // Find specific source field
+    const sourceField = selections.find(f =>
+      (f.alias?.value ?? f.name.value) === source
+    );
+    if (!sourceField) {
+      throw new Error(`Source field '${source}' not found in query`);
+    }
+    return buildRelation(sourceField);
+  }
+
+  // Multi-root or single root
+  if (selections.length === 1) {
+    return buildRelation(selections[0]);
+  }
+
+  // QueryRoot equivalent
+  const root = relation('query', ...selections.map(buildSchemaNode));
+  return root;
+}
+
+function buildRelation(field: FieldNode): Relation {
+  const name = field.alias?.value ?? field.name.value;
+  const children = field.selectionSet
+    ? field.selectionSet.selections
+        .filter((s): s is FieldNode => s.kind === Kind.FIELD)
+        .map(buildSchemaNode)
+    : [];
+  return relation(name, ...children);
+}
+
+function buildSchemaNode(field: FieldNode): SchemaNode {
+  const name = field.alias?.value ?? field.name.value;
+  if (field.selectionSet && field.selectionSet.selections.length > 0) {
+    return buildRelation(field);
+  }
+  return primitive(name);
+}
+
+/**
+ * Parse a GraphQL query and return the DocumentNode.
+ */
+export function parseQuery(query: string): DocumentNode {
+  return parse(query);
+}

--- a/js/packages/graphql/test/smoke.test.ts
+++ b/js/packages/graphql/test/smoke.test.ts
@@ -1,9 +1,151 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect } from 'vitest';
-import { VERSION } from '../src/index.js';
+import { parse } from 'graphql';
+import {
+  buildSchema, parseQuery, addField, removeField, serialize,
+  parseIntrospection, baseName, INTROSPECTION_QUERY,
+} from '../src/index.js';
 
-describe('@kramer/graphql', () => {
-  it('exports version', () => {
-    expect(VERSION).toBe('0.0.1');
+describe('GraphQL Util: buildSchema', () => {
+  it('parses flat query into Relation', () => {
+    const schema = buildSchema('{ users { name email } }');
+    expect(schema.kind).toBe('relation');
+    expect(schema.field).toBe('users');
+    expect(schema.children).toHaveLength(2);
+    expect(schema.children[0].field).toBe('name');
+    expect(schema.children[1].field).toBe('email');
+  });
+
+  it('parses nested query', () => {
+    const schema = buildSchema('{ departments { name courses { number title } } }');
+    expect(schema.field).toBe('departments');
+    expect(schema.children).toHaveLength(2);
+    const courses = schema.children[1];
+    expect(courses.kind).toBe('relation');
+    if (courses.kind === 'relation') {
+      expect(courses.children).toHaveLength(2);
+    }
+  });
+
+  it('parses with source selection', () => {
+    const schema = buildSchema('{ users { name } posts { title } }', 'posts');
+    expect(schema.field).toBe('posts');
+    expect(schema.children[0].field).toBe('title');
+  });
+
+  it('handles multi-root without source', () => {
+    const schema = buildSchema('{ users { name } posts { title } }');
+    expect(schema.field).toBe('query');
+    expect(schema.children).toHaveLength(2);
+  });
+});
+
+describe('QueryExpander', () => {
+  it('adds a field to a selection set', () => {
+    const doc = parse('{ users { name } }');
+    const modified = addField(doc, ['users'], 'email');
+    const result = serialize(modified);
+    expect(result).toContain('email');
+    expect(result).toContain('name');
+  });
+
+  it('is idempotent — adding existing field is no-op', () => {
+    const doc = parse('{ users { name email } }');
+    const modified = addField(doc, ['users'], 'name');
+    const result = serialize(modified);
+    // Should still have exactly one 'name'
+    const nameCount = (result.match(/name/g) ?? []).length;
+    expect(nameCount).toBe(1);
+  });
+
+  it('removes a field', () => {
+    const doc = parse('{ users { name email age } }');
+    const modified = removeField(doc, ['users', 'email']);
+    const result = serialize(modified);
+    expect(result).not.toContain('email');
+    expect(result).toContain('name');
+    expect(result).toContain('age');
+  });
+
+  it('round-trip: add → serialize → parse preserves structure', () => {
+    const doc = parse('{ users { name } }');
+    const modified = addField(doc, ['users'], 'age');
+    const serialized = serialize(modified);
+    const reparsed = parse(serialized);
+
+    const opDef = reparsed.definitions[0];
+    expect(opDef.kind).toBe('OperationDefinition');
+    if (opDef.kind === 'OperationDefinition') {
+      const users = opDef.selectionSet.selections[0];
+      if (users.kind === 'Field' && users.selectionSet) {
+        const fields = users.selectionSet.selections
+          .filter((s): s is import('graphql').FieldNode => s.kind === 'Field')
+          .map(f => f.name.value);
+        expect(fields).toContain('name');
+        expect(fields).toContain('age');
+      }
+    }
+  });
+});
+
+describe('TypeIntrospector', () => {
+  const sampleIntrospection = {
+    data: {
+      __schema: {
+        types: [
+          {
+            name: 'Employee', kind: 'OBJECT',
+            fields: [
+              { name: 'id', description: 'Primary key', type: { name: 'ID', kind: 'SCALAR', ofType: null } },
+              { name: 'name', description: null, type: { name: 'String', kind: 'SCALAR', ofType: null } },
+              { name: 'projects', description: null, type: { name: null, kind: 'LIST', ofType: { name: 'Project', kind: 'OBJECT', ofType: null } } },
+            ],
+          },
+          {
+            name: 'Project', kind: 'OBJECT',
+            fields: [
+              { name: 'title', description: null, type: { name: 'String', kind: 'SCALAR', ofType: null } },
+            ],
+          },
+          { name: '__Schema', kind: 'OBJECT', fields: [] },
+          { name: 'String', kind: 'SCALAR', fields: null },
+        ],
+      },
+    },
+  };
+
+  it('parses user types, filters system types', () => {
+    const result = parseIntrospection(sampleIntrospection);
+    expect(result.typeIndex.has('Employee')).toBe(true);
+    expect(result.typeIndex.has('Project')).toBe(true);
+    expect(result.typeIndex.has('__Schema')).toBe(false);
+    expect(result.typeIndex.has('String')).toBe(false);
+  });
+
+  it('parses fields with type refs', () => {
+    const result = parseIntrospection(sampleIntrospection);
+    const employee = result.typeIndex.get('Employee')!;
+    expect(employee.fields).toHaveLength(3);
+    expect(employee.fields[0].name).toBe('id');
+    expect(employee.fields[0].description).toBe('Primary key');
+  });
+
+  it('unwraps LIST type ref', () => {
+    const result = parseIntrospection(sampleIntrospection);
+    const employee = result.typeIndex.get('Employee')!;
+    const projects = employee.fields[2];
+    expect(projects.type.kind).toBe('LIST');
+    expect(baseName(projects.type)).toBe('Project');
+  });
+
+  it('lists user types', () => {
+    const result = parseIntrospection(sampleIntrospection);
+    expect(result.userTypes).toHaveLength(2);
+    expect(result.userTypes.map(t => t.name)).toContain('Employee');
+    expect(result.userTypes.map(t => t.name)).toContain('Project');
+  });
+
+  it('introspection query is valid GraphQL', () => {
+    expect(() => parse(INTROSPECTION_QUERY)).not.toThrow();
   });
 });

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -25,10 +25,10 @@ importers:
       '@kramer/core':
         specifier: workspace:*
         version: link:../core
-    devDependencies:
       graphql:
-        specifier: ^16.0.0
+        specifier: ^16.13.0
         version: 16.13.1
+    devDependencies:
       tsup:
         specifier: ^8.0.0
         version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
Completes Phase 3 of RDR-033: GraphQL integration package.

- **util.ts**: Parse GraphQL queries into Kramer Relation schema trees
- **expander.ts**: Add/remove fields from AST via graphql-js visit()/print()
- **introspector.ts**: Parse __schema introspection, TypeRef unwrapping

13 tests covering query parsing, nested schemas, field expansion round-trip, introspection parsing.